### PR TITLE
fix: delete unused features of alloy-chains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ ethereum_ssz = "0.5"
 
 alloy-primitives = "0.7.2"
 alloy-rlp = "0.3.4"
-alloy-chains = { version = "0.1.18", feature = ["serde", "rlp", "arbitrary"] }
+alloy-chains = "0.1.23"
 alloy-provider = { git = "https://github.com/alloy-rs/alloy", version = "0.2" }
 alloy-eips = { git = "https://github.com/alloy-rs/alloy", version = "0.2" }
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", version = "0.2" }


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
hi, this PR 
+ fixes #65 compilation warnings for unused features of `alloy-chains`
+ ~~fixes the lint errors of `doc_lazy_continuation`, which introduced in Rust 1.80~~

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
