### PR TITLE
Fetch missing used sbundles

### DIFF
--- a/crates/rbuilder/src/backtest/fetch/mempool.rs
+++ b/crates/rbuilder/src/backtest/fetch/mempool.rs
@@ -43,7 +43,7 @@ pub fn get_mempool_transactions(
             let order: Order = RawOrder::Tx(RawTx {
                 tx: tx.raw_tx.into(),
             })
-            .decode(TxEncoding::NoBlobData)
+            .decode(TxEncoding::WithBlobData)
             .map_err(|err| error!("Failed to parse raw tx: {:?}", err))
             .ok()?;
             let timestamp_ms = tx


### PR DESCRIPTION
## 📝 Summary

1. When fetching share bundles from the db we also fetch the ones that were actually used by the builder because current code might miss some of them.
2. Fixes mempool datasource (removes error `2024-08-06T07:02:58.220392Z ERROR rbuilder::backtest::fetch::mempool: Failed to parse raw tx: FailedToDecodeTransaction(FailedToDecodeTransaction(UnexpectedList))`)

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
