### PR TITLE
Shell expand the reth data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ You can use [builder-playground](https://github.com/flashbots/builder-playground
 
 To do so:
 1. Start [builder-playground](https://github.com/flashbots/builder-playground)
-2. Edit `config-playground.toml` to set the location of your home directory (replace the _HOME_ placeholder)
-3. Then, run the rbuilder:
+2. Then, run the rbuilder:
 
 ```
 cargo run --bin rbuilder run config-playground.toml

--- a/config-playground.toml
+++ b/config-playground.toml
@@ -3,8 +3,8 @@ log_level = "info,rbuilder=debug"
 telemetry_port = 6060
 telemetry_ip = "0.0.0.0"
 
-chain = "_HOME_/.playground/devnet/genesis.json"
-reth_datadir = "_HOME_/.playground/devnet/data_reth"
+chain = "$HOME/.playground/devnet/genesis.json"
+reth_datadir = "$HOME/.playground/devnet/data_reth"
 relay_secret_key = "5eae315483f028b5cdd5d1090ff0c7618b18737ea9bf3c35047189db22835c48"
 coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -617,7 +617,18 @@ pub fn create_provider_factory(
     reth_static_files_path: Option<&Path>,
     chain_spec: Arc<ChainSpec>,
 ) -> eyre::Result<ProviderFactoryReopener<Arc<DatabaseEnv>>> {
-    let reth_db_path = match (reth_db_path, reth_datadir) {
+    // shellexpand the reth datadir
+    let reth_datadir = if let Some(reth_datadir) = reth_datadir {
+        let reth_datadir = reth_datadir
+            .to_str()
+            .ok_or_else(|| eyre::eyre!("Invalid UTF-8 in path"))?;
+
+        Some(PathBuf::from(shellexpand::full(reth_datadir)?.into_owned()))
+    } else {
+        None
+    };
+
+    let reth_db_path = match (reth_db_path, reth_datadir.clone()) {
         (Some(reth_db_path), _) => PathBuf::from(reth_db_path),
         (None, Some(reth_datadir)) => reth_datadir.join("db"),
         (None, None) => eyre::bail!("Either reth_db_path or reth_datadir must be provided"),


### PR DESCRIPTION
## 📝 Summary

This PR shell expands the reth data-dir and updates the playground config.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
