### PR TITLE
Move relay config to relay crate

### DIFF
--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -31,7 +31,10 @@ use rbuilder::{
         simulation::SimulatedOrderCommand,
         LiveBuilder,
     },
-    primitives::{mev_boost::MevBoostRelay, SimulatedOrder},
+    primitives::{
+        mev_boost::{MevBoostRelay, RelayConfig},
+        SimulatedOrder,
+    },
     roothash::RootHashMode,
     utils::Signer,
 };
@@ -55,18 +58,12 @@ async fn main() -> eyre::Result<()> {
     let chain_spec = MAINNET.clone();
     let cancel = CancellationToken::new();
     let bidding_service = Box::new(DummyBiddingService {});
-    let relay = MevBoostRelay::try_from_name_or_url(
-        "flashbots",
-        "https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net",
-        0,
-        false,
-        false,
-        false,
-        None,
-        None,
-        None,
-        None,
-    )?;
+
+    let relay_config = RelayConfig::default().
+        with_url("https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net").
+        with_name("flashbots");
+
+    let relay = MevBoostRelay::from_config(&relay_config)?;
 
     let builder = LiveBuilder::<Arc<DatabaseEnv>, TraceBlockSinkFactory> {
         cls: vec![Client::default()],

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -10,7 +10,7 @@ use crate::{
         LiveBuilder,
     },
     mev_boost::BLSBlockSigner,
-    primitives::mev_boost::MevBoostRelay,
+    primitives::mev_boost::{MevBoostRelay, RelayConfig},
     telemetry::{setup_reloadable_tracing_subscriber, LoggerConfig},
     utils::{http_provider, BoxedProvider, ProviderFactoryReopener, Signer},
     validation_api_client::ValidationAPIClient,
@@ -270,41 +270,7 @@ impl BaseConfig {
     pub fn relays(&self) -> eyre::Result<Vec<MevBoostRelay>> {
         let mut results = Vec::new();
         for relay in &self.relays {
-            let authorization_header =
-                if let Some(authorization_header) = &relay.authorization_header {
-                    Some(authorization_header.value()?)
-                } else {
-                    None
-                };
-
-            let builder_id_header = if let Some(builder_id_header) = &relay.builder_id_header {
-                Some(builder_id_header.value()?)
-            } else {
-                None
-            };
-
-            let api_token_header = if let Some(api_token_header) = &relay.api_token_header {
-                Some(api_token_header.value()?)
-            } else {
-                None
-            };
-
-            let interval_between_submissions = relay
-                .interval_between_submissions_ms
-                .map(Duration::from_millis);
-
-            results.push(MevBoostRelay::try_from_name_or_url(
-                &relay.name,
-                &relay.url,
-                relay.priority,
-                relay.use_ssz_for_submit,
-                relay.use_gzip_for_submit,
-                relay.optimistic,
-                authorization_header,
-                builder_id_header,
-                api_token_header,
-                interval_between_submissions,
-            )?);
+            results.push(MevBoostRelay::from_config(relay)?);
         }
         Ok(results)
     }
@@ -530,29 +496,6 @@ where
         let s = String::deserialize(deserializer)?;
         Ok(EnvOrValue(s, std::marker::PhantomData))
     }
-}
-
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct RelayConfig {
-    pub name: String,
-    pub url: String,
-    pub priority: usize,
-    // true->ssz false->json
-    #[serde(default)]
-    pub use_ssz_for_submit: bool,
-    #[serde(default)]
-    pub use_gzip_for_submit: bool,
-    #[serde(default)]
-    pub optimistic: bool,
-    #[serde(default)]
-    pub authorization_header: Option<EnvOrValue<String>>,
-    #[serde(default)]
-    pub builder_id_header: Option<EnvOrValue<String>>,
-    #[serde(default)]
-    pub api_token_header: Option<EnvOrValue<String>>,
-    #[serde(default)]
-    pub interval_between_submissions_ms: Option<u64>,
 }
 
 pub const DEFAULT_ERROR_STORAGE_PATH: &str = "/tmp/rbuilder-error.sqlite";

--- a/crates/rbuilder/src/primitives/mev_boost.rs
+++ b/crates/rbuilder/src/primitives/mev_boost.rs
@@ -1,10 +1,50 @@
 use crate::mev_boost::{RelayClient, SubmitBlockErr, SubmitBlockRequest};
 use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
-use std::{sync::Arc, time::Duration};
+use serde::{Deserialize, Deserializer};
+use std::{env, sync::Arc, time::Duration};
 use url::Url;
 
 /// Usually human readable id for relays. Not used on anything on any protocol just to identify the relays.
 pub type MevBoostRelayID = String;
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RelayConfig {
+    pub name: String,
+    pub url: String,
+    pub priority: usize,
+    // true->ssz false->json
+    #[serde(default)]
+    pub use_ssz_for_submit: bool,
+    #[serde(default)]
+    pub use_gzip_for_submit: bool,
+    #[serde(default)]
+    pub optimistic: bool,
+    #[serde(default, deserialize_with = "deserialize_env_var")]
+    pub authorization_header: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_env_var")]
+    pub builder_id_header: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_env_var")]
+    pub api_token_header: Option<String>,
+    #[serde(default)]
+    pub interval_between_submissions_ms: Option<u64>,
+}
+
+impl RelayConfig {
+    pub fn with_url(self, url: &str) -> Self {
+        Self {
+            url: url.to_string(),
+            ..self
+        }
+    }
+
+    pub fn with_name(self, name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            ..self
+        }
+    }
+}
 
 /// Wrapper over RelayClient that allows to submit blocks and
 /// hides the particular configuration (eg: ssz, gip, optimistic).
@@ -25,42 +65,30 @@ pub struct MevBoostRelay {
 }
 
 impl MevBoostRelay {
-    #[allow(clippy::too_many_arguments)]
-    pub fn try_from_name_or_url(
-        id: &str,
-        name_or_url: &str,
-        priority: usize,
-        use_ssz_for_submit: bool,
-        use_gzip_for_submit: bool,
-        optimistic: bool,
-        authorization_header: Option<String>,
-        builder_id_header: Option<String>,
-        api_token_header: Option<String>,
-        interval_between_submissions: Option<Duration>,
-    ) -> eyre::Result<Self> {
+    pub fn from_config(config: &RelayConfig) -> eyre::Result<Self> {
         let client = {
-            let url: Url = name_or_url.parse()?;
+            let url: Url = config.url.parse()?;
             RelayClient::from_url(
                 url,
-                authorization_header,
-                builder_id_header,
-                api_token_header,
+                config.authorization_header.clone(),
+                config.builder_id_header.clone(),
+                config.api_token_header.clone(),
             )
         };
 
-        let submission_rate_limiter = interval_between_submissions.map(|d| {
+        let submission_rate_limiter = config.interval_between_submissions_ms.map(|d| {
             Arc::new(RateLimiter::direct(
-                Quota::with_period(d).expect("Rate limiter time period"),
+                Quota::with_period(Duration::from_millis(d)).expect("Rate limiter time period"),
             ))
         });
 
         Ok(MevBoostRelay {
-            id: id.to_string(),
+            id: config.name.to_string(),
             client,
-            priority,
-            use_ssz_for_submit,
-            use_gzip_for_submit,
-            optimistic,
+            priority: config.priority,
+            use_ssz_for_submit: config.use_ssz_for_submit,
+            use_gzip_for_submit: config.use_gzip_for_submit,
+            optimistic: config.optimistic,
             submission_rate_limiter,
         })
     }
@@ -69,5 +97,48 @@ impl MevBoostRelay {
         self.client
             .submit_block(data, self.use_ssz_for_submit, self.use_gzip_for_submit)
             .await
+    }
+}
+
+fn deserialize_env_var<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Option<String> = Option::deserialize(deserializer)?;
+    Ok(match s {
+        Some(val) if val.starts_with("env:") => {
+            let env_var = &val[4..];
+            env::var(env_var).ok()
+        }
+        _ => s,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_relay_config() {
+        let example = "
+        name = 'relay1'
+        url = 'url'
+        priority = 0
+        authorization_header = 'env:XXX'
+        builder_id_header = 'env:YYY'
+        api_token_header = 'env:ZZZ'
+        ";
+
+        std::env::set_var("XXX", "AAA");
+        std::env::set_var("YYY", "BBB");
+        std::env::set_var("ZZZ", "CCC");
+
+        let config: RelayConfig = toml::from_str(&example).unwrap();
+        assert_eq!(config.name, "relay1");
+        assert_eq!(config.url, "url");
+        assert_eq!(config.priority, 0);
+        assert_eq!(config.authorization_header.unwrap(), "AAA");
+        assert_eq!(config.builder_id_header.unwrap(), "BBB");
+        assert_eq!(config.api_token_header.unwrap(), "CCC");
     }
 }


### PR DESCRIPTION
## 📝 Summary

This PR moves the `RelayConfig` to the relay crate. It includes a unit test to ensure the backward compatibility for reading env variables in the config toml file.

## 💡 Motivation and Context

Move L1 specific configuration out of the Live builder to their own repositories.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
