### PR TITLE
chore: cleanup example config: comment internal blocks_processor_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,15 @@ rbuilder has a solid initial benchmarking setup (based on [Criterion.rs](https:/
 
 You can use [builder-playground](https://github.com/flashbots/builder-playground) to deploy a fully functional local setup for the builder ([Lighthouse](https://github.com/sigp/lighthouse) consensus client (proposer + validator) + [Reth](https://github.com/paradigmxyz/reth/) execution client + [MEV-Boost-Relay](https://github.com/flashbots/mev-boost-relay))) to test rbuilder.
 
-To do so:
-1. Start [builder-playground](https://github.com/flashbots/builder-playground)
-2. Then, run the rbuilder:
+First, start [builder-playground](https://github.com/flashbots/builder-playground):
+
+```
+git clone git@github.com:flashbots/builder-playground.git
+cd builder-playground
+go run main.go
+```
+
+Then, run `rbuilder` using the `config-playground.toml` config file:
 
 ```
 cargo run --bin rbuilder run config-playground.toml

--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -21,7 +21,7 @@ blocklist_file_path = "./blocklist.json"
 dry_run = true
 dry_run_validation_url = "http://localhost:8545"
 
-blocks_processor_url = "http://block_processor.internal"
+blocks_processor_url = ""
 ignore_cancellable_orders = true
 
 sbundle_mergeabe_signers = []
@@ -51,4 +51,3 @@ discard_txs = true
 sorting = "max-profit"
 failed_order_retries = 1
 drop_failed_orders = true
-

--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -8,8 +8,8 @@ reth_datadir = "/mnt/data/reth"
 
 coinbase_secret_key = "env:COINBASE_SECRET_KEY"
 
-#cl_node_url can be a single value, array of values, or passed by an environment variables with values separated with a comma
-#cl_node_url = "http://localhost:3500"
+# cl_node_url can be a single value, array of values, or passed by an environment variables with values separated with a comma
+# cl_node_url = "http://localhost:3500"
 cl_node_url = ["env:CL_NODE_URL"]
 jsonrpc_server_port = 8645
 jsonrpc_server_ip = "0.0.0.0"
@@ -21,12 +21,14 @@ blocklist_file_path = "./blocklist.json"
 dry_run = true
 dry_run_validation_url = "http://localhost:8545"
 
-blocks_processor_url = ""
+# blocks_processor_url can be an API service to record bids and transactions. It is not required.
+# blocks_processor_url = "http://block_processor.internal"
+
 ignore_cancellable_orders = true
 
 sbundle_mergeabe_signers = []
 # slot_delta_to_start_submits_ms is usually negative since we start bidding BEFORE the slot start
-#slot_delta_to_start_submits_ms = -5000
+# slot_delta_to_start_submits_ms = -5000
 live_builders = ["mp-ordering", "mgp-ordering", "merging"]
 
 [[relays]]

--- a/config-playground.toml
+++ b/config-playground.toml
@@ -17,12 +17,14 @@ extra_data = "⚡🤖"
 dry_run = false
 dry_run_validation_url = "http://localhost:8545"
 
-blocks_processor_url = "http://block_processor.internal"
+# blocks_processor_url can be an API service to record bids and transactions. It is not required.
+# blocks_processor_url = "http://block_processor.internal"
+
 ignore_cancellable_orders = true
 
 sbundle_mergeabe_signers = []
 # slot_delta_to_start_submits_ms is usually negative since we start bidding BEFORE the slot start
-#slot_delta_to_start_submits_ms = -5000
+# slot_delta_to_start_submits_ms = -5000
 live_builders = ["mp-ordering"]
 
 [[relays]]


### PR DESCRIPTION
## 📝 Summary

Remove internal URL from example config to reduce confusion


---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
