### PR TITLE
Exclude failed or fully dropped orders

### DIFF
--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -321,6 +321,7 @@ pub struct ExecutionResult {
     pub order: Order,
     pub txs: Vec<TransactionSignedEcRecoveredWithBlobs>,
     /// Patch to get the executed OrderIds for merged sbundles (see: [`BundleOk::original_order_ids`],[`ShareBundleMerger`] )
+    /// Fully dropped orders (TxRevertBehavior::AllowedExcluded allows it!) are not included.
     pub original_order_ids: Vec<OrderId>,
     pub receipts: Vec<Receipt>,
     pub nonces_updated: Vec<(Address, u64)>,

--- a/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
@@ -8,8 +8,8 @@ use crate::{
         BlockState, ExecutionError, ExecutionResult, OrderErr, PartialBlock,
     },
     primitives::{
-        order_builder::OrderBuilder, BundleReplacementData, Refund, RefundConfig, SimulatedOrder,
-        TransactionSignedEcRecoveredWithBlobs, TxRevertBehavior,
+        order_builder::OrderBuilder, BundleReplacementData, OrderId, Refund, RefundConfig,
+        SimulatedOrder, TransactionSignedEcRecoveredWithBlobs, TxRevertBehavior,
     },
 };
 use alloy_primitives::{Address, TxHash};
@@ -90,6 +90,11 @@ impl TestSetup {
     pub fn set_inner_bundle_refund_config(&mut self, refund_config: Vec<RefundConfig>) {
         self.order_builder
             .set_inner_bundle_refund_config(refund_config)
+    }
+
+    pub fn set_inner_bundle_original_order_id(&mut self, original_order_id: OrderId) {
+        self.order_builder
+            .set_inner_bundle_original_order_id(original_order_id)
     }
 
     /// Adds a tx that does nothing

--- a/crates/rbuilder/src/flashbots/blocks_processor.rs
+++ b/crates/rbuilder/src/flashbots/blocks_processor.rs
@@ -185,7 +185,7 @@ impl BlocksProcessorClient {
                 if let Order::ShareBundle(sbundle) = &exec_result.order {
                     // don't like having special cases (merged vs not merged), can we improve this?
                     let filtered_sbundles = if sbundle.is_merged_order() {
-                        // We include only original orders that are contained con original_order_ids.
+                        // We include only original orders that are contained in original_order_ids.
                         // If not contained in original_order_ids then the sub sbundle failed or was an empty execution.
                         sbundle
                             .original_orders

--- a/crates/rbuilder/src/flashbots/blocks_processor.rs
+++ b/crates/rbuilder/src/flashbots/blocks_processor.rs
@@ -181,19 +181,36 @@ impl BlocksProcessorClient {
         built_block_trace
             .included_orders
             .iter()
-            .flat_map(|sim| {
-                if let Order::ShareBundle(_) = &sim.order {
-                    // get original orders (in case of order merging)
-                    sim.order
-                        .original_orders()
-                        .iter()
-                        .filter_map(|sub_order| {
-                            if let Order::ShareBundle(sbundle) = sub_order {
-                                Some(sbundle)
-                            } else {
-                                None
-                            }
-                        })
+            .flat_map(|exec_result| {
+                if let Order::ShareBundle(sbundle) = &exec_result.order {
+                    // don't like having special cases (merged vs not merged), can we improve this?
+                    let filtered_sbundles = if sbundle.is_merged_order() {
+                        // We include only original orders that are contained con original_order_ids.
+                        // If not contained in original_order_ids then the sub sbundle failed or was an empty execution.
+                        sbundle
+                            .original_orders
+                            .iter()
+                            .filter_map(|sub_order| {
+                                if let Order::ShareBundle(sbundle) = sub_order {
+                                    if exec_result.original_order_ids.contains(&sub_order.id()) {
+                                        Some(sbundle)
+                                    } else {
+                                        None
+                                    }
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect()
+                    } else if exec_result.txs.is_empty() {
+                        // non merged empty execution sbundle
+                        vec![]
+                    } else {
+                        // non merged non empty execution sbundle
+                        vec![sbundle]
+                    };
+                    filtered_sbundles
+                        .into_iter()
                         .map(|sbundle| UsedSbundle {
                             bundle: RawShareBundle::encode_no_blobs(sbundle.clone()),
                             success: true,

--- a/crates/rbuilder/src/primitives/order_builder.rs
+++ b/crates/rbuilder/src/primitives/order_builder.rs
@@ -1,7 +1,7 @@
 use std::mem;
 
 use super::{
-    Bundle, BundleReplacementData, MempoolTx, Order, Refund, RefundConfig, ShareBundle,
+    Bundle, BundleReplacementData, MempoolTx, Order, OrderId, Refund, RefundConfig, ShareBundle,
     ShareBundleBody, ShareBundleInner, ShareBundleTx, TransactionSignedEcRecoveredWithBlobs,
     TxRevertBehavior,
 };
@@ -132,6 +132,15 @@ impl OrderBuilder {
             _ => panic!("Only ShareBundle can have refund config"),
         }
     }
+
+    pub fn set_inner_bundle_original_order_id(&mut self, original_order_id: OrderId) {
+        match self {
+            OrderBuilder::ShareBundle(builder) => {
+                builder.set_inner_bundle_original_order_id(original_order_id);
+            }
+            _ => panic!("Only ShareBundle can have refund config"),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -202,17 +211,13 @@ pub struct ShareBundleBuilder {
 
 impl ShareBundleBuilder {
     fn new(block: u64, max_block: u64) -> Self {
-        Self {
+        let mut res = Self {
             block,
             max_block,
-            inner_bundle_stack: vec![ShareBundleInner {
-                body: vec![],
-                refund: vec![],
-                refund_config: vec![],
-                can_skip: false,
-                original_order_id: None,
-            }],
-        }
+            inner_bundle_stack: Vec::new(),
+        };
+        res.start_inner_bundle(false);
+        res
     }
 
     fn build(mut self) -> ShareBundle {
@@ -249,6 +254,11 @@ impl ShareBundleBuilder {
     fn set_inner_bundle_refund_config(&mut self, refund_config: Vec<RefundConfig>) {
         let last = self.inner_bundle_stack.last_mut().unwrap();
         last.refund_config = refund_config;
+    }
+
+    fn set_inner_bundle_original_order_id(&mut self, original_order_id: OrderId) {
+        let last = self.inner_bundle_stack.last_mut().unwrap();
+        last.original_order_id = Some(original_order_id);
     }
 
     fn finish_inner_bundle(&mut self) {


### PR DESCRIPTION
## 📝 Summary

For merged sbundles, we were wrongly reporting as included failed or fully dropped subbundles.
A fully dropped sub bundle is a bundle with all droppable children (TxRevertBehavior::AllowedExcluded) that when executed dropped everything so no tx was included.

## 💡 Motivation and Context

We saw some weird stuff on our DB.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
