### PR TITLE
feat: Add a lower block bound to check_provider_factory_health

### DIFF
--- a/crates/rbuilder/src/utils/provider_factory_reopen.rs
+++ b/crates/rbuilder/src/utils/provider_factory_reopen.rs
@@ -105,13 +105,18 @@ pub fn check_provider_factory_health<DB: Database>(
 ) -> eyre::Result<()> {
     // evm must have access to block hashed of 256 of the previous blocks
     for i in 1u64..=256 {
-        let hash = provider_factory.block_hash(current_block_number - i)?;
+        let num = current_block_number - i;
+        let hash = provider_factory.block_hash(num)?;
         if hash.is_none() {
             eyre::bail!(
                 "Missing historical block hash for block {}, current block: {}",
                 current_block_number - i,
                 current_block_number
             );
+        }
+
+        if num == 0 {
+            break;
         }
     }
 


### PR DESCRIPTION
## 📝 Summary

If the current block number is less than 256, the `check_provider_factory_health` will overflow and check for the block of the max uint which will not exists. This can happen in devnets with a few blocks.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
