### PR TITLE
test(bench): Playing with flamegraph generation [wip]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2381,15 @@ name = "debug-helper"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid 1.7.0",
+]
 
 [[package]]
 name = "delay_map"
@@ -3377,6 +3395,18 @@ name = "fiat-crypto"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "finl_unicode"
@@ -4639,6 +4669,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
+name = "inferno"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
+dependencies = [
+ "ahash",
+ "indexmap 2.2.5",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5708,6 +5756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6110,6 +6167,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6216,6 +6284,16 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
 
 [[package]]
 name = "num-integer"
@@ -6963,7 +7041,7 @@ dependencies = [
  "lexical",
  "lexical-core",
  "memchr",
- "memmap2",
+ "memmap2 0.7.1",
  "num-traits",
  "once_cell",
  "polars-arrow",
@@ -7152,6 +7230,28 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "criterion",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -7433,6 +7533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7647,6 +7756,7 @@ dependencies = [
  "mev-share-sse",
  "mockall",
  "once_cell",
+ "pprof",
  "primitive-types",
  "priority-queue",
  "prometheus",
@@ -8615,7 +8725,7 @@ dependencies = [
  "cuckoofilter",
  "derive_more",
  "lz4_flex",
- "memmap2",
+ "memmap2 0.7.1",
  "ph",
  "reth-primitives",
  "serde",
@@ -9340,6 +9450,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -10700,6 +10819,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "streaming-decompression"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10866,6 +10991,29 @@ dependencies = [
  "thiserror",
  "url",
  "zip",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "12.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71297dc3e250f7dbdf8adb99e235da783d690f5819fdeb4cce39d9cfb0aca9f1"
+dependencies = [
+ "debugid",
+ "memmap2 0.9.4",
+ "stable_deref_trait",
+ "uuid 1.7.0",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424fa2c9bf2c862891b9cfd354a752751a6730fd838a4691e7f6c2c7957b9daf"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,10 @@ fmt: ## Format the code
 .PHONY: bench
 bench: ## Run benchmarks
 	cargo bench --bench bench_main
-#	 cargo bench --bench bench_main -- --verbose
+
+.PHONY: bench-flamegraphs
+bench-flamegraphs: ## Create flamegraphs for the benchmarks
+	cargo bench --bench bench_flamegraphs -- --profile-time 3
 
 .PHONY: bench-report-open
 bench-report-open: ## Open last benchmark report in the browser

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -107,7 +107,12 @@ built = { version = "0.7.1", features = ["git2", "chrono"] }
 [dev-dependencies]
 tempfile = "3.8"
 criterion = { version = "0.5.1", features = ["html_reports"] }
+pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
 
 [[bench]]
 name = "bench_main"
+harness = false
+
+[[bench]]
+name = "bench_flamegraphs"
 harness = false

--- a/crates/rbuilder/benches/bench_flamegraphs.rs
+++ b/crates/rbuilder/benches/bench_flamegraphs.rs
@@ -1,0 +1,7 @@
+use criterion::criterion_main;
+
+mod benchmarks;
+
+criterion_main! {
+    benchmarks::mev_boost::serialization_flamegraph,
+}


### PR DESCRIPTION
## 📝 Summary

Trying to integrate flamegraph generation for the benchmarks (using flamegraph-rs and pprof-rs):

- https://github.com/tikv/pprof-rs/tree/master?tab=readme-ov-file#integrate-with-criterion
- https://bheisler.github.io/criterion.rs/book/user_guide/profiling.html
- https://github.com/flamegraph-rs/flamegraph#systems-performance-work-guided-by-flamegraphs

This setup uses the [pprof-rs Flamegraph-Profiler for Criterion](https://github.com/tikv/pprof-rs/tree/master?tab=readme-ov-file#integrate-with-criterion). Note: Custom profilers are only executed when passing a --profile-time argument (see also [the relevant Criterion docs](https://bheisler.github.io/criterion.rs/book/user_guide/profiling.html)).

Flamegraphs can be generated for benchmarks with this command:

```
$ make bench-flamegraphs 
```

Curiously, trying to generate flamegraphs for the SSZ encoding benchmark causes a segfault:
```
$ cargo bench --bench bench_flamegraphs -- --profile-time 3

[...]

Benchmarking MEV-Boost SubmitBlock serialization/SSZ encoding: Profiling for 3.0000 serror: bench failed, to rerun pass `--bench bench_flamegraphs`

Caused by:
  process didn't exit successfully: `/Users/metachris/Projects/2024/rbuilder-private/target/release/deps/bench_flamegraphs-9f5a78747b3c4349 --profile-time 3 --bench` (signal: 5, SIGTRAP: trace/breakpoint trap)
That's why the flamegraph benchmarks are separated into bench_flamegraphs for now.
```

## 💡 Motivation and Context

It would be amazing to have meaningful flamegraphs.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
