### PR TITLE
Add proc macros to ignore tests if env or http not set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7677,6 +7677,7 @@ dependencies = [
  "ssz_rs 0.9.0 (git+https://github.com/ralexstokes/ssz-rs.git)",
  "ssz_rs_derive 0.9.0 (git+https://github.com/ralexstokes/ssz-rs.git)",
  "tempfile",
+ "test_utils",
  "thiserror",
  "time",
  "tokio",
@@ -11019,6 +11020,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "test_utils"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "reqwest 0.11.26",
+ "syn 2.0.53",
+ "which",
+]
+
+[[package]]
 name = "thin-vec"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12121,6 +12133,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
-members = ["crates/rbuilder"]
+members = [
+    "crates/rbuilder",
+    "crates/rbuilder/src/test_utils"
+]
 resolver = "2"
 
 # Like release, but with full debug symbols. Useful for e.g. `perf`.

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -38,6 +38,8 @@ alloy-network.workspace = true
 alloy-transport.workspace = true
 alloy-serde.workspace = true
 
+test_utils = { path = "src/test_utils" }
+
 reqwest = { version = "0.11.20", features = ["blocking"] }
 serde_with = { version = "3.8.1", features = ["time_0_3"] }
 primitive-types = "0.12.1"

--- a/crates/rbuilder/src/backtest/fetch/mempool.rs
+++ b/crates/rbuilder/src/backtest/fetch/mempool.rs
@@ -89,9 +89,10 @@ fn check_and_download_transaction_files(
 #[cfg(test)]
 mod test {
     use super::*;
+    use test_utils::ignore_if_env_not_set;
     use time::macros::datetime;
 
-    #[ignore]
+    #[ignore_if_env_not_set("MEMPOOL_DATADIR")]
     #[test]
     fn test_get_mempool_transactions() {
         let data_dir = std::env::var("MEMPOOL_DATADIR").expect("MEMPOOL_DATADIR not set");

--- a/crates/rbuilder/src/test_utils/Cargo.toml
+++ b/crates/rbuilder/src/test_utils/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test_utils"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+which = "4.0"
+reqwest = { version = "0.11.20", features = ["blocking"] }

--- a/crates/rbuilder/src/test_utils/src/lib.rs
+++ b/crates/rbuilder/src/test_utils/src/lib.rs
@@ -10,7 +10,7 @@ pub fn ignore_if_env_not_set(attr: TokenStream, item: TokenStream) -> TokenStrea
     let input = parse_macro_input!(item as ItemFn);
 
     // Check if the environment variable is set
-    let env_var_set = env::var(&env_var_to_check).is_ok();
+    let env_var_set = env::var(env_var_to_check).is_ok();
 
     let result = if env_var_set {
         // If the environment variable is set, return the original function
@@ -43,7 +43,7 @@ pub fn ignore_if_endpoint_unavailable(attr: TokenStream, item: TokenStream) -> T
         .build()
         .unwrap();
 
-    let endpoint_available = client.get(&endpoint_to_check).send().is_ok();
+    let endpoint_available = client.get(endpoint_to_check).send().is_ok();
 
     let result = if endpoint_available {
         // If the endpoint is available, return the original function

--- a/crates/rbuilder/src/test_utils/src/lib.rs
+++ b/crates/rbuilder/src/test_utils/src/lib.rs
@@ -1,0 +1,66 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use reqwest::blocking::Client;
+use std::{env, time::Duration};
+use syn::{parse_macro_input, ItemFn, LitStr};
+
+#[proc_macro_attribute]
+pub fn ignore_if_env_not_set(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let env_var_to_check = parse_macro_input!(attr as LitStr).value();
+    let input = parse_macro_input!(item as ItemFn);
+
+    // Check if the environment variable is set
+    let env_var_set = env::var(&env_var_to_check).is_ok();
+
+    let result = if env_var_set {
+        // If the environment variable is set, return the original function
+        quote! { #input }
+    } else {
+        // If the environment variable is not set, add the #[ignore] attribute
+        let attrs = &input.attrs;
+        let vis = &input.vis;
+        let sig = &input.sig;
+        let block = &input.block;
+
+        quote! {
+            #[ignore]
+            #(#attrs)*
+            #vis #sig #block
+        }
+    };
+
+    result.into()
+}
+
+#[proc_macro_attribute]
+pub fn ignore_if_endpoint_unavailable(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let endpoint_to_check = parse_macro_input!(attr as LitStr).value();
+    let input = parse_macro_input!(item as ItemFn);
+
+    // Check if the HTTP endpoint is available
+    let client = Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap();
+
+    let endpoint_available = client.get(&endpoint_to_check).send().is_ok();
+
+    let result = if endpoint_available {
+        // If the endpoint is available, return the original function
+        quote! { #input }
+    } else {
+        // If the endpoint is not available, add the #[ignore] attribute
+        let attrs = &input.attrs;
+        let vis = &input.vis;
+        let sig = &input.sig;
+        let block = &input.block;
+
+        quote! {
+            #(#attrs)*
+            #[ignore]
+            #vis #sig #block
+        }
+    };
+
+    result.into()
+}


### PR DESCRIPTION
## 📝 Summary

This PR creates two new procedural macro (and crate otherwise it does not work) that:
- Ignore a test if some env variable is not set.
- Ignore a test if some endpoint is not available.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
