### PR TITLE
feat: spoof balances for backtesting

### DIFF
--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -78,6 +78,7 @@ async fn main() -> eyre::Result<()> {
         blocklist: Default::default(),
         excess_blob_gas: block_data.excess_blob_gas,
         spec_id: SpecId::LATEST,
+        backtest_balances_to_spoof: None,
     };
 
     let orders = block_data

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -73,6 +73,9 @@ pub struct BlockBuildingContext {
     pub excess_blob_gas: Option<u64>,
     /// Version of the EVM that we are going to use
     pub spec_id: SpecId,
+    // An optional Vec of a tuple of addresses and balances to spoof during simulation
+    // [!SAFETY!] Only use in backtesting
+    pub backtest_balances_to_spoof: Option<Vec<(Address, u128)>>,
 }
 
 impl BlockBuildingContext {
@@ -138,6 +141,7 @@ impl BlockBuildingContext {
             extra_data,
             excess_blob_gas,
             spec_id,
+            backtest_balances_to_spoof: None,
         }
     }
 
@@ -235,6 +239,7 @@ impl BlockBuildingContext {
                 .excess_blob_gas
                 .map(|b| b as u64),
             spec_id,
+            backtest_balances_to_spoof: None,
         }
     }
 


### PR DESCRIPTION
## 📝 Summary

Introduces an optional field that allows for balance spoofing, primarily useful for testing contexts.

## 💡 Motivation and Context
This change is required to generate transactions from test accounts without funding those accounts, which we want to do as a part of making synthetic bundles.

We may prefer instead to use @ferranbt's recent work that allows for usage of pre-funded accounts on a dev network instead.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
