### PR TITLE
ci: Upload benchmark report from separate workflow

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -48,11 +48,10 @@ jobs:
           echo "BASE_SHA_SHORT=${BASE_SHA_SHORT}" >> $fn_vars
           cat $fn_vars
 
-      #
-      # RUN BENCHMARKS (and upload the report)
-      #
+      # RUN BENCHMARKS
       - run: make bench-in-ci
 
+      # Store results as artifact
       - name: Zip the report
         run: |
           # mkdir -p target/benchmark-in-ci/benchmark-report

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -39,22 +39,14 @@ jobs:
         run: |
           source scripts/ci/env-vars.sh
 
-          echo "HEAD_SHA: ${HEAD_SHA}"
-          echo "HEAD_SHA_SHORT: ${HEAD_SHA_SHORT}"
-          echo "BASE_SHA: ${BASE_SHA}"
-          echo "BASE_SHA_SHORT: ${BASE_SHA_SHORT}"
-
-          echo "HEAD_SHA=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
-          echo "HEAD_SHA_SHORT=${HEAD_SHA_SHORT}" >> "$GITHUB_OUTPUT"
-          echo "BASE_SHA=${BASE_SHA}" >> "$GITHUB_OUTPUT"
-          echo "BASE_SHA_SHORT=${BASE_SHA_SHORT}" >> "$GITHUB_OUTPUT"
-
+          # Keep important variables around for the upload workflow that comes afterwards
           fn_vars="vars.txt"
           echo "PR_NUMBER=${PR_NUMBER}" >> $fn_vars
           echo "HEAD_SHA=${HEAD_SHA}" >> $fn_vars
           echo "HEAD_SHA_SHORT=${HEAD_SHA_SHORT}" >> $fn_vars
           echo "BASE_SHA=${BASE_SHA}" >> $fn_vars
           echo "BASE_SHA_SHORT=${BASE_SHA_SHORT}" >> $fn_vars
+          cat $fn_vars
 
       #
       # RUN BENCHMARKS (and upload the report)
@@ -73,14 +65,12 @@ jobs:
           zip -r benchmark-report.zip benchmark-report
           mv benchmark-report.zip ../../
 
-      # Upload as artifact
       - name: Upload report as artifact
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-report.zip
           path: benchmark-report.zip
 
-      - name: Add summary to CI job summary
+      - name: Add details to CI job summary
         run: |
           cat target/benchmark-in-ci/benchmark-report/benchmark-summary.md >> $GITHUB_STEP_SUMMARY
-

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,7 +1,6 @@
 name: Benchmarks
 
 on:
-  workflow_dispatch:
   pull_request:
   push:
     branches: [develop]
@@ -9,14 +8,14 @@ on:
 jobs:
   bench:
     name: Benchmark the code
-    runs-on: warp-ubuntu-latest-x64-16x
+    runs-on: ubuntu-latest
+    # runs-on: warp-ubuntu-latest-x64-16x
     strategy:
       matrix:
         toolchain:
           - stable
     env:
       PR_NUMBER: ${{ github.event.number }}
-      BENCH_AGAINST_BASE: 1
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -50,74 +49,38 @@ jobs:
           echo "BASE_SHA=${BASE_SHA}" >> "$GITHUB_OUTPUT"
           echo "BASE_SHA_SHORT=${BASE_SHA_SHORT}" >> "$GITHUB_OUTPUT"
 
-          # S3 upload directory, depending if it includes a comparison or not
-          if [ "$HEAD_SHA" == "$BASE_SHA" ]; then
-            # No comparison (i.e. running on a branch like develop directly)
-            S3_UPLOAD_DIR="benchmark/${HEAD_SHA_SHORT}"
-          else
-            # Comparison (i.e. running on a PR)
-            S3_UPLOAD_DIR="benchmark/${HEAD_SHA_SHORT}-${BASE_SHA_SHORT}"
-          fi
-          echo "S3_UPLOAD_DIR: ${S3_UPLOAD_DIR}"
-          echo "S3_UPLOAD_DIR=${S3_UPLOAD_DIR}" >> "$GITHUB_OUTPUT"
-          echo "S3_UPLOAD_DIR=${S3_UPLOAD_DIR}" >> "$GITHUB_ENV"
+          fn_vars="vars.txt"
+          echo "PR_NUMBER=${PR_NUMBER}" >> $fn_vars
+          echo "HEAD_SHA=${HEAD_SHA}" >> $fn_vars
+          echo "HEAD_SHA_SHORT=${HEAD_SHA_SHORT}" >> $fn_vars
+          echo "BASE_SHA=${BASE_SHA}" >> $fn_vars
+          echo "BASE_SHA_SHORT=${BASE_SHA_SHORT}" >> $fn_vars
 
       #
       # RUN BENCHMARKS (and upload the report)
       #
       - run: make bench-in-ci
 
-      # Upload as artifact first
+      - name: Zip the report
+        run: |
+          # mkdir -p target/benchmark-in-ci/benchmark-report
+          # echo hello > target/benchmark-in-ci/benchmark-report/index.html
+
+          cp vars.txt target/benchmark-in-ci/benchmark-report/
+          # cp scripts/ci/templates/benchmark-pr-comment.md target/benchmark-in-ci/benchmark-report/
+
+          cd target/benchmark-in-ci
+          zip -r benchmark-report.zip benchmark-report
+          mv benchmark-report.zip ../../
+
+      # Upload as artifact
       - name: Upload report as artifact
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
-          name: benchmark-report
-          path: target/benchmark-in-ci/benchmark-report/
+          name: benchmark-report.zip
+          path: benchmark-report.zip
 
-      - name: Zip the report and add to folder (for S3 upload)
-        working-directory: target/benchmark-in-ci
-        run: |
-          zip_fn="report.zip"
-          zip -r $zip_fn benchmark-report
-          mv $zip_fn benchmark-report/
+      # - name: Add summary to CI job summary
+      #   run: |
+      #     cat target/benchmark-in-ci/benchmark-report/benchmark-summary.md >> $GITHUB_STEP_SUMMARY
 
-      # Upload S3 (using https://github.com/shallwefootball/upload-s3-action)
-      - name: Upload report to S3
-        uses: shallwefootball/s3-upload-action@master
-        id: S3
-        with:
-          aws_key_id: ${{secrets.AWS_KEY_ID}}
-          aws_secret_access_key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-          aws_bucket: flashbots-rbuilder-ci-stats
-          source_dir: target/benchmark-in-ci/benchmark-report
-          destination_dir: ${{ steps.vars.outputs.S3_UPLOAD_DIR }}
-
-      #
-      # POST SUMMARY (to PR comment and CI job summary)
-      #
-      - name: Add summary to CI job summary
-        run: |
-          BENCH_URL="https://flashbots-rbuilder-ci-stats.s3.us-east-2.amazonaws.com/${{steps.S3.outputs.object_key}}/report/index.html"
-          sed -i "s|__BENCH_URL__|${BENCH_URL}|" target/benchmark-in-ci/benchmark-summary.md
-          sed -i "s|__BENCH_URL__|${BENCH_URL}|" target/benchmark-in-ci/benchmark-pr-comment.md
-          cat target/benchmark-in-ci/benchmark-summary.md >> $GITHUB_STEP_SUMMARY
-
-      # https://github.com/peter-evans/find-comment
-      - name: Find previous PR comment
-        uses: peter-evans/find-comment@v3
-        if: github.event_name == 'pull_request'
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Benchmark results
-
-      # https://github.com/peter-evans/create-or-update-comment
-      - name: Create or update PR comment
-        uses: peter-evans/create-or-update-comment@v4
-        if: github.event_name == 'pull_request'
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body-path: target/benchmark-in-ci/benchmark-pr-comment.md

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -80,7 +80,7 @@ jobs:
           name: benchmark-report.zip
           path: benchmark-report.zip
 
-      # - name: Add summary to CI job summary
-      #   run: |
-      #     cat target/benchmark-in-ci/benchmark-report/benchmark-summary.md >> $GITHUB_STEP_SUMMARY
+      - name: Add summary to CI job summary
+        run: |
+          cat target/benchmark-in-ci/benchmark-report/benchmark-summary.md >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -8,8 +8,7 @@ on:
 jobs:
   bench:
     name: Benchmark the code
-    runs-on: ubuntu-latest
-    # runs-on: warp-ubuntu-latest-x64-16x
+    runs-on: warp-ubuntu-latest-x64-16x
     strategy:
       matrix:
         toolchain:
@@ -51,14 +50,9 @@ jobs:
       # RUN BENCHMARKS
       - run: make bench-in-ci
 
-      # Store results as artifact
       - name: Zip the report
         run: |
-          # mkdir -p target/benchmark-in-ci/benchmark-report
-          # echo hello > target/benchmark-in-ci/benchmark-report/index.html
-
           cp vars.txt target/benchmark-in-ci/benchmark-report/
-          # cp scripts/ci/templates/benchmark-pr-comment.md target/benchmark-in-ci/benchmark-report/
 
           cd target/benchmark-in-ci
           zip -r benchmark-report.zip benchmark-report

--- a/.github/workflows/bench_upload_for_pr.yaml
+++ b/.github/workflows/bench_upload_for_pr.yaml
@@ -1,12 +1,11 @@
-name: Benchmark upload (for PRs)
+name: Benchmark upload
 
 #
-# PRs can contain malicious code, and uploading the report requires access to S3 secrets.
+# This workflow runs after every benchmark, to uploading the report to S3.
 #
-# Therefore we separate this upload workflow for PRs, to run in a safe context when the
-# benchmark has completed successfully for the PR in the previous job.
+# It is it's own workflow, because PRs can contain malicious code and run in a context with secrets..
 #
-# See also
+# See also https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 #
 
 on:
@@ -18,12 +17,8 @@ on:
 jobs:
   upload:
     name: Upload benchmark report
-    runs-on: ubuntu-latest
-    # runs-on: warp-ubuntu-latest-x64-16x
-    # if: github.event.workflow_run.conclusion == 'success'
-    if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+    runs-on: warp-ubuntu-latest-x64-16x
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       # https://github.com/actions/download-artifact
       - uses: actions/download-artifact@v4
@@ -32,12 +27,14 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
-      - name: Prepare upload
-        id: prepare
+      - name: Extract report
         run: |
           unzip benchmark-report.zip
           ls -alh benchmark-report/
 
+      - name: Prepare variables
+        id: prepare
+        run: |
           cat benchmark-report/vars.txt
           source benchmark-report/vars.txt
 
@@ -46,7 +43,7 @@ jobs:
           echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       # Upload S3 (using https://github.com/shallwefootball/upload-s3-action)
-      - name: Upload report to S3
+      - name: Upload to S3
         uses: shallwefootball/s3-upload-action@master
         id: S3
         with:
@@ -65,8 +62,12 @@ jobs:
           sed -i "s|__BENCH_URL__|${BENCH_URL}|" benchmark-report/benchmark-pr-comment.md
           cat benchmark-report/benchmark-pr-comment.md
 
+          cat benchmark-report/benchmark-pr-comment.md >> $GITHUB_STEP_SUMMARY
+          cat benchmark-report/benchmark-summary.md >> $GITHUB_STEP_SUMMARY
+
       # https://github.com/peter-evans/find-comment
       - name: Find previous PR comment
+        if: steps.prepare.outputs.PR_NUMBER != ''
         uses: peter-evans/find-comment@v3
         id: fc
         with:
@@ -76,6 +77,7 @@ jobs:
 
       # https://github.com/peter-evans/create-or-update-comment
       - name: Create or update PR comment
+        if: steps.prepare.outputs.PR_NUMBER != ''
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/bench_upload_for_pr.yaml
+++ b/.github/workflows/bench_upload_for_pr.yaml
@@ -1,9 +1,9 @@
 name: Benchmark upload
 
 #
-# This workflow runs after every benchmark, to uploading the report to S3.
+# This workflow runs after every benchmark, to upload the report to S3.
 #
-# It is it's own workflow, because PRs can contain malicious code and run in a context with secrets..
+# It is its own workflow, because PRs can contain malicious code and run in a context with secrets..
 #
 # See also https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 #

--- a/.github/workflows/bench_upload_for_pr.yaml
+++ b/.github/workflows/bench_upload_for_pr.yaml
@@ -1,0 +1,76 @@
+name: Benchmark upload for PRs
+
+on:
+  workflow_run:
+    workflows: ["Benchmarks"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    # runs-on: warp-ubuntu-latest-x64-16x
+    # if: github.event.workflow_run.conclusion == 'success'
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      # https://github.com/actions/download-artifact
+      - uses: actions/download-artifact@v4
+        with:
+          name: benchmark-report.zip
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Prepare upload
+        id: prepare
+        run: |
+          unzip benchmark-report.zip
+          ls -alh benchmark-report/
+
+          cat benchmark-report/vars.txt
+          source benchmark-report/vars.txt
+
+          S3_UPLOAD_DIR="benchmark/${HEAD_SHA_SHORT}-${BASE_SHA_SHORT}"
+          echo "S3_UPLOAD_DIR=${S3_UPLOAD_DIR}" >> "$GITHUB_OUTPUT"
+          echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      # Upload S3 (using https://github.com/shallwefootball/upload-s3-action)
+      - name: Upload report to S3
+        uses: shallwefootball/s3-upload-action@master
+        id: S3
+        with:
+          aws_key_id: ${{secrets.AWS_KEY_ID}}
+          aws_secret_access_key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          aws_bucket: flashbots-rbuilder-ci-stats
+          source_dir: benchmark-report
+          destination_dir: ${{ steps.prepare.outputs.S3_UPLOAD_DIR }}
+
+      #
+      # POST SUMMARY (to PR comment and CI job summary)
+      #
+      - name: Add summary to CI job summary
+        run: |
+          BENCH_URL="https://flashbots-rbuilder-ci-stats.s3.us-east-2.amazonaws.com/${{steps.S3.outputs.object_key}}/report/index.html"
+          sed -i "s|__BENCH_URL__|${BENCH_URL}|" benchmark-report/benchmark-pr-comment.md
+          cat benchmark-report/benchmark-pr-comment.md
+
+      # https://github.com/peter-evans/find-comment
+      - name: Find previous PR comment
+        uses: peter-evans/find-comment@v3
+        if: github.event_name == 'pull_request'
+        id: fc
+        with:
+          issue-number: ${{ steps.prepare.outputs.PR_NUMBER }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Benchmark results
+
+      # https://github.com/peter-evans/create-or-update-comment
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@v4
+        if: github.event_name == 'pull_request'
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ steps.prepare.outputs.PR_NUMBER }}
+          edit-mode: replace
+          body-path: benchmark-report/benchmark-pr-comment.md

--- a/.github/workflows/bench_upload_for_pr.yaml
+++ b/.github/workflows/bench_upload_for_pr.yaml
@@ -1,4 +1,13 @@
-name: Benchmark upload for PRs
+name: Benchmark upload (for PRs)
+
+#
+# PRs can contain malicious code, and uploading the report requires access to S3 secrets.
+#
+# Therefore we separate this upload workflow for PRs, to run in a safe context when the
+# benchmark has completed successfully for the PR in the previous job.
+#
+# See also
+#
 
 on:
   workflow_run:
@@ -8,6 +17,7 @@ on:
 
 jobs:
   upload:
+    name: Upload benchmark report
     runs-on: ubuntu-latest
     # runs-on: warp-ubuntu-latest-x64-16x
     # if: github.event.workflow_run.conclusion == 'success'
@@ -58,7 +68,6 @@ jobs:
       # https://github.com/peter-evans/find-comment
       - name: Find previous PR comment
         uses: peter-evans/find-comment@v3
-        if: github.event_name == 'pull_request'
         id: fc
         with:
           issue-number: ${{ steps.prepare.outputs.PR_NUMBER }}
@@ -68,7 +77,6 @@ jobs:
       # https://github.com/peter-evans/create-or-update-comment
       - name: Create or update PR comment
         uses: peter-evans/create-or-update-comment@v4
-        if: github.event_name == 'pull_request'
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ steps.prepare.outputs.PR_NUMBER }}

--- a/scripts/ci/benchmark-in-ci.sh
+++ b/scripts/ci/benchmark-in-ci.sh
@@ -90,11 +90,11 @@ mkdir -p target/benchmark-in-ci
 echo "Saved report: target/benchmark-in-ci/benchmark-report/report/index.html"
 
 # Create summary markdown
-fn="target/benchmark-in-ci/benchmark-summary.md"
+fn="target/benchmark-in-ci/benchmark-report/benchmark-summary.md"
 envsubst < scripts/ci/templates/benchmark-summary.md > $fn
 echo "Wrote summary: $fn"
 
 # Create summary pr comment
-fn="target/benchmark-in-ci/benchmark-pr-comment.md"
+fn="target/benchmark-in-ci/benchmark-report/benchmark-pr-comment.md"
 envsubst < scripts/ci/templates/benchmark-pr-comment.md > $fn
 echo "Wrote PR comment: $fn"

--- a/scripts/ci/templates/benchmark-summary.md
+++ b/scripts/ci/templates/benchmark-summary.md
@@ -1,7 +1,5 @@
 # Benchmark results for `${HEAD_SHA_SHORT}`
 
-Full report: __BENCH_URL__
-
 |                |                      |
 | -------------- | -------------------- |
 | Date (UTC)     | ${DATE}              |


### PR DESCRIPTION
## 📝 Summary

CI for PRs should (and do) run in a context that doesn't have access to secrets. This PR separates the upload of the report into a separate workflow. 

See also https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
