### PR TITLE
Add audit job to CI pipeline

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -57,6 +57,7 @@ jobs:
       - name: Install native dependencies
         run: sudo apt-get install -y libsqlite3-dev
 
-      # lint and test
+      # lint, test, and audit
       - run: make lint
       - run: make test
+      - run: make audit

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ fmt: ## Format the code
 	cargo fix --allow-staged
 	cargo clippy --fix --allow-staged
 
+.PHONY: audit
+audit:
+	cargo audit
+
 .PHONY: bench
 bench: ## Run benchmarks
 	cargo bench --bench bench_main


### PR DESCRIPTION
## 📝 Summary

 - Add `cargo audit` invocation to `Makefile` as `make audit`
 - Add `make audit` to existing CI pipeline

## 💡 Motivation and Context

See #79 for context.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] ~~Added tests (if applicable)~~
