### PR TITLE
test: Add unit tests + ci to test the txfetcher

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -49,6 +49,11 @@ jobs:
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
+      - name: Install Foundry toolchain
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
       - name: Install native dependencies
         run: sudo apt-get install -y libsqlite3-dev
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "alloy-consensus"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-eips 0.1.2",
  "alloy-primitives 0.7.6",
@@ -204,12 +204,13 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-primitives 0.7.6",
  "alloy-rlp",
  "alloy-serde 0.1.2",
  "c-kzg",
+ "derive_more",
  "once_cell",
  "serde",
  "sha2 0.10.8",
@@ -222,6 +223,16 @@ source = "git+https://github.com/alloy-rs/alloy?rev=39b8695#39b869585955d95e9c64
 dependencies = [
  "alloy-primitives 0.7.6",
  "alloy-serde 0.1.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.2"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
+dependencies = [
+ "alloy-primitives 0.7.6",
+ "alloy-serde 0.1.2",
  "serde",
 ]
 
@@ -240,7 +251,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-primitives 0.7.6",
  "serde",
@@ -252,7 +263,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-consensus 0.1.2",
  "alloy-eips 0.1.2",
@@ -266,6 +277,21 @@ dependencies = [
  "auto_impl",
  "futures-utils-wasm",
  "thiserror",
+]
+
+[[package]]
+name = "alloy-node-bindings"
+version = "0.1.2"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
+dependencies = [
+ "alloy-genesis 0.1.2",
+ "alloy-primitives 0.7.6",
+ "k256 0.13.3",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -319,7 +345,7 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 0.1.2",
@@ -372,7 +398,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -396,7 +422,7 @@ source = "git+https://github.com/alloy-rs/alloy?rev=39b8695#39b869585955d95e9c64
 dependencies = [
  "alloy-consensus 0.1.0",
  "alloy-eips 0.1.0",
- "alloy-genesis",
+ "alloy-genesis 0.1.0",
  "alloy-primitives 0.7.6",
  "alloy-rlp",
  "alloy-serde 0.1.0",
@@ -414,7 +440,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde 0.1.2",
@@ -449,7 +475,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-eth"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-consensus 0.1.2",
  "alloy-eips 0.1.2",
@@ -488,7 +514,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-primitives 0.7.6",
  "serde",
@@ -498,13 +524,28 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-primitives 0.7.6",
  "async-trait",
  "auto_impl",
  "elliptic-curve 0.13.8",
  "k256 0.13.3",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.1.2"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
+dependencies = [
+ "alloy-consensus 0.1.2",
+ "alloy-network",
+ "alloy-primitives 0.7.6",
+ "alloy-signer",
+ "async-trait",
+ "k256 0.13.3",
+ "rand 0.8.5",
  "thiserror",
 ]
 
@@ -579,7 +620,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.0",
@@ -596,7 +637,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.2"
-source = "git+https://github.com/alloy-rs/alloy#a1c9f8af873398f290d2e458ab4435b43367198a"
+source = "git+https://github.com/alloy-rs/alloy#6ac263579752188c0e2cbf5fecc6690c486cad34"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -4224,7 +4265,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -7610,13 +7651,16 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "alloy-chains",
+ "alloy-consensus 0.1.2",
  "alloy-json-rpc",
  "alloy-network",
+ "alloy-node-bindings",
  "alloy-primitives 0.7.6",
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types 0.1.2",
  "alloy-serde 0.1.2",
+ "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
  "atoi",
@@ -8811,7 +8855,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v0.2.0-beta.6#ac29b4b73be3
 dependencies = [
  "alloy-chains",
  "alloy-eips 0.1.0",
- "alloy-genesis",
+ "alloy-genesis 0.1.0",
  "alloy-primitives 0.7.6",
  "alloy-rlp",
  "alloy-trie",
@@ -9033,7 +9077,7 @@ name = "reth-rpc-types"
 version = "0.2.0-beta.6"
 source = "git+https://github.com/paradigmxyz/reth?tag=v0.2.0-beta.6#ac29b4b73be382caf2a2462d426e6bad75e18af9"
 dependencies = [
- "alloy-genesis",
+ "alloy-genesis 0.1.0",
  "alloy-primitives 0.7.6",
  "alloy-rlp",
  "alloy-rpc-types 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,7 @@ alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", version = "0.1" }
 alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", version = "0.1" }
 alloy-network = { git = "https://github.com/alloy-rs/alloy", version = "0.1" }
 alloy-transport = { git = "https://github.com/alloy-rs/alloy", version = "0.1" }
+alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy", version = "0.1" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", version = "0.1", features = ["kzg"] }
 alloy-serde = { git = "https://github.com/alloy-rs/alloy", version = "0.1" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", version = "0.1" }

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -36,7 +36,10 @@ alloy-json-rpc.workspace = true
 alloy-transport-http.workspace = true
 alloy-network.workspace = true
 alloy-transport.workspace = true
+alloy-node-bindings.workspace = true
+alloy-consensus.workspace = true
 alloy-serde.workspace = true
+alloy-signer-local.workspace = true
 
 reqwest = { version = "0.11.20", features = ["blocking"] }
 serde_with = { version = "3.8.1", features = ["time_0_3"] }


### PR DESCRIPTION
## 📝 Summary

This PR adds a unit test to check the end-to-end functionality of the transaction fetcher. It uses an anvil node as an Eth client to subscribe to its transactions. Adding also anvil to the CI/CD pipeline.

The setup for the test is a bit verbose now but I imagine that if this pattern becomes useful (unit testing with a real Eth node) we will create more concrete util abstractions.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
