### PR TITLE
Rename field name in UsedStateTrace

### DIFF
--- a/crates/rbuilder/src/building/evm_inspector.rs
+++ b/crates/rbuilder/src/building/evm_inspector.rs
@@ -14,10 +14,10 @@ pub struct SlotKey {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct UsedStateTrace {
-    /// read set contains first read
-    pub read_set: HashMap<SlotKey, B256>,
-    /// write set contains last write
-    pub write_set: HashMap<SlotKey, B256>,
+    /// read slot values contains first read
+    pub read_slot_values: HashMap<SlotKey, B256>,
+    /// write slot values contains last write
+    pub written_slot_values: HashMap<SlotKey, B256>,
 }
 
 #[derive(Debug)]
@@ -36,14 +36,14 @@ impl<'a> UsedStateEVMInspector<'a> {
     }
 
     fn use_tx_nonce(&mut self, tx: &TransactionSignedEcRecovered) {
-        self.used_state_trace.read_set.insert(
+        self.used_state_trace.read_slot_values.insert(
             SlotKey {
                 address: tx.signer(),
                 key: Default::default(),
             },
             U256::from(tx.nonce()).into(),
         );
-        self.used_state_trace.write_set.insert(
+        self.used_state_trace.written_slot_values.insert(
             SlotKey {
                 address: tx.signer(),
                 key: Default::default(),
@@ -65,7 +65,10 @@ where
                     address: interpreter.contract.address,
                     key: slot,
                 };
-                self.used_state_trace.read_set.entry(key).or_insert(value);
+                self.used_state_trace
+                    .read_slot_values
+                    .entry(key)
+                    .or_insert(value);
             }
         }
 
@@ -85,7 +88,7 @@ where
                         address: interpreter.contract.address,
                         key: B256::from(slot.to_be_bytes()),
                     };
-                    self.used_state_trace.write_set.insert(key, value);
+                    self.used_state_trace.written_slot_values.insert(key, value);
                 }
             }
             _ => (),


### PR DESCRIPTION
## 📝 Summary
Rename `read_set/write_set` to `read_slot_values/written_slot_values`
## 💡 Motivation and Context

As discussed in https://github.com/flashbots/rbuilder/issues/58, we renamed the fields to make it more descriptive and clear with the coming fields we are going to add.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
