### PR TITLE
feat: Add abstraction for the beacon api client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "beacon-api-client"
+version = "0.1.0"
+source = "git+https://github.com/ralexstokes/ethereum-consensus/?rev=0e8809c1eda3f54a78991d7a5987ff42c9195d42#0e8809c1eda3f54a78991d7a5987ff42c9195d42"
+dependencies = [
+ "clap",
+ "ethereum-consensus",
+ "http 0.2.12",
+ "itertools 0.10.5",
+ "mev-share-sse",
+ "reqwest 0.11.26",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,7 +4243,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5814,8 +5833,7 @@ dependencies = [
 [[package]]
 name = "mev-share-sse"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba263a1c478aade75b60835fbeb6f57c0280fb0953742c3d84de45ea51139ae4"
+source = "git+https://github.com/paradigmxyz/mev-share-rs?rev=9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8#9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8"
 dependencies = [
  "async-sse",
  "bytes",
@@ -7620,6 +7638,7 @@ dependencies = [
  "alloy-transport",
  "alloy-transport-http",
  "atoi",
+ "beacon-api-client",
  "bigdecimal 0.4.3",
  "built",
  "clap",

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -71,6 +71,7 @@ secp256k1 = { version = "0.27.0", features = [
 ] }
 rayon = "1.8.0"
 flate2 = "1.0.27"
+# Version required by ethereum-consensus beacon-api-client
 mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8", default-features = false }
 jsonrpsee = { version = "0.20.3", features = ["full"] }
 ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs.git", version = "0.9.0" }

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -71,9 +71,10 @@ secp256k1 = { version = "0.27.0", features = [
 ] }
 rayon = "1.8.0"
 flate2 = "1.0.27"
-mev-share-sse = "0.1.5"
+mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8", default-features = false }
 jsonrpsee = { version = "0.20.3", features = ["full"] }
 ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs.git", version = "0.9.0" }
+beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "0e8809c1eda3f54a78991d7a5987ff42c9195d42" }
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "0e8809c1eda3f54a78991d7a5987ff42c9195d42" }
 ssz_rs_derive = { git = "https://github.com/ralexstokes/ssz-rs.git", version = "0.9.0" }
 tokio-util = "0.7.11"

--- a/crates/rbuilder/src/beacon_api_client/mod.rs
+++ b/crates/rbuilder/src/beacon_api_client/mod.rs
@@ -17,6 +17,14 @@ impl Debug for Client {
     }
 }
 
+impl Default for Client {
+    fn default() -> Self {
+        Self {
+            inner: bClient::new(Url::parse("http://localhost:8000").unwrap()),
+        }
+    }
+}
+
 impl Client {
     pub fn new(endpoint: Url) -> Self {
         Self {
@@ -52,6 +60,7 @@ impl Topic for PayloadAttributesTopic {
 
 #[cfg(test)]
 mod tests {
+    // TODO: Enable these tests.
     use super::*;
     use futures::StreamExt;
 
@@ -65,6 +74,7 @@ mod tests {
         spec.get("GENESIS_FORK_VERSION").unwrap();
     }
 
+    #[ignore]
     #[tokio::test]
     async fn test_get_events() {
         let client = Client::new(Url::parse("http://localhost:8000").unwrap());

--- a/crates/rbuilder/src/beacon_api_client/mod.rs
+++ b/crates/rbuilder/src/beacon_api_client/mod.rs
@@ -5,6 +5,8 @@ use serde::Deserialize;
 use std::{collections::HashMap, fmt::Debug};
 use url::Url;
 
+pub const DEFAULT_CL_NODE_URL: &str = "http://localhost:8000";
+
 #[derive(Deserialize, Clone)]
 #[serde(try_from = "String")]
 pub struct Client {
@@ -20,7 +22,7 @@ impl Debug for Client {
 impl Default for Client {
     fn default() -> Self {
         Self {
-            inner: bClient::new(Url::parse("http://localhost:8000").unwrap()),
+            inner: bClient::new(Url::parse(DEFAULT_CL_NODE_URL).unwrap()),
         }
     }
 }
@@ -67,7 +69,7 @@ mod tests {
     #[ignore]
     #[tokio::test]
     async fn test_get_spec() {
-        let client = Client::new(Url::parse("http://localhost:8000").unwrap());
+        let client = Client::default();
         let spec = client.get_spec().await.unwrap();
 
         // validate that the spec contains the genesis fork version
@@ -77,7 +79,7 @@ mod tests {
     #[ignore]
     #[tokio::test]
     async fn test_get_events() {
-        let client = Client::new(Url::parse("http://localhost:8000").unwrap());
+        let client = Client::default();
         let mut stream = client.get_events::<PayloadAttributesTopic>().await.unwrap();
 
         // validate that the stream is not empty

--- a/crates/rbuilder/src/beacon_api_client/mod.rs
+++ b/crates/rbuilder/src/beacon_api_client/mod.rs
@@ -1,0 +1,78 @@
+use beacon_api_client::{mainnet::Client as bClient, Error, Topic};
+use mev_share_sse::client::EventStream;
+use reth::rpc::types::beacon::events::PayloadAttributesEvent;
+use serde::Deserialize;
+use std::{collections::HashMap, fmt::Debug};
+use url::Url;
+
+#[derive(Deserialize, Clone)]
+#[serde(try_from = "String")]
+pub struct Client {
+    inner: bClient,
+}
+
+impl Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client").finish()
+    }
+}
+
+impl Client {
+    pub fn new(endpoint: Url) -> Self {
+        Self {
+            inner: bClient::new(endpoint),
+        }
+    }
+
+    pub async fn get_spec(&self) -> Result<HashMap<String, String>, Error> {
+        self.inner.get_spec().await
+    }
+
+    pub async fn get_events<T: Topic>(&self) -> Result<EventStream<T::Data>, Error> {
+        self.inner.get_events::<T>().await
+    }
+}
+
+impl TryFrom<String> for Client {
+    type Error = url::ParseError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let url = Url::parse(&s)?;
+        Ok(Client::new(url))
+    }
+}
+
+pub struct PayloadAttributesTopic;
+
+impl Topic for PayloadAttributesTopic {
+    const NAME: &'static str = "payload_attributes";
+
+    type Data = PayloadAttributesEvent;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[ignore]
+    #[tokio::test]
+    async fn test_get_spec() {
+        let client = Client::new(Url::parse("http://localhost:8000").unwrap());
+        let spec = client.get_spec().await.unwrap();
+
+        // validate that the spec contains the genesis fork version
+        spec.get("GENESIS_FORK_VERSION").unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_events() {
+        let client = Client::new(Url::parse("http://localhost:8000").unwrap());
+        let mut stream = client.get_events::<PayloadAttributesTopic>().await.unwrap();
+
+        // validate that the stream is not empty
+        // TODO: add timeout
+        let event = stream.next().await.unwrap().unwrap();
+        print!("{:?}", event);
+    }
+}

--- a/crates/rbuilder/src/bin/debug-order-sim.rs
+++ b/crates/rbuilder/src/bin/debug-order-sim.rs
@@ -48,7 +48,7 @@ pub async fn main() -> eyre::Result<()> {
     let relays = config.base_config().relays()?;
 
     let (_new_slots, mut slots) = MevBoostSlotDataGenerator::new(
-        config.base_config().beacon_clients(),
+        config.base_config().beacon_clients()?,
         relays,
         Default::default(),
         CancellationToken::new(),

--- a/crates/rbuilder/src/bin/debug-order-sim.rs
+++ b/crates/rbuilder/src/bin/debug-order-sim.rs
@@ -48,7 +48,7 @@ pub async fn main() -> eyre::Result<()> {
     let relays = config.base_config().relays()?;
 
     let (_new_slots, mut slots) = MevBoostSlotDataGenerator::new(
-        config.base_config().cl_node_url.clone(),
+        config.base_config().beacon_clients(),
         relays,
         Default::default(),
         CancellationToken::new(),

--- a/crates/rbuilder/src/bin/debug-slot-data-generator.rs
+++ b/crates/rbuilder/src/bin/debug-slot-data-generator.rs
@@ -39,7 +39,7 @@ pub async fn main() -> eyre::Result<()> {
     let relays = config.base_config().relays()?;
 
     let (handle, mut slots) = MevBoostSlotDataGenerator::new(
-        config.base_config().beacon_clients(),
+        config.base_config().beacon_clients()?,
         relays,
         Default::default(),
         cancel,

--- a/crates/rbuilder/src/bin/debug-slot-data-generator.rs
+++ b/crates/rbuilder/src/bin/debug-slot-data-generator.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use payload_events::MevBoostSlotDataGenerator;
 use rbuilder::{
+    beacon_api_client::Client,
     live_builder::{
         base_config::load_config_toml_and_env, cli::LiveBuilderConfig, config::Config,
         payload_events,
@@ -39,7 +40,7 @@ pub async fn main() -> eyre::Result<()> {
     let relays = config.base_config().relays()?;
 
     let (handle, mut slots) = MevBoostSlotDataGenerator::new(
-        config.base_config().cl_node_url.clone(),
+        Client::new(config.base_config().cl_node_url.parse().unwrap()),
         relays,
         Default::default(),
         cancel,

--- a/crates/rbuilder/src/bin/debug-slot-data-generator.rs
+++ b/crates/rbuilder/src/bin/debug-slot-data-generator.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
 use payload_events::MevBoostSlotDataGenerator;
 use rbuilder::{
-    beacon_api_client::Client,
     live_builder::{
         base_config::load_config_toml_and_env, cli::LiveBuilderConfig, config::Config,
         payload_events,
@@ -40,7 +39,7 @@ pub async fn main() -> eyre::Result<()> {
     let relays = config.base_config().relays()?;
 
     let (handle, mut slots) = MevBoostSlotDataGenerator::new(
-        Client::new(config.base_config().cl_node_url.parse().unwrap()),
+        config.base_config().beacon_clients(),
         relays,
         Default::default(),
         cancel,

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -8,6 +8,7 @@ use std::{path::PathBuf, sync::Arc, thread::sleep, time::Duration};
 use alloy_primitives::U256;
 use jsonrpsee::RpcModule;
 use rbuilder::{
+    beacon_api_client::Client,
     building::{
         builders::{
             finalize_block_execution, Block, BlockBuildingAlgorithm, BlockBuildingAlgorithmInput,
@@ -17,8 +18,8 @@ use rbuilder::{
     },
     live_builder::{
         base_config::{
-            DEFAULT_CL_NODE_URL, DEFAULT_EL_NODE_IPC_PATH, DEFAULT_ERROR_STORAGE_PATH,
-            DEFAULT_INCOMING_BUNDLES_PORT, DEFAULT_IP, DEFAULT_RETH_DB_PATH,
+            DEFAULT_EL_NODE_IPC_PATH, DEFAULT_ERROR_STORAGE_PATH, DEFAULT_INCOMING_BUNDLES_PORT,
+            DEFAULT_IP, DEFAULT_RETH_DB_PATH,
         },
         bidding::{DummyBiddingService, SlotBidder},
         config::create_provider_factory,
@@ -67,7 +68,7 @@ async fn main() -> eyre::Result<()> {
     )?;
 
     let builder = LiveBuilder::<Arc<DatabaseEnv>, TraceBlockSinkFactory> {
-        cl_urls: vec![DEFAULT_CL_NODE_URL.to_string()],
+        cls: vec![Client::default()],
         relays: vec![relay],
         watchdog_timeout: Duration::from_secs(10000),
         error_storage_path: DEFAULT_ERROR_STORAGE_PATH.parse().unwrap(),

--- a/crates/rbuilder/src/lib.rs
+++ b/crates/rbuilder/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod backtest;
+pub mod beacon_api_client;
 pub mod building;
 pub mod flashbots;
 pub mod live_builder;

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -1,6 +1,7 @@
 //! Config should always be deserializable, default values should be used
 //!
 use crate::{
+    beacon_api_client::Client,
     flashbots::BlocksProcessorClient,
     live_builder::{
         bidding::DummyBiddingService,
@@ -41,6 +42,7 @@ use std::{
     time::Duration,
 };
 use tracing::{info, warn};
+use url::Url;
 
 /// From experience (Vitaly's) all generated blocks before slot_time-8sec end loosing (due to last moment orders?)
 const DEFAULT_SLOT_DELTA_TO_START_SUBMITS: time::Duration = time::Duration::milliseconds(-8000);
@@ -207,7 +209,7 @@ impl BaseConfig {
         let sink_factory = RelaySubmitSinkFactory::new(self.submission_config()?, relays.clone());
 
         Ok(LiveBuilder::<Arc<DatabaseEnv>, RelaySubmitSinkFactory> {
-            cl_urls: self.cl_node_url.clone(),
+            cls: self.beacon_clients(),
             relays,
             watchdog_timeout: self.watchdog_timeout(),
             error_storage_path: self.error_storage_path.clone(),
@@ -240,6 +242,16 @@ impl BaseConfig {
 
     pub fn chain_spec(&self) -> eyre::Result<Arc<ChainSpec>> {
         genesis_value_parser(&self.chain)
+    }
+
+    pub fn beacon_clients(&self) -> Vec<Client> {
+        self.cl_node_url
+            .iter()
+            .map(|url| {
+                let url = Url::parse(url).unwrap();
+                Client::new(url)
+            })
+            .collect()
     }
 
     pub fn sbundle_mergeabe_signers(&self) -> Vec<Address> {

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -209,7 +209,7 @@ impl BaseConfig {
         let sink_factory = RelaySubmitSinkFactory::new(self.submission_config()?, relays.clone());
 
         Ok(LiveBuilder::<Arc<DatabaseEnv>, RelaySubmitSinkFactory> {
-            cls: self.beacon_clients(),
+            cls: self.beacon_clients()?,
             relays,
             watchdog_timeout: self.watchdog_timeout(),
             error_storage_path: self.error_storage_path.clone(),
@@ -244,12 +244,12 @@ impl BaseConfig {
         genesis_value_parser(&self.chain)
     }
 
-    pub fn beacon_clients(&self) -> Vec<Client> {
+    pub fn beacon_clients(&self) -> eyre::Result<Vec<Client>> {
         self.cl_node_url
             .iter()
             .map(|url| {
-                let url = Url::parse(url).unwrap();
-                Client::new(url)
+                let url = Url::parse(url)?;
+                Ok(Client::new(url))
             })
             .collect()
     }

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -7,7 +7,6 @@ pub mod order_input;
 pub mod payload_events;
 pub mod simulation;
 mod watchdog;
-use url::Url;
 
 use crate::{
     beacon_api_client::Client,
@@ -56,7 +55,7 @@ const GET_BLOCK_HEADER_PERIOD: time::Duration = time::Duration::milliseconds(250
 /// Create and run()
 #[derive(Debug)]
 pub struct LiveBuilder<DB, BuilderSinkFactoryType: BuilderSinkFactory> {
-    pub cl_urls: Vec<String>,
+    pub cls: Vec<Client>,
     pub relays: Vec<MevBoostRelay>,
     pub watchdog_timeout: Duration,
     pub error_storage_path: PathBuf,
@@ -115,15 +114,9 @@ where
 
         let mut inner_jobs_handles = Vec::new();
 
-        let cls = self
-            .cl_urls
-            .iter()
-            .map(|url| Client::new(Url::parse(url).unwrap()))
-            .collect();
-
         let mut payload_events_channel = {
             let payload_event = MevBoostSlotDataGenerator::new(
-                cls,
+                self.cls,
                 self.relays.clone(),
                 self.blocklist.clone(),
                 self.global_cancellation.clone(),

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -7,8 +7,10 @@ pub mod order_input;
 pub mod payload_events;
 pub mod simulation;
 mod watchdog;
+use url::Url;
 
 use crate::{
+    beacon_api_client::Client,
     building::{
         builders::{BlockBuildingAlgorithm, BuilderSinkFactory},
         BlockBuildingContext,
@@ -113,9 +115,15 @@ where
 
         let mut inner_jobs_handles = Vec::new();
 
+        let cls = self
+            .cl_urls
+            .iter()
+            .map(|url| Client::new(Url::parse(url).unwrap()))
+            .collect();
+
         let mut payload_events_channel = {
             let payload_event = MevBoostSlotDataGenerator::new(
-                self.cl_urls,
+                cls,
                 self.relays.clone(),
                 self.blocklist.clone(),
                 self.global_cancellation.clone(),

--- a/crates/rbuilder/src/live_builder/payload_events/mod.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/mod.rs
@@ -6,6 +6,7 @@ pub mod payload_source;
 pub mod relay_epoch_cache;
 
 use crate::{
+    beacon_api_client::Client,
     live_builder::payload_events::{
         payload_source::PayloadSourceMuxer,
         relay_epoch_cache::{RelaysForSlotData, SlotData},
@@ -67,7 +68,7 @@ impl MevBoostSlotData {
 }
 
 pub struct MevBoostSlotDataGenerator {
-    cl_urls: Vec<String>,
+    cls: Vec<Client>,
     relays: Vec<MevBoostRelay>,
     blocklist: HashSet<Address>,
 
@@ -76,13 +77,13 @@ pub struct MevBoostSlotDataGenerator {
 
 impl MevBoostSlotDataGenerator {
     pub fn new(
-        cl_urls: Vec<String>,
+        cls: Vec<Client>,
         relays: Vec<MevBoostRelay>,
         blocklist: HashSet<Address>,
         global_cancellation: CancellationToken,
     ) -> Self {
         Self {
-            cl_urls,
+            cls,
             relays,
             blocklist,
             global_cancellation,
@@ -95,7 +96,7 @@ impl MevBoostSlotDataGenerator {
         let (send, receive) = mpsc::unbounded_channel();
         let handle = tokio::spawn(async move {
             let mut source = PayloadSourceMuxer::new(
-                &self.cl_urls,
+                &self.cls,
                 NEW_PAYLOAD_RECV_TIMEOUT,
                 CONSENSUS_CLIENT_RECONNECT_WAIT,
                 self.global_cancellation.clone(),

--- a/crates/rbuilder/src/live_builder/payload_events/payload_source.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/payload_source.rs
@@ -1,5 +1,5 @@
+use crate::beacon_api_client::{Client, PayloadAttributesTopic};
 use futures::future::join_all;
-use mev_share_sse::EventClient;
 use reth::rpc::types::beacon::events::PayloadAttributesEvent;
 
 use tokio::{
@@ -27,15 +27,10 @@ pub struct CLPayloadSource {
 }
 
 impl CLPayloadSource {
-    pub fn new(cl_url: String, cancellation: CancellationToken) -> Self {
-        let payloads_url = format!("{}/eth/v1/events?topics=payload_attributes", cl_url);
+    pub fn new(cl: Client, cancellation: CancellationToken) -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
         let join_handle = tokio::spawn(async move {
-            let client = EventClient::default();
-            if let Ok(mut subscription) = client
-                .subscribe::<PayloadAttributesEvent>(&payloads_url)
-                .await
-            {
+            if let Ok(mut subscription) = cl.get_events::<PayloadAttributesTopic>().await {
                 loop {
                     tokio::select! {
                         _ = cancellation.cancelled() =>{
@@ -45,19 +40,19 @@ impl CLPayloadSource {
                             let event_res = match opt_event {
                                     Some(event_res) => event_res,
                                     None => {
-                                        warn!(cl_url, "CL SSE channel closed");
+                                        warn!("CL SSE channel closed");
                                         return;
                                     }
                             };
                             match event_res {
                                 Ok(event) => {
                                     if sender.send(event).is_err() {
-                                        error!(cl_url, "Error while sending payload event,CLPayloadSource closed");
+                                        error!("Error while sending payload event,CLPayloadSource closed");
                                         return;
                                     }
                                 }
                                 Err(err) => {
-                                    error!(cl_url, "Error while receiving CL SEE event: {:?}, ignoring", err);
+                                    error!("Error while receiving CL SEE event: {:?}, ignoring", err);
                                 }
                             }
                         }
@@ -130,7 +125,7 @@ impl PayloadSourceReconnector {
 
     /// reconnect_wait is the time it waits before reconnecting to avoid 100% CPU reconnection loop and killing the CL machine.
     pub fn new(
-        cl_url: String,
+        cl: Client,
         recv_timeout: std::time::Duration,
         reconnect_wait: std::time::Duration,
         cancellation: CancellationToken,
@@ -138,12 +133,12 @@ impl PayloadSourceReconnector {
         let (sender, receiver) = mpsc::unbounded_channel();
         let join_handle = tokio::spawn(async move {
             loop {
-                info!(cl_url, "PayloadSourceReconnector connecting");
-                let mut source = CLPayloadSource::new(cl_url.clone(), cancellation.clone());
+                info!("PayloadSourceReconnector connecting");
+                let mut source = CLPayloadSource::new(cl.clone(), cancellation.clone());
                 if !Self::poll_payloads(&mut source, &sender, recv_timeout, &cancellation).await {
                     return;
                 }
-                info!(cl_url, "PayloadSourceReconnector waiting to reconnect");
+                info!("PayloadSourceReconnector waiting to reconnect");
                 let timeout_res = timeout(reconnect_wait, cancellation.cancelled()).await;
                 if timeout_res.is_ok() {
                     return; // cancelled
@@ -172,24 +167,20 @@ pub struct PayloadSourceMuxer {
 
 impl PayloadSourceMuxer {
     pub fn new(
-        cl_urls: &[String],
+        cls: &[Client],
         recv_timeout: std::time::Duration,
         reconnect_wait: std::time::Duration,
         cancellation: CancellationToken,
     ) -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
-        let mut join_handles = Vec::new();
-        for cl_url in cl_urls {
+        let mut join_handles: Vec<JoinHandle<()>> = Vec::new();
+        for cl in cls {
             let sender = sender.clone();
             let cancellation = cancellation.clone();
-            let cl_url = cl_url.clone();
+            let cl = cl.clone();
             let join_handle = tokio::spawn(async move {
-                let mut source = PayloadSourceReconnector::new(
-                    cl_url,
-                    recv_timeout,
-                    reconnect_wait,
-                    cancellation,
-                );
+                let mut source =
+                    PayloadSourceReconnector::new(cl, recv_timeout, reconnect_wait, cancellation);
                 while let Some(payload) = source.recv().await {
                     if sender.send(payload).is_err() {
                         error!("PayloadSourceMuxer send error");


### PR DESCRIPTION
## 📝 Summary

This PR adds a small abstraction over the beacon client api and implements the methods required by the rbuilder.

There are a couple of unit tests that require a running beacon node. They are ignore right now but we will enable them in a followup PR.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
