### PR TITLE
Add block source abstraction to live_builder

### DIFF
--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -8,7 +8,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     building::builders::{BacktestSimulateBlockInput, Block},
-    live_builder::base_config::load_config_toml_and_env,
+    live_builder::{
+        base_config::load_config_toml_and_env, payload_events::MevBoostSlotDataGenerator,
+    },
     telemetry::spawn_telemetry_server,
     utils::build_info::Version,
 };
@@ -41,7 +43,9 @@ pub trait LiveBuilderConfig: std::fmt::Debug + serde::de::DeserializeOwned {
         &self,
         cancellation_token: CancellationToken,
     ) -> impl std::future::Future<
-        Output = eyre::Result<LiveBuilder<Arc<DatabaseEnv>, RelaySubmitSinkFactory>>,
+        Output = eyre::Result<
+            LiveBuilder<Arc<DatabaseEnv>, RelaySubmitSinkFactory, MevBoostSlotDataGenerator>,
+        >,
     > + Send;
 
     /// Patch until we have a unified way of backtesting using the exact algorithms we use on the LiveBuilder.

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         Sorting,
     },
-    live_builder::cli::LiveBuilderConfig,
+    live_builder::{cli::LiveBuilderConfig, payload_events::MevBoostSlotDataGenerator},
     utils::{build_info::rbuilder_version, ProviderFactoryReopener, Signer},
 };
 use alloy_primitives::{Address, B256};
@@ -62,7 +62,11 @@ impl LiveBuilderConfig for Config {
         &self,
         cancellation_token: tokio_util::sync::CancellationToken,
     ) -> eyre::Result<
-        super::LiveBuilder<Arc<DatabaseEnv>, super::building::relay_submit::RelaySubmitSinkFactory>,
+        super::LiveBuilder<
+            Arc<DatabaseEnv>,
+            super::building::relay_submit::RelaySubmitSinkFactory,
+            MevBoostSlotDataGenerator,
+        >,
     > {
         let live_builder = self.base_config.create_builder(cancellation_token).await?;
         let root_hash_task_pool = self.base_config.root_hash_task_pool()?;

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -50,7 +50,7 @@ const GET_BLOCK_HEADER_PERIOD: time::Duration = time::Duration::milliseconds(250
 
 /// Trait used to trigger a new block building process in the slot.
 pub trait SlotSource {
-    fn req_slot_channel(self) -> mpsc::UnboundedReceiver<MevBoostSlotData>;
+    fn recv_slot_channel(self) -> mpsc::UnboundedReceiver<MevBoostSlotData>;
 }
 
 /// Main builder struct.
@@ -120,7 +120,7 @@ where
             .with_context(|| "Error spawning error storage writer")?;
 
         let mut inner_jobs_handles = Vec::new();
-        let mut payload_events_channel = self.blocks_source.req_slot_channel();
+        let mut payload_events_channel = self.blocks_source.recv_slot_channel();
 
         let orderpool_subscriber = {
             let (handle, sub) = start_orderpool_jobs(

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -9,7 +9,6 @@ pub mod simulation;
 mod watchdog;
 
 use crate::{
-    beacon_api_client::Client,
     building::{
         builders::{BlockBuildingAlgorithm, BuilderSinkFactory},
         BlockBuildingContext,
@@ -19,7 +18,6 @@ use crate::{
         simulation::OrderSimulationPool,
         watchdog::spawn_watchdog_thread,
     },
-    primitives::mev_boost::MevBoostRelay,
     telemetry::inc_active_slots,
     utils::{error_storage::spawn_error_storage_writer, ProviderFactoryReopener, Signer},
 };
@@ -29,7 +27,7 @@ use bidding::BiddingService;
 use building::BlockBuildingPool;
 use eyre::Context;
 use jsonrpsee::RpcModule;
-use payload_events::MevBoostSlotDataGenerator;
+use payload_events::MevBoostSlotData;
 use reth::{
     primitives::Header,
     providers::{HeaderProvider, ProviderFactory},
@@ -38,7 +36,7 @@ use reth_chainspec::ChainSpec;
 use reth_db::database::Database;
 use std::{cmp::min, path::PathBuf, sync::Arc, time::Duration};
 use time::OffsetDateTime;
-use tokio::task::spawn_blocking;
+use tokio::{sync::mpsc, task::spawn_blocking};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -50,18 +48,25 @@ const BLOCK_HEADER_DEAD_LINE_DELTA: time::Duration = time::Duration::millisecond
 /// Polling period while trying to get a block header
 const GET_BLOCK_HEADER_PERIOD: time::Duration = time::Duration::milliseconds(250);
 
+pub trait BlocksSource {
+    fn recv_block_params(self) -> mpsc::UnboundedReceiver<MevBoostSlotData>;
+}
+
 /// Main builder struct.
 /// Connects to the CL, get the new slots and builds blocks for each slot.
 /// # Usage
 /// Create and run()
 #[derive(Debug)]
-pub struct LiveBuilder<DB, BuilderSinkFactoryType: BuilderSinkFactory> {
-    pub cls: Vec<Client>,
-    pub relays: Vec<MevBoostRelay>,
+pub struct LiveBuilder<
+    DB,
+    BuilderSinkFactoryType: BuilderSinkFactory,
+    BlocksSourceType: BlocksSource,
+> {
     pub watchdog_timeout: Duration,
     pub error_storage_path: PathBuf,
     pub simulation_threads: usize,
     pub order_input_config: OrderInputConfig,
+    pub blocks_source: BlocksSourceType,
 
     pub chain_chain_spec: Arc<ChainSpec>,
     pub provider_factory: ProviderFactoryReopener<DB>,
@@ -79,8 +84,11 @@ pub struct LiveBuilder<DB, BuilderSinkFactoryType: BuilderSinkFactory> {
     pub extra_rpc: RpcModule<()>,
 }
 
-impl<DB: Database + Clone + 'static, BuilderSinkFactoryType: BuilderSinkFactory>
-    LiveBuilder<DB, BuilderSinkFactoryType>
+impl<
+        DB: Database + Clone + 'static,
+        BuilderSinkFactoryType: BuilderSinkFactory,
+        BuilderSourceType: BlocksSource,
+    > LiveBuilder<DB, BuilderSinkFactoryType, BuilderSourceType>
 where
     <BuilderSinkFactoryType as BuilderSinkFactory>::SinkType: 'static,
 {
@@ -114,18 +122,7 @@ where
             .with_context(|| "Error spawning error storage writer")?;
 
         let mut inner_jobs_handles = Vec::new();
-
-        let mut payload_events_channel = {
-            let payload_event = MevBoostSlotDataGenerator::new(
-                self.cls,
-                self.relays.clone(),
-                self.blocklist.clone(),
-                self.global_cancellation.clone(),
-            );
-            let (handle, chan) = payload_event.spawn();
-            inner_jobs_handles.push(handle);
-            chan
-        };
+        let mut payload_events_channel = self.blocks_source.recv_block_params();
 
         let orderpool_subscriber = {
             let (handle, sub) = start_orderpool_jobs(

--- a/crates/rbuilder/src/live_builder/payload_events/mod.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/mod.rs
@@ -7,9 +7,12 @@ pub mod relay_epoch_cache;
 
 use crate::{
     beacon_api_client::Client,
-    live_builder::payload_events::{
-        payload_source::PayloadSourceMuxer,
-        relay_epoch_cache::{RelaysForSlotData, SlotData},
+    live_builder::{
+        payload_events::{
+            payload_source::PayloadSourceMuxer,
+            relay_epoch_cache::{RelaysForSlotData, SlotData},
+        },
+        BlocksSource,
     },
     primitives::mev_boost::{MevBoostRelay, MevBoostRelayID},
 };
@@ -178,6 +181,13 @@ impl MevBoostSlotDataGenerator {
         });
 
         (handle, receive)
+    }
+}
+
+impl BlocksSource for MevBoostSlotDataGenerator {
+    fn recv_block_params(self) -> mpsc::UnboundedReceiver<MevBoostSlotData> {
+        let (_handle, chan) = self.spawn();
+        chan
     }
 }
 

--- a/crates/rbuilder/src/live_builder/payload_events/mod.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/mod.rs
@@ -12,7 +12,7 @@ use crate::{
             payload_source::PayloadSourceMuxer,
             relay_epoch_cache::{RelaysForSlotData, SlotData},
         },
-        BlocksSource,
+        SlotSource,
     },
     primitives::mev_boost::{MevBoostRelay, MevBoostRelayID},
 };
@@ -184,8 +184,8 @@ impl MevBoostSlotDataGenerator {
     }
 }
 
-impl BlocksSource for MevBoostSlotDataGenerator {
-    fn recv_block_params(self) -> mpsc::UnboundedReceiver<MevBoostSlotData> {
+impl SlotSource for MevBoostSlotDataGenerator {
+    fn req_slot_channel(self) -> mpsc::UnboundedReceiver<MevBoostSlotData> {
         let (_handle, chan) = self.spawn();
         chan
     }

--- a/crates/rbuilder/src/live_builder/payload_events/mod.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/mod.rs
@@ -185,7 +185,7 @@ impl MevBoostSlotDataGenerator {
 }
 
 impl SlotSource for MevBoostSlotDataGenerator {
-    fn req_slot_channel(self) -> mpsc::UnboundedReceiver<MevBoostSlotData> {
+    fn recv_slot_channel(self) -> mpsc::UnboundedReceiver<MevBoostSlotData> {
         let (_handle, chan) = self.spawn();
         chan
     }


### PR DESCRIPTION
## 📝 Summary

This PR removes the two L1 concrete references in the live_builder (cls, and relays) and introduces a new abstraction akin to the BlockSinker but to notify the live_builder when to build blocks, the `BlocksSource`.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
