### PR TITLE
fix(jsonrpc): Return tx hash from eth_sendRawTransaction

### DIFF
--- a/crates/rbuilder/src/live_builder/order_input/rpc_server.rs
+++ b/crates/rbuilder/src/live_builder/order_input/rpc_server.rs
@@ -4,6 +4,7 @@ use crate::primitives::{
     Bundle, BundleReplacementKey, MempoolTx, Order,
 };
 use alloy_primitives::Address;
+use jsonrpsee::types::ErrorObject;
 use jsonrpsee::{server::Server, RpcModule};
 use reth::primitives::Bytes;
 use serde::Deserialize;
@@ -87,7 +88,7 @@ pub async fn start_server_accepting_bundles(
                 Err(err) => {
                     warn!(?err, "Failed to parse transaction");
                     // @Metric
-                    return;
+                    return Err(err);
                 }
             };
             let raw_tx_order = RawTx { tx: raw_tx };
@@ -97,13 +98,15 @@ pub async fn start_server_accepting_bundles(
                 Err(err) => {
                     warn!(?err, "Failed to verify transaction");
                     // @Metric
-                    return;
+                    return Err(ErrorObject::owned(-32602, "failed to verify transaction", None::<()>));
                 }
             };
+            let hash = tx.tx_with_blobs.hash();
             let order = Order::Tx(tx);
             let parse_duration = start.elapsed();
             trace!(order = ?order.id(), parse_duration_mus = parse_duration.as_micros(), "Received mempool tx from API");
             send_order(order, &results, timeout).await;
+            Ok(hash)
         }
     })?;
 


### PR DESCRIPTION
## 📝 Summary

Have `rbuilder` correctly return the transaction hash in response to `eth_sendRawTransaction`.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

I noticed in local testing that `cast send` always returns null.

NOTE: the same is true of the other RPC methods `eth_sendBundle` etc. but I figured I'd leave those as a Good First Issue for others.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
