### PR TITLE
[wip - don't merge] initial bundle sponsorship code

### DIFF
--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -174,7 +174,7 @@ pub struct TransactionOk {
     pub receipt: Receipt,
 }
 
-#[derive(Error, Debug, Eq, PartialEq)]
+#[derive(Clone, Error, Debug, Eq, PartialEq)]
 pub enum TransactionErr {
     #[error("Invalid transaction: {0:?}")]
     InvalidTransaction(InvalidTransaction),
@@ -203,7 +203,7 @@ pub struct BundleOk {
     pub original_order_ids: Vec<OrderId>,
 }
 
-#[derive(Error, Debug, Eq, PartialEq)]
+#[derive(Clone, Error, Debug, Eq, PartialEq)]
 pub enum BundleErr {
     #[error("Invalid transaction, hash: {0:?}, err: {1}")]
     InvalidTransaction(B256, TransactionErr),
@@ -264,7 +264,7 @@ pub struct OrderOk {
     pub used_state_trace: Option<UsedStateTrace>,
 }
 
-#[derive(Error, Debug, Eq, PartialEq)]
+#[derive(Clone, Error, Debug, Eq, PartialEq)]
 pub enum OrderErr {
     #[error("Transaction error: {0}")]
     Transaction(#[from] TransactionErr),

--- a/crates/rbuilder/src/building/payout_tx.rs
+++ b/crates/rbuilder/src/building/payout_tx.rs
@@ -32,7 +32,7 @@ pub fn create_payout_tx(
     signer.sign_tx(tx)
 }
 
-#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+#[derive(Clone, Debug, thiserror::Error, Eq, PartialEq)]
 pub enum PayoutTxErr {
     #[error("Reth error: {0}")]
     Reth(#[from] ProviderError),
@@ -92,7 +92,7 @@ pub fn insert_test_payout_tx(
     }
 }
 
-#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+#[derive(Clone, Debug, thiserror::Error, Eq, PartialEq)]
 pub enum EstimatePayoutGasErr {
     #[error("Reth error: {0}")]
     Reth(#[from] ProviderError),


### PR DESCRIPTION
## 📝 Summary
This work starts to implement #25, bundle sponsorship. It shows how you can catch the InvalidTransaction::LackOfFundForMaxFee error and parse it to grab the necessary information to attempt a bundle sponsorship.

**I started this PR months ago but didn't carry it out because at the time reth had a bug and was returning the wrong information. I am no longer actively working on it as my priorities have changed, so I'd encourage someone else to pick it up from here.**

The next steps for this work:
* Simulate sponsored bundles
* Evaluate if they are profitable to sponsor and handle the results of simulation
* Alter `SimulatedOrder` to include info about sponsorship if desirable
* Parse and handle sponsored bundles when filling orders (e.g. by inserting a sponsor tx with the right nonce)

But I haven't thought it out thoroughly!

## 💡 Motivation and Context
See #25, we might want this because it allows us to execute some transactions and make fees from them that we otherwise wouldn't be able to - thus leading to more valuable blocks.
<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
