### PR TITLE
chore(ci): use develop as default branch

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [main]
+    branches: [develop]
 
 jobs:
   bench:
@@ -52,7 +52,7 @@ jobs:
 
           # S3 upload directory, depending if it includes a comparison or not
           if [ "$HEAD_SHA" == "$BASE_SHA" ]; then
-            # No comparison (i.e. running on a branch like main directly)
+            # No comparison (i.e. running on a branch like develop directly)
             S3_UPLOAD_DIR="benchmark/${HEAD_SHA_SHORT}"
           else
             # Comparison (i.e. running on a PR)

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [main]
+    branches: [develop]
 
 env:
   CARGO_TERM_COLOR: always

--- a/scripts/ci/env-vars.sh
+++ b/scripts/ci/env-vars.sh
@@ -26,7 +26,7 @@ if [ -z "$HEAD_BRANCH" ]; then
 fi
 
 # BASE_REF and BASE_SHA are the baseline (what the PR is pointing to, and what Criterion can compoare).
-export BASE_REF=${GITHUB_BASE_REF:=main} # main branch by default
+export BASE_REF=${GITHUB_BASE_REF:=develop} # "develop" branch is the default
 export BASE_SHA=$( git log -n 1 --pretty=format:"%H" origin/${BASE_REF} ) # get hash of base branch
 export BASE_SHA_SHORT=$( echo $BASE_SHA | cut -c1-7 )
 


### PR DESCRIPTION
## 📝 Summary

Use `develop` as default branch.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
