### PR TITLE
feat: add full git version to version output

### DIFF
--- a/crates/rbuilder/src/utils/build_info.rs
+++ b/crates/rbuilder/src/utils/build_info.rs
@@ -5,11 +5,12 @@ mod internal {
 }
 
 use internal::{
-    BUILT_TIME_UTC, FEATURES, GIT_COMMIT_HASH_SHORT, GIT_DIRTY, GIT_HEAD_REF, PROFILE,
+    BUILT_TIME_UTC, FEATURES, GIT_COMMIT_HASH_SHORT, GIT_DIRTY, GIT_HEAD_REF, GIT_VERSION, PROFILE,
     RUSTC_VERSION,
 };
 
 pub fn print_version_info() {
+    println!("version:    {}", GIT_VERSION.unwrap_or_default());
     println!("commit:     {}", GIT_COMMIT_HASH_SHORT.unwrap_or_default());
     println!("dirty:      {}", GIT_DIRTY.unwrap_or_default());
     println!("branch:     {}", GIT_HEAD_REF.unwrap_or_default());


### PR DESCRIPTION
## 📝 Summary

Output before was missing the full git version:

```
commit:     7688350
dirty:      true
branch:     refs/heads/flamegraph-test
build_time: Wed, 3 Jul 2024 12:16:26 +0000
rustc:      rustc 1.79.0 (129f3b996 2024-06-10)
features:   []
profile:    debug
```

This PR fixes it:

```
version:    v0.1.0-rc1-1-g7688350
commit:     7688350
dirty:      true
branch:     refs/heads/flamegraph-test
build_time: Wed, 3 Jul 2024 12:16:26 +0000
rustc:      rustc 1.79.0 (129f3b996 2024-06-10)
features:   []
profile:    debug
```

## 💡 Motivation and Context

Tag is a relevant piece of information and should be surfaced too

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
