### PR TITLE
Redistribution improvements

### DIFF
--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -72,12 +72,14 @@ pub fn backtest_prepare_ctx_for_block<DB: Database + Clone>(
             Some(order.order.clone())
         })
         .collect::<Vec<_>>();
-    let ctx = BlockBuildingContext::from_block_data(
-        &block_data,
+    let ctx = BlockBuildingContext::from_onchain_block(
+        block_data.onchain_block,
         chain_spec.clone(),
-        blocklist,
         None,
-        builder_signer,
+        blocklist,
+        builder_signer.address,
+        block_data.winning_bid_trace.proposer_fee_recipient,
+        Some(builder_signer),
     );
     let (sim_orders, sim_errors) =
         simulate_all_orders_with_sim_tree(provider_factory.clone(), &ctx, &orders, false)?;

--- a/crates/rbuilder/src/backtest/mod.rs
+++ b/crates/rbuilder/src/backtest/mod.rs
@@ -4,6 +4,7 @@ pub mod execute;
 pub mod fetch;
 
 pub mod redistribute;
+pub mod restore_landed_orders;
 mod results_store;
 mod store;
 

--- a/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
@@ -93,7 +93,7 @@ pub async fn run_backtest_redistribute<ConfigType: LiveBuilderConfig>() -> eyre:
     Ok(())
 }
 
-fn process_redisribution<ConfigType: LiveBuilderConfig>(
+fn process_redisribution<ConfigType: LiveBuilderConfig + Send + Sync>(
     block_data: BlockData,
     csv_writer: Option<&mut CSVResultWriter>,
     provider_factory: ProviderFactory<Arc<DatabaseEnv>>,

--- a/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
@@ -21,6 +21,8 @@ struct Cli {
     config: PathBuf,
     #[clap(long, help = "CSV output path")]
     csv: Option<PathBuf>,
+    #[clap(long, help = "distribute to mempool txs", default_value = "false")]
+    distribute_to_mempool_txs: bool,
     #[clap(subcommand)]
     command: Commands,
 }
@@ -70,6 +72,7 @@ pub async fn run_backtest_redistribute<ConfigType: LiveBuilderConfig>() -> eyre:
                 csv_writer.as_mut(),
                 provider_factory.clone(),
                 &config,
+                cli.distribute_to_mempool_txs,
             )?;
         }
         Commands::Range {
@@ -85,6 +88,7 @@ pub async fn run_backtest_redistribute<ConfigType: LiveBuilderConfig>() -> eyre:
                     csv_writer.as_mut(),
                     provider_factory.clone(),
                     &config,
+                    cli.distribute_to_mempool_txs,
                 )?;
             }
         }
@@ -98,11 +102,17 @@ fn process_redisribution<ConfigType: LiveBuilderConfig + Send + Sync>(
     csv_writer: Option<&mut CSVResultWriter>,
     provider_factory: ProviderFactory<Arc<DatabaseEnv>>,
     config: &ConfigType,
+    distribute_to_mempool_txs: bool,
 ) -> eyre::Result<()> {
     let block_number = block_data.block_number;
     let block_hash = block_data.onchain_block.header.hash.unwrap_or_default();
     info!(block_number, "Calculating redistribution for a block");
-    let redistribution_values = calc_redistributions(provider_factory.clone(), config, block_data)?;
+    let redistribution_values = calc_redistributions(
+        provider_factory.clone(),
+        config,
+        block_data,
+        distribute_to_mempool_txs,
+    )?;
 
     if let Some(csv_writer) = csv_writer {
         let values = redistribution_values

--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -145,6 +145,9 @@ pub fn calc_redistributions<ConfigType: LiveBuilderConfig + Send + Sync>(
     let profit_without_exclusion = calc_profit(provider_factory.clone(), config, &block_data, &[])?;
 
     let profit_after_address_exclusion = all_orders_by_address
+        .into_iter()
+        .filter(|(address, _)| landed_orders_by_address.contains_key(address))
+        .collect::<Vec<_>>()
         .into_par_iter()
         .map(|(address, orders)| {
             (

--- a/crates/rbuilder/src/backtest/redistribute/redistribution_algo.rs
+++ b/crates/rbuilder/src/backtest/redistribute/redistribution_algo.rs
@@ -1,0 +1,284 @@
+use crate::backtest::restore_landed_orders::LandedOrderData;
+use crate::primitives::OrderId;
+use alloy_primitives::{Address, I256, U256};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug)]
+pub struct IncludedOrderData {
+    pub id: OrderId,
+    pub landed_order_data: LandedOrderData,
+}
+
+#[derive(Debug)]
+pub struct RedistributionIdentityData {
+    pub address: Address,
+    /// This is the difference between block value with all orders and
+    /// block value when we exclude orders by this identity
+    pub value_delta_after_exclusion: I256,
+    pub included_orders: Vec<IncludedOrderData>,
+}
+
+#[derive(Debug)]
+pub struct RedistributionCalculator {
+    pub landed_block_profit: U256,
+    pub identity_data: Vec<RedistributionIdentityData>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct RedistributionEntityResult {
+    pub address: Address,
+    pub value_received: U256,
+    /// Contribution to the value_received by each individual order
+    pub order_contributions: Vec<(OrderId, U256)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct RedistributionResult {
+    /// This is onchain block profit that is being redistributed
+    pub landed_block_profit: U256,
+    /// Total value that is redistributed to different identities <= landed_block_profit
+    pub total_value_redistributed: U256,
+    pub value_by_identity: Vec<RedistributionEntityResult>,
+}
+
+pub fn calculate_redistribution(data: RedistributionCalculator) -> RedistributionResult {
+    let mut value_after_exclusion = Vec::new();
+    let mut value_paid_to_coinbase = Vec::new();
+    let mut identity_orders = Vec::new();
+    let mut value_paid_by_order_to_coinbase = Vec::new();
+    for identity in &data.identity_data {
+        let (sign, abs) = identity.value_delta_after_exclusion.into_sign_and_abs();
+        if sign.is_positive() {
+            value_after_exclusion.push(abs);
+        } else {
+            value_after_exclusion.push(U256::ZERO);
+        }
+        let mut order_paid_to_coinbase = Vec::new();
+        let mut order_id = Vec::new();
+        for order in &identity.included_orders {
+            let (sign, abs) = order
+                .landed_order_data
+                .unique_coinbase_profit
+                .into_sign_and_abs();
+            order_id.push(order.id);
+            if sign.is_positive() {
+                order_paid_to_coinbase.push(abs);
+            } else {
+                order_paid_to_coinbase.push(U256::ZERO);
+            }
+        }
+        value_paid_to_coinbase.push(order_paid_to_coinbase.iter().sum::<U256>());
+        value_paid_by_order_to_coinbase.push(order_paid_to_coinbase);
+        identity_orders.push(order_id);
+    }
+
+    // we clamp value after exclusion to the value paid to coinbase
+    // so that orders that had huge contribution in backtest but small onchain will not suppress others
+    for i in 0..value_after_exclusion.len() {
+        value_after_exclusion[i] =
+            std::cmp::min(value_after_exclusion[i], value_paid_to_coinbase[i]);
+    }
+
+    let mut result = RedistributionResult {
+        landed_block_profit: data.landed_block_profit,
+        total_value_redistributed: U256::ZERO,
+        value_by_identity: vec![],
+    };
+
+    let total_value_split = split_value(data.landed_block_profit, &value_after_exclusion);
+    for (i, identity) in data.identity_data.into_iter().enumerate() {
+        let value_received = std::cmp::min(total_value_split[i], value_paid_to_coinbase[i]);
+        result.total_value_redistributed += value_received;
+        let per_order_split = split_value(value_received, &value_paid_by_order_to_coinbase[i]);
+        let order_contribution = identity_orders[i]
+            .iter()
+            .cloned()
+            .zip(per_order_split.into_iter())
+            .collect();
+        result.value_by_identity.push(RedistributionEntityResult {
+            address: identity.address,
+            value_received,
+            order_contributions: order_contribution,
+        })
+    }
+
+    result
+}
+
+fn split_value(value: U256, split_vector: &[U256]) -> Vec<U256> {
+    let total_split = split_vector.iter().sum::<U256>();
+    if total_split.is_zero() {
+        return split_vector.iter().map(|_| U256::ZERO).collect();
+    }
+    let mut result = Vec::new();
+    for split in split_vector {
+        result.push((value * split) / total_split);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::*;
+
+    #[test]
+    fn test_split_value() {
+        let test_data = vec![
+            (100, vec![100], vec![100]),
+            (100, vec![30, 70], vec![30, 70]),
+            (100, vec![10, 20], vec![33, 66]),
+            (100, vec![100, 200], vec![33, 66]),
+            (100, vec![0, 0], vec![0, 0]),
+        ];
+
+        for (value, split_vector, expected) in test_data {
+            let value = U256::from(value);
+            let split_vector = split_vector
+                .into_iter()
+                .map(U256::from)
+                .collect::<Vec<U256>>();
+            let expected = expected.into_iter().map(U256::from).collect::<Vec<U256>>();
+            assert_eq!(split_value(value, &split_vector), expected);
+        }
+    }
+
+    #[test]
+    fn test_calculate_redistribution() {
+        let input = RedistributionCalculator {
+            landed_block_profit: u256(1000),
+            identity_data: vec![
+                // simple identity with one bundle
+                RedistributionIdentityData {
+                    address: addr(1),
+                    value_delta_after_exclusion: i256(10),
+                    included_orders: vec![IncludedOrderData {
+                        id: order_id(0x11),
+                        landed_order_data: LandedOrderData {
+                            order: order_id(0x11),
+                            unique_coinbase_profit: i256(10),
+                            total_coinbase_profit: i256(10),
+                            error: None,
+                            overlapping_txs: vec![],
+                        },
+                    }],
+                },
+                // identity value after exclusion is negative
+                RedistributionIdentityData {
+                    address: addr(2),
+                    value_delta_after_exclusion: i256(-10),
+                    included_orders: vec![IncludedOrderData {
+                        id: order_id(0x21),
+                        landed_order_data: LandedOrderData {
+                            order: order_id(0x21),
+                            unique_coinbase_profit: i256(-10),
+                            total_coinbase_profit: i256(-10),
+                            error: None,
+                            overlapping_txs: vec![],
+                        },
+                    }],
+                },
+                // identity has no landed bundles
+                RedistributionIdentityData {
+                    address: addr(3),
+                    value_delta_after_exclusion: i256(10),
+                    included_orders: vec![],
+                },
+                // identity has bundle with negative contribution, bundle
+                RedistributionIdentityData {
+                    address: addr(4),
+                    value_delta_after_exclusion: i256(20),
+                    included_orders: vec![
+                        IncludedOrderData {
+                            id: order_id(0x41),
+                            landed_order_data: LandedOrderData {
+                                order: order_id(0x41),
+                                unique_coinbase_profit: i256(20),
+                                total_coinbase_profit: i256(10), // make sure that this is not used
+                                error: None,
+                                overlapping_txs: vec![],
+                            },
+                        },
+                        IncludedOrderData {
+                            id: order_id(0x42),
+                            landed_order_data: LandedOrderData {
+                                order: order_id(0x41),
+                                unique_coinbase_profit: i256(-10),
+                                total_coinbase_profit: i256(-10),
+                                error: None,
+                                overlapping_txs: vec![],
+                            },
+                        },
+                    ],
+                },
+                // identity with 2 value, hube backtest contribution but small onchain
+                RedistributionIdentityData {
+                    address: addr(5),
+                    value_delta_after_exclusion: i256(4000),
+                    included_orders: vec![
+                        IncludedOrderData {
+                            id: order_id(0x51),
+                            landed_order_data: LandedOrderData {
+                                order: order_id(0x51),
+                                unique_coinbase_profit: i256(30),
+                                total_coinbase_profit: i256(30),
+                                error: None,
+                                overlapping_txs: vec![],
+                            },
+                        },
+                        IncludedOrderData {
+                            id: order_id(0x52),
+                            landed_order_data: LandedOrderData {
+                                order: order_id(0x52),
+                                unique_coinbase_profit: i256(50),
+                                total_coinbase_profit: i256(50),
+                                error: None,
+                                overlapping_txs: vec![],
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        let output = RedistributionResult {
+            landed_block_profit: u256(1000),
+            total_value_redistributed: u256(110),
+            value_by_identity: vec![
+                RedistributionEntityResult {
+                    address: addr(1),
+                    value_received: u256(10),
+                    order_contributions: vec![(order_id(0x11), u256(10))],
+                },
+                RedistributionEntityResult {
+                    address: addr(2),
+                    value_received: u256(0),
+                    order_contributions: vec![(order_id(0x21), u256(0))],
+                },
+                RedistributionEntityResult {
+                    address: addr(3),
+                    value_received: u256(0),
+                    order_contributions: vec![],
+                },
+                RedistributionEntityResult {
+                    address: addr(4),
+                    value_received: u256(20),
+                    order_contributions: vec![
+                        (order_id(0x41), u256(20)),
+                        (order_id(0x42), u256(0)),
+                    ],
+                },
+                RedistributionEntityResult {
+                    address: addr(5),
+                    value_received: u256(80),
+                    order_contributions: vec![
+                        (order_id(0x51), u256(30)),
+                        (order_id(0x52), u256(50)),
+                    ],
+                },
+            ],
+        };
+
+        assert_eq!(calculate_redistribution(input), output);
+    }
+}

--- a/crates/rbuilder/src/backtest/restore_landed_orders/find_landed_orders.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/find_landed_orders.rs
@@ -1,0 +1,865 @@
+use crate::primitives::{Order, OrderId, ShareBundleBody, ShareBundleInner, TxRevertBehavior};
+use crate::utils::get_percent;
+use ahash::HashMap;
+use alloy_primitives::{B256, I256, U256};
+
+/// SimplifiedOrder represents unified form of the order
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SimplifiedOrder {
+    pub id: OrderId,
+    pub chunks: Vec<OrderChunk>,
+}
+
+impl SimplifiedOrder {
+    pub fn new(id: OrderId, chunks: Vec<OrderChunk>) -> Self {
+        SimplifiedOrder { id, chunks }
+    }
+
+    pub fn new_from_order(order: &Order) -> Self {
+        let id = order.id();
+        match order {
+            Order::Tx(tx) => SimplifiedOrder::new(
+                id,
+                vec![OrderChunk::new(
+                    vec![(tx.tx_with_blobs.hash(), TxRevertBehavior::AllowedIncluded)],
+                    false,
+                    0,
+                )],
+            ),
+            Order::Bundle(_) => {
+                let txs = order
+                    .list_txs()
+                    .into_iter()
+                    .map(|(tx, optional)| {
+                        let revert = if optional {
+                            TxRevertBehavior::AllowedExcluded
+                        } else {
+                            TxRevertBehavior::NotAllowed
+                        };
+                        (tx.tx.hash, revert)
+                    })
+                    .collect();
+                SimplifiedOrder::new(id, vec![OrderChunk::new(txs, false, 0)])
+            }
+            Order::ShareBundle(bundle) => SimplifiedOrder::new(
+                id,
+                OrderChunk::chunks_from_inner_share_bundle(&bundle.inner_bundle),
+            ),
+        }
+    }
+}
+
+/// OrderChunk is atomic set of txs
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct OrderChunk {
+    pub txs: Vec<(B256, TxRevertBehavior)>,
+    /// If true this chunk can be dropped from the Order
+    pub optional: bool,
+    pub kickback_percent: usize,
+}
+
+impl OrderChunk {
+    pub fn new(
+        txs: Vec<(B256, TxRevertBehavior)>,
+        optional: bool,
+        kickback_percent: usize,
+    ) -> Self {
+        OrderChunk {
+            txs,
+            optional,
+            kickback_percent,
+        }
+    }
+
+    pub fn chunks_from_inner_share_bundle(inner: &ShareBundleInner) -> Vec<Self> {
+        let total_refund_percent = inner.refund.iter().map(|r| r.percent).sum::<usize>();
+
+        let mut accumulated_chunks = Vec::new();
+
+        let mut prev_element_payed_refund = false;
+        let mut current_chunk_txs = Vec::new();
+
+        let release_chunk = |current_chunk_txs: &mut Vec<(B256, TxRevertBehavior)>,
+                             accumulated_chunks: &mut Vec<OrderChunk>,
+                             kickback_percent| {
+            if !current_chunk_txs.is_empty() {
+                accumulated_chunks.push(OrderChunk {
+                    txs: std::mem::take(current_chunk_txs),
+                    optional: inner.can_skip,
+                    kickback_percent,
+                })
+            }
+        };
+
+        for (idx, body) in inner.body.iter().enumerate() {
+            let current_element_pays_refund = !inner.refund.iter().any(|r| r.body_idx == idx);
+
+            if prev_element_payed_refund != current_element_pays_refund {
+                let chunk_refund_percent = if prev_element_payed_refund {
+                    total_refund_percent
+                } else {
+                    0
+                };
+                release_chunk(
+                    &mut current_chunk_txs,
+                    &mut accumulated_chunks,
+                    chunk_refund_percent,
+                );
+                prev_element_payed_refund = current_element_pays_refund;
+            }
+
+            match body {
+                ShareBundleBody::Tx(tx) => {
+                    current_chunk_txs.push((tx.hash(), tx.revert_behavior));
+                }
+                ShareBundleBody::Bundle(inner_bundle) => {
+                    let chunk_refund_percent = if prev_element_payed_refund {
+                        total_refund_percent
+                    } else {
+                        0
+                    };
+                    release_chunk(
+                        &mut current_chunk_txs,
+                        &mut accumulated_chunks,
+                        chunk_refund_percent,
+                    );
+
+                    let mut inner_chunks = Self::chunks_from_inner_share_bundle(inner_bundle);
+                    for chunk in &mut inner_chunks {
+                        if current_element_pays_refund {
+                            chunk.kickback_percent = multiply_inner_refunds(
+                                chunk.kickback_percent,
+                                chunk_refund_percent,
+                            );
+                        }
+                        if inner.can_skip {
+                            chunk.optional = true;
+                        }
+                    }
+                    accumulated_chunks.extend(inner_chunks);
+                }
+            }
+        }
+
+        let chunk_refund_percent = if prev_element_payed_refund {
+            total_refund_percent
+        } else {
+            0
+        };
+        release_chunk(
+            &mut current_chunk_txs,
+            &mut accumulated_chunks,
+            chunk_refund_percent,
+        );
+
+        accumulated_chunks
+    }
+}
+
+fn multiply_inner_refunds(a: usize, b: usize) -> usize {
+    if a > 100 || b > 100 {
+        return 0;
+    }
+    100 - (100 - a) * (100 - b) / 100
+}
+
+/// ExecutedBlockTx is data from the tx executed in the block
+#[derive(Debug)]
+pub struct ExecutedBlockTx {
+    pub hash: B256,
+    pub coinbase_profit: I256,
+    pub success: bool,
+}
+
+impl ExecutedBlockTx {
+    pub fn new(hash: B256, coinbase_profit: I256, success: bool) -> Self {
+        ExecutedBlockTx {
+            hash,
+            coinbase_profit,
+            success,
+        }
+    }
+}
+
+/// LandedOrderData is info about order that was restored from the block
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct LandedOrderData {
+    pub order: OrderId,
+    pub total_coinbase_profit: I256,
+    /// Unique profit is the profit that is unique to this order and its does not overlap with other landed orders
+    /// For example, if we merged two backruns for one tx it only count backrun tx profit for each order
+    pub unique_coinbase_profit: I256,
+    pub error: Option<OrderIdentificationError>,
+    pub overlapping_txs: Vec<(OrderId, B256)>,
+}
+
+#[derive(Debug, Clone, thiserror::Error, Eq, PartialEq)]
+pub enum OrderIdentificationError {
+    #[error("Tx not found: {0}")]
+    TxNotFound(B256),
+    #[error("Tx reverted: {0}")]
+    TxReverted(B256),
+    #[error("Tx is in incorrect position")]
+    TxIsIncorrectPosition,
+    #[error("No landed txs found")]
+    NoOrderTxs,
+}
+
+impl LandedOrderData {
+    pub fn new(
+        order: OrderId,
+        total_coinbase_profit: I256,
+        unique_coinbase_profit: I256,
+        error: Option<OrderIdentificationError>,
+        overlapping_txs: Vec<(OrderId, B256)>,
+    ) -> Self {
+        LandedOrderData {
+            order,
+            total_coinbase_profit,
+            unique_coinbase_profit,
+            error,
+            overlapping_txs,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ExecutedBlockData {
+    block_txs: Vec<ExecutedBlockTx>,
+    txs_by_hash: HashMap<B256, usize>,
+}
+
+impl ExecutedBlockData {
+    fn new_from_txs(txs: Vec<ExecutedBlockTx>) -> Self {
+        let mut txs_by_hash = HashMap::default();
+        for (idx, tx) in txs.iter().enumerate() {
+            txs_by_hash.insert(tx.hash, idx);
+        }
+        ExecutedBlockData {
+            block_txs: txs,
+            txs_by_hash,
+        }
+    }
+
+    fn find_tx(&self, hash: B256) -> Option<(usize, &ExecutedBlockTx)> {
+        self.txs_by_hash
+            .get(&hash)
+            .map(|idx| (*idx, &self.block_txs[*idx]))
+    }
+
+    fn tx_coinbase_profit(&self, hash: B256) -> Option<I256> {
+        self.find_tx(hash).map(|(_, tx)| tx.coinbase_profit)
+    }
+}
+
+pub fn restore_landed_orders(
+    block_txs: Vec<ExecutedBlockTx>,
+    orders: Vec<SimplifiedOrder>,
+) -> HashMap<OrderId, LandedOrderData> {
+    let executed_block_data = ExecutedBlockData::new_from_txs(block_txs);
+
+    let mut result = HashMap::default();
+
+    let mut txs_to_orders: HashMap<B256, Vec<(OrderId, usize)>> = HashMap::default();
+
+    for order in orders {
+        match find_landed_order_data(&executed_block_data, &order) {
+            Ok(data) => {
+                for (tx, kickback) in data.landed_txs {
+                    txs_to_orders
+                        .entry(tx)
+                        .or_default()
+                        .push((order.id, kickback));
+                }
+            }
+            Err(e) => {
+                result.insert(
+                    order.id,
+                    LandedOrderData {
+                        order: order.id,
+                        total_coinbase_profit: I256::ZERO,
+                        unique_coinbase_profit: I256::ZERO,
+                        error: Some(e),
+                        overlapping_txs: Vec::new(),
+                    },
+                );
+            }
+        }
+    }
+
+    for (tx, orders) in txs_to_orders {
+        let profit = executed_block_data.tx_coinbase_profit(tx).unwrap();
+        for (order, kickback) in &orders {
+            let order = *order;
+            let entry = result.entry(order).or_insert(LandedOrderData {
+                order,
+                total_coinbase_profit: I256::ZERO,
+                unique_coinbase_profit: I256::ZERO,
+                error: None,
+                overlapping_txs: Vec::new(),
+            });
+            let profit = if *kickback == 0 {
+                profit
+            } else {
+                let profit: U256 = profit.try_into().unwrap_or_default();
+                let kickback = get_percent(profit, *kickback);
+                profit
+                    .checked_sub(kickback)
+                    .unwrap_or_default()
+                    .try_into()
+                    .unwrap_or_default()
+            };
+            entry.total_coinbase_profit += profit;
+            if orders.len() == 1 {
+                entry.unique_coinbase_profit += profit;
+            } else {
+                entry.overlapping_txs = orders
+                    .iter()
+                    .filter_map(|(o, _)| if *o != order { Some((*o, tx)) } else { None })
+                    .collect();
+            }
+        }
+    }
+
+    for landed_data in result.values_mut() {
+        landed_data.overlapping_txs.sort_by_key(|(d, _)| *d);
+    }
+
+    result
+}
+
+#[derive(Debug)]
+struct FoundChunkData {
+    txs: Vec<B256>,
+    last_tx_idx: usize,
+}
+
+fn find_order_chunk(
+    block_data: &ExecutedBlockData,
+    chunk: &OrderChunk,
+) -> Result<FoundChunkData, OrderIdentificationError> {
+    let mut txs = Vec::new();
+    let mut last_tx_idx = 0;
+
+    for (tx, revert) in &chunk.txs {
+        let (idx, tx_data) = if let Some((idx, tx_data)) = block_data.find_tx(*tx) {
+            (idx, tx_data)
+        } else {
+            // tx was not found in the block
+            if revert != &TxRevertBehavior::AllowedExcluded {
+                // tx not found
+                return Err(OrderIdentificationError::TxNotFound(*tx));
+            } else {
+                continue;
+            }
+        };
+
+        if !tx_data.success && !revert.can_revert() {
+            return Err(OrderIdentificationError::TxReverted(*tx));
+        }
+        if idx < last_tx_idx {
+            return Err(OrderIdentificationError::TxIsIncorrectPosition);
+        }
+        last_tx_idx = idx;
+        txs.push(*tx);
+    }
+
+    Ok(FoundChunkData { txs, last_tx_idx })
+}
+
+#[derive(Debug)]
+struct FoundOrderData {
+    /// (tx_hash, kickback_percent)
+    landed_txs: Vec<(B256, usize)>,
+}
+
+fn find_landed_order_data(
+    block_data: &ExecutedBlockData,
+    order: &SimplifiedOrder,
+) -> Result<FoundOrderData, OrderIdentificationError> {
+    let mut landed_txs = Vec::new();
+
+    let mut idx_past_last_chunk = 0;
+    for chunk in &order.chunks {
+        match find_order_chunk(block_data, chunk) {
+            Ok(data) => {
+                // we found the chunk
+                if data.last_tx_idx < idx_past_last_chunk {
+                    // chunks are messed up, order not found
+                    return Err(OrderIdentificationError::TxIsIncorrectPosition);
+                }
+                landed_txs.extend(data.txs.into_iter().map(|tx| (tx, chunk.kickback_percent)));
+                idx_past_last_chunk = data.last_tx_idx + 1;
+            }
+            Err(e) => {
+                if chunk.optional {
+                    continue;
+                }
+                return Err(e);
+            }
+        }
+    }
+
+    if landed_txs.is_empty() {
+        return Err(OrderIdentificationError::NoOrderTxs);
+    }
+
+    Ok(FoundOrderData { landed_txs })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::{Bundle, MempoolTx, Refund, ShareBundle, ShareBundleTx};
+    use crate::utils::test_utils::*;
+
+    fn assert_result(
+        executed_txs: Vec<ExecutedBlockTx>,
+        orders: Vec<SimplifiedOrder>,
+        expected: Vec<LandedOrderData>,
+    ) {
+        let got = restore_landed_orders(executed_txs, orders);
+        assert_eq!(expected.len(), got.len());
+        for expected_result in expected {
+            let got_result = got
+                .get(&expected_result.order)
+                .unwrap_or_else(|| panic!("Order not found: {:?}", expected_result));
+            assert_eq!(expected_result, *got_result);
+        }
+    }
+
+    #[test]
+    fn test_simple_block_identification() {
+        let executed_block = vec![
+            // random mempool tx
+            ExecutedBlockTx::new(hash(1), i256(11), true),
+            // bundle 1 with 1 tx
+            ExecutedBlockTx::new(hash(2), i256(12), true),
+            // bundle 2 with 2/3 landed txs
+            ExecutedBlockTx::new(hash(3), i256(13), false), // tx can revert
+            ExecutedBlockTx::new(hash(33), i256(14), true),
+            // random mempool tx
+            ExecutedBlockTx::new(hash(4), i256(14), true),
+            // bundle with simple kickback
+            ExecutedBlockTx::new(hash(5), i256(15), true),
+            ExecutedBlockTx::new(hash(6), i256(16), true), // backrun 1
+            ExecutedBlockTx::new(hash(7), i256(-14), true), // kickback payout
+            // last tx in the block
+            ExecutedBlockTx::new(hash(8), i256(-20), true),
+        ];
+
+        let orders = vec![
+            // bundle 1 with 1 tx
+            SimplifiedOrder::new(
+                order_id(0xb1),
+                vec![OrderChunk::new(
+                    vec![(hash(2), TxRevertBehavior::NotAllowed)],
+                    false,
+                    0,
+                )],
+            ),
+            // bundle 2 with 2/3 landed txs
+            SimplifiedOrder::new(
+                order_id(0xb2),
+                vec![OrderChunk::new(
+                    vec![
+                        (hash(3), TxRevertBehavior::AllowedIncluded),
+                        (hash(33), TxRevertBehavior::NotAllowed),
+                        (hash(333), TxRevertBehavior::AllowedExcluded), // this tx never landed
+                    ],
+                    false,
+                    0,
+                )],
+            ),
+            // bundle with simple kickback
+            SimplifiedOrder::new(
+                order_id(0xb3),
+                vec![
+                    OrderChunk::new(vec![(hash(5), TxRevertBehavior::AllowedIncluded)], false, 0),
+                    OrderChunk::new(vec![(hash(6), TxRevertBehavior::NotAllowed)], false, 90),
+                ],
+            ),
+        ];
+
+        let results = vec![
+            // bundle 1 with 1 tx
+            LandedOrderData::new(order_id(0xb1), i256(12), i256(12), None, vec![]),
+            // bundle 2 with 2/3 landed txs
+            LandedOrderData::new(order_id(0xb2), i256(13 + 14), i256(13 + 14), None, vec![]),
+            // bundle with simple kickback
+            LandedOrderData::new(order_id(0xb3), i256(15 + 2), i256(15 + 2), None, vec![]),
+        ];
+        assert_result(executed_block, orders, results);
+    }
+
+    #[test]
+    fn test_merged_sandwich_identification() {
+        // although this version of builder does not do that, this is possible
+        // in this hypothetical scenario we have two sandwiches like
+        // bundle_1: tx1_1, tx_mempool, tx1_2
+        // bundle_2: tx2_1, tx_mempool, tx2_2
+        // included txs: tx1_1, tx2_1, tx_mempool, tx1_2, tx2_2
+        let executed_block = vec![
+            ExecutedBlockTx::new(hash(0x11), i256(0x11), true),
+            ExecutedBlockTx::new(hash(0x21), i256(0x21), true),
+            ExecutedBlockTx::new(hash(0xaa), i256(0xaa), true),
+            ExecutedBlockTx::new(hash(0x12), i256(0x12), true),
+            ExecutedBlockTx::new(hash(0x22), i256(0x22), true),
+        ];
+
+        let orders = vec![
+            SimplifiedOrder::new(
+                order_id(0xb1),
+                vec![OrderChunk::new(
+                    vec![
+                        (hash(0x11), TxRevertBehavior::NotAllowed),
+                        (hash(0xaa), TxRevertBehavior::NotAllowed),
+                        (hash(0x12), TxRevertBehavior::NotAllowed),
+                    ],
+                    false,
+                    0,
+                )],
+            ),
+            SimplifiedOrder::new(
+                order_id(0xb2),
+                vec![OrderChunk::new(
+                    vec![
+                        (hash(0x21), TxRevertBehavior::NotAllowed),
+                        (hash(0xaa), TxRevertBehavior::NotAllowed),
+                        (hash(0x22), TxRevertBehavior::NotAllowed),
+                    ],
+                    false,
+                    0,
+                )],
+            ),
+        ];
+
+        let results = vec![
+            LandedOrderData::new(
+                order_id(0xb1),
+                i256(0x11 + 0xaa + 0x12),
+                i256(0x11 + 0x12),
+                None,
+                vec![(order_id(0xb2), hash(0xaa))],
+            ),
+            LandedOrderData::new(
+                order_id(0xb2),
+                i256(0x21 + 0xaa + 0x22),
+                i256(0x21 + 0x22),
+                None,
+                vec![(order_id(0xb1), hash(0xaa))],
+            ),
+        ];
+        assert_result(executed_block, orders, results);
+    }
+
+    #[test]
+    fn test_merged_backruns_identification() {
+        // bundle_1: tx0
+        // bundle_2: tx0, tx2 (backrun = 90)
+        // bundle_3: tx0, tx3 (backrun = 80)
+        // included txs: tx0, tx3, tx2
+        let executed_block = vec![
+            ExecutedBlockTx::new(hash(0x00), i256(12), true),
+            ExecutedBlockTx::new(hash(0x03), i256(2000), true),
+            ExecutedBlockTx::new(hash(0x02), i256(1000), true),
+        ];
+
+        let orders = vec![
+            SimplifiedOrder::new(
+                order_id(0xb1),
+                vec![OrderChunk::new(
+                    vec![(hash(0x00), TxRevertBehavior::NotAllowed)],
+                    false,
+                    0,
+                )],
+            ),
+            SimplifiedOrder::new(
+                order_id(0xb2),
+                vec![
+                    OrderChunk::new(vec![(hash(0x00), TxRevertBehavior::NotAllowed)], false, 0),
+                    OrderChunk::new(vec![(hash(0x02), TxRevertBehavior::NotAllowed)], false, 90),
+                ],
+            ),
+            SimplifiedOrder::new(
+                order_id(0xb3),
+                vec![
+                    OrderChunk::new(
+                        vec![(hash(0x00), TxRevertBehavior::AllowedExcluded)],
+                        true,
+                        0,
+                    ), // this is how we merge backruns now
+                    OrderChunk::new(vec![(hash(0x03), TxRevertBehavior::NotAllowed)], false, 80),
+                ],
+            ),
+        ];
+
+        let results = vec![
+            LandedOrderData::new(
+                order_id(0xb1),
+                i256(12),
+                i256(0),
+                None,
+                vec![(order_id(0xb2), hash(0x00)), (order_id(0xb3), hash(0x00))],
+            ),
+            LandedOrderData::new(
+                order_id(0xb2),
+                i256(12 + 100),
+                i256(100),
+                None,
+                vec![(order_id(0xb1), hash(0x00)), (order_id(0xb3), hash(0x00))],
+            ),
+            LandedOrderData::new(
+                order_id(0xb3),
+                i256(12 + 400),
+                i256(400),
+                None,
+                vec![(order_id(0xb1), hash(0x00)), (order_id(0xb2), hash(0x00))],
+            ),
+        ];
+        assert_result(executed_block, orders, results);
+    }
+
+    #[test]
+    fn test_bundle_identification_errors() {
+        let executed_block = vec![
+            ExecutedBlockTx::new(hash(0x01), i256(11), false),
+            ExecutedBlockTx::new(hash(0x02), i256(12), true),
+            ExecutedBlockTx::new(hash(0x03), i256(12), true),
+        ];
+
+        let orders = vec![
+            SimplifiedOrder::new(
+                order_id(0xb1),
+                vec![OrderChunk::new(
+                    vec![(hash(0x01), TxRevertBehavior::NotAllowed)],
+                    false,
+                    0,
+                )],
+            ),
+            SimplifiedOrder::new(
+                order_id(0xb2),
+                vec![
+                    OrderChunk::new(vec![(hash(0x02), TxRevertBehavior::NotAllowed)], false, 0),
+                    OrderChunk::new(vec![(hash(0xAA), TxRevertBehavior::NotAllowed)], false, 90),
+                ],
+            ),
+            SimplifiedOrder::new(
+                order_id(0xb3),
+                vec![OrderChunk::new(
+                    vec![
+                        (hash(0x03), TxRevertBehavior::NotAllowed),
+                        (hash(0x02), TxRevertBehavior::NotAllowed),
+                    ],
+                    false,
+                    0,
+                )],
+            ),
+            SimplifiedOrder::new(
+                order_id(0xb4),
+                vec![
+                    OrderChunk::new(vec![(hash(0x03), TxRevertBehavior::NotAllowed)], true, 0), // this is how we merge backruns now
+                    OrderChunk::new(vec![(hash(0x02), TxRevertBehavior::NotAllowed)], false, 80),
+                ],
+            ),
+            SimplifiedOrder::new(
+                order_id(0xb5),
+                vec![OrderChunk::new(
+                    vec![(hash(0x01), TxRevertBehavior::NotAllowed)],
+                    true,
+                    0,
+                )],
+            ),
+        ];
+
+        let results = vec![
+            LandedOrderData::new(
+                order_id(0xb1),
+                i256(0),
+                i256(0),
+                Some(OrderIdentificationError::TxReverted(hash(0x01))),
+                vec![],
+            ),
+            LandedOrderData::new(
+                order_id(0xb2),
+                i256(0),
+                i256(0),
+                Some(OrderIdentificationError::TxNotFound(hash(0xAA))),
+                vec![],
+            ),
+            LandedOrderData::new(
+                order_id(0xb3),
+                i256(0),
+                i256(0),
+                Some(OrderIdentificationError::TxIsIncorrectPosition),
+                vec![],
+            ),
+            LandedOrderData::new(
+                order_id(0xb4),
+                i256(0),
+                i256(0),
+                Some(OrderIdentificationError::TxIsIncorrectPosition),
+                vec![],
+            ),
+            LandedOrderData::new(
+                order_id(0xb5),
+                i256(0),
+                i256(0),
+                Some(OrderIdentificationError::NoOrderTxs),
+                vec![],
+            ),
+        ];
+        assert_result(executed_block, orders, results);
+    }
+
+    #[test]
+    fn test_simplified_order_conversion_mempool_tx() {
+        let order = Order::Tx(MempoolTx {
+            tx_with_blobs: tx(0x01),
+        });
+        let expected = SimplifiedOrder::new(
+            OrderId::Tx(hash(0x01)),
+            vec![OrderChunk::new(
+                vec![(hash(0x01), TxRevertBehavior::AllowedIncluded)],
+                false,
+                0,
+            )],
+        );
+
+        let got = SimplifiedOrder::new_from_order(&order);
+        assert_eq!(expected, got);
+    }
+
+    #[test]
+    fn test_simplified_order_conversion_bundle() {
+        let bundle = Order::Bundle(Bundle {
+            block: 0,
+            min_timestamp: None,
+            max_timestamp: None,
+            txs: vec![tx(0x01), tx(0x02)],
+            reverting_tx_hashes: vec![hash(0x02)],
+            hash: Default::default(),
+            uuid: uuid::uuid!("00000000-0000-0000-0000-ffff00000002"),
+            replacement_data: None,
+            signer: None,
+            metadata: Default::default(),
+        });
+        let expected = SimplifiedOrder::new(
+            OrderId::Bundle(uuid::uuid!("00000000-0000-0000-0000-ffff00000002")),
+            vec![OrderChunk::new(
+                vec![
+                    (hash(0x01), TxRevertBehavior::NotAllowed),
+                    (hash(0x02), TxRevertBehavior::AllowedExcluded),
+                ],
+                false,
+                0,
+            )],
+        );
+
+        let got = SimplifiedOrder::new_from_order(&bundle);
+        assert_eq!(expected, got);
+    }
+
+    #[test]
+    fn test_simplified_order_conversion_share_bundle() {
+        let bundle = Order::ShareBundle(ShareBundle {
+            hash: hash(0xb1),
+            block: 0,
+            max_block: 0,
+            inner_bundle: ShareBundleInner {
+                body: vec![
+                    ShareBundleBody::Tx(ShareBundleTx {
+                        tx: tx(0x01),
+                        revert_behavior: TxRevertBehavior::NotAllowed,
+                    }),
+                    ShareBundleBody::Tx(ShareBundleTx {
+                        tx: tx(0x02),
+                        revert_behavior: TxRevertBehavior::AllowedExcluded,
+                    }),
+                    ShareBundleBody::Tx(ShareBundleTx {
+                        tx: tx(0x03),
+                        revert_behavior: TxRevertBehavior::AllowedIncluded,
+                    }),
+                    ShareBundleBody::Bundle(ShareBundleInner {
+                        body: vec![
+                            ShareBundleBody::Bundle(ShareBundleInner {
+                                body: vec![ShareBundleBody::Tx(ShareBundleTx {
+                                    tx: tx(0x11),
+                                    revert_behavior: TxRevertBehavior::NotAllowed,
+                                })],
+                                refund: vec![],
+                                refund_config: vec![],
+                                can_skip: false,
+                                original_order_id: None,
+                            }),
+                            ShareBundleBody::Tx(ShareBundleTx {
+                                tx: tx(0x12),
+                                revert_behavior: TxRevertBehavior::NotAllowed,
+                            }),
+                        ],
+                        refund: vec![Refund {
+                            body_idx: 0,
+                            percent: 20,
+                        }],
+                        refund_config: vec![],
+                        can_skip: true,
+                        original_order_id: None,
+                    }),
+                    ShareBundleBody::Tx(ShareBundleTx {
+                        tx: tx(0x04),
+                        revert_behavior: TxRevertBehavior::AllowedIncluded,
+                    }),
+                ],
+                refund: vec![
+                    Refund {
+                        body_idx: 0,
+                        percent: 10,
+                    },
+                    Refund {
+                        body_idx: 1,
+                        percent: 20,
+                    },
+                    Refund {
+                        body_idx: 4,
+                        percent: 30,
+                    },
+                ],
+                refund_config: vec![],
+                can_skip: false,
+                original_order_id: None,
+            },
+            signer: None,
+            replacement_data: None,
+            original_orders: vec![],
+            metadata: Default::default(),
+        });
+        let expected = SimplifiedOrder::new(
+            OrderId::ShareBundle(hash(0xb1)),
+            vec![
+                OrderChunk::new(
+                    vec![
+                        (hash(0x01), TxRevertBehavior::NotAllowed),
+                        (hash(0x02), TxRevertBehavior::AllowedExcluded),
+                    ],
+                    false,
+                    0,
+                ),
+                OrderChunk::new(
+                    vec![(hash(0x03), TxRevertBehavior::AllowedIncluded)],
+                    false,
+                    60,
+                ),
+                OrderChunk::new(vec![(hash(0x11), TxRevertBehavior::NotAllowed)], true, 60),
+                OrderChunk::new(vec![(hash(0x12), TxRevertBehavior::NotAllowed)], true, 68),
+                OrderChunk::new(
+                    vec![(hash(0x04), TxRevertBehavior::AllowedIncluded)],
+                    false,
+                    0,
+                ),
+            ],
+        );
+
+        let got = SimplifiedOrder::new_from_order(&bundle);
+        assert_eq!(got, expected);
+    }
+}

--- a/crates/rbuilder/src/backtest/restore_landed_orders/mod.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/mod.rs
@@ -1,0 +1,8 @@
+mod find_landed_orders;
+mod resim_landed_block;
+
+pub use resim_landed_block::{sim_historical_block, ExecutedTxs};
+
+pub use find_landed_orders::{
+    restore_landed_orders, ExecutedBlockTx, LandedOrderData, SimplifiedOrder,
+};

--- a/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
@@ -1,0 +1,110 @@
+use crate::building::{BlockBuildingContext, BlockState, PartialBlock, PartialBlockFork};
+use crate::primitives::serialize::{RawTx, TxEncoding};
+use crate::primitives::TransactionSignedEcRecoveredWithBlobs;
+use crate::utils::signed_uint_delta;
+use ahash::HashSet;
+use alloy_consensus::TxEnvelope;
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{Address, I256};
+use eyre::Context;
+use reth_chainspec::ChainSpec;
+use reth_db::DatabaseEnv;
+use reth_primitives::{Receipt, TransactionSignedEcRecovered};
+use reth_provider::ProviderFactory;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct ExecutedTxs {
+    pub tx: TransactionSignedEcRecovered,
+    pub receipt: Receipt,
+    pub coinbase_profit: I256,
+}
+
+pub fn sim_historical_block(
+    provider_factory: ProviderFactory<Arc<DatabaseEnv>>,
+    chain_spec: Arc<ChainSpec>,
+    onchain_block: alloy_rpc_types::Block,
+) -> eyre::Result<Vec<ExecutedTxs>> {
+    let mut results = Vec::new();
+
+    let txs = extract_onchain_block_txs(&onchain_block)?;
+
+    let suggested_fee_recipient = find_suggested_fee_recipient(&onchain_block, &txs);
+    let coinbase = onchain_block.header.miner;
+
+    let ctx = BlockBuildingContext::from_onchain_block(
+        onchain_block,
+        chain_spec,
+        None,
+        HashSet::default(),
+        coinbase,
+        suggested_fee_recipient,
+        None,
+    );
+
+    let state_provider = provider_factory.history_by_block_hash(ctx.attributes.parent)?;
+    let mut partial_block = PartialBlock::new(true, None);
+    let mut state = BlockState::new(&state_provider);
+
+    partial_block
+        .pre_block_call(&ctx, &mut state)
+        .with_context(|| "Failed to pre_block_call")?;
+
+    let mut cumulative_gas_used = 0;
+    let mut cumulative_blob_gas_used = 0;
+    for (idx, tx) in txs.into_iter().enumerate() {
+        let coinbase_balance_before = state.balance(coinbase)?;
+        let result = {
+            let mut fork = PartialBlockFork::new(&mut state);
+            fork.commit_tx(&tx, &ctx, cumulative_gas_used, 0, cumulative_blob_gas_used)?
+                .with_context(|| format!("Failed to commit tx: {} {:?}", idx, tx.hash()))?
+        };
+        let coinbase_balance_after = state.balance(coinbase)?;
+        let coinbase_profit = signed_uint_delta(coinbase_balance_after, coinbase_balance_before);
+
+        cumulative_gas_used += result.gas_used;
+        cumulative_blob_gas_used += result.blob_gas_used;
+
+        results.push(ExecutedTxs {
+            tx: tx.tx,
+            receipt: result.receipt,
+            coinbase_profit,
+        })
+    }
+
+    Ok(results)
+}
+
+fn find_suggested_fee_recipient(
+    block: &alloy_rpc_types::Block,
+    txs: &[TransactionSignedEcRecoveredWithBlobs],
+) -> Address {
+    let coinbase = block.header.miner;
+    let (last_tx_signer, last_tx_to) = if let Some((signer, to)) = txs
+        .last()
+        .map(|tx| (tx.tx.signer(), tx.tx.to().unwrap_or_default()))
+    {
+        (signer, to)
+    } else {
+        return coinbase;
+    };
+
+    if last_tx_signer == coinbase {
+        last_tx_to
+    } else {
+        coinbase
+    }
+}
+
+fn extract_onchain_block_txs(
+    onchain_block: &alloy_rpc_types::Block,
+) -> eyre::Result<Vec<TransactionSignedEcRecoveredWithBlobs>> {
+    let mut result = Vec::new();
+    for tx in onchain_block.transactions.clone().into_transactions() {
+        let tx_envelope: TxEnvelope = tx.try_into()?;
+        let encoded = tx_envelope.encoded_2718();
+        let tx = RawTx { tx: encoded.into() }.decode(TxEncoding::NoBlobData)?;
+        result.push(tx.tx_with_blobs);
+    }
+    Ok(result)
+}

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -179,7 +179,7 @@ impl Bundle {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TxRevertBehavior {
     /// Tx in a bundle can't revert.
     NotAllowed,

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -793,6 +793,14 @@ impl OrderId {
             }
         }
     }
+
+    /// Returns tx hash if the order is mempool tx
+    pub fn tx_hash(&self) -> Option<B256> {
+        match self {
+            Self::Tx(hash) => Some(*hash),
+            _ => None,
+        }
+    }
 }
 
 impl FromStr for OrderId {

--- a/crates/rbuilder/src/utils/mod.rs
+++ b/crates/rbuilder/src/utils/mod.rs
@@ -9,8 +9,11 @@ pub mod reconnect;
 mod test_data_generator;
 mod tx_signer;
 
+#[cfg(test)]
+pub mod test_utils;
+
 use alloy_network::Ethereum;
-use alloy_primitives::U256;
+use alloy_primitives::{Sign, I256, U256};
 use alloy_provider::RootProvider;
 use alloy_transport::BoxTransport;
 
@@ -71,8 +74,8 @@ pub fn set_test_debug_tracing_subscriber() {
         .unwrap_or_default();
 }
 
-pub fn get_percent(value: U256, pecent: usize) -> U256 {
-    (value * U256::from(pecent)) / U256::from(100)
+pub fn get_percent(value: U256, percent: usize) -> U256 {
+    (value * U256::from(percent)) / U256::from(100)
 }
 
 pub fn a2r_withdrawal(w: alloy_rpc_types::Withdrawal) -> reth_primitives::Withdrawal {
@@ -187,6 +190,14 @@ pub fn offset_datetime_to_timestamp_ms(date: OffsetDateTime) -> u64 {
 pub fn timestamp_ms_to_offset_datetime(timestamp: u64) -> OffsetDateTime {
     OffsetDateTime::from_unix_timestamp_nanos((timestamp * 1_000_000) as i128)
         .expect("failed to convert timestamp")
+}
+
+/// returns signer result of a - b
+/// panics on overflows
+pub fn signed_uint_delta(a: U256, b: U256) -> I256 {
+    let a = I256::checked_from_sign_and_abs(Sign::Positive, a).expect("A is too big");
+    let b = I256::checked_from_sign_and_abs(Sign::Positive, b).expect("B is too big");
+    a.checked_sub(b).expect("Subtraction overflow")
 }
 
 #[cfg(test)]

--- a/crates/rbuilder/src/utils/test_utils.rs
+++ b/crates/rbuilder/src/utils/test_utils.rs
@@ -1,0 +1,39 @@
+use crate::primitives::{OrderId, TransactionSignedEcRecoveredWithBlobs};
+use alloy_primitives::{Address, B256, I256, U256};
+use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
+use std::sync::Arc;
+
+pub fn order_id(id: u64) -> OrderId {
+    OrderId::Tx(hash(id))
+}
+
+pub fn hash(id: u64) -> B256 {
+    B256::from(U256::from(id))
+}
+
+pub fn addr(id: u64) -> Address {
+    Address::from_slice(&u256(id).as_le_slice()[0..20])
+}
+
+pub fn u256(i: u64) -> U256 {
+    U256::from(i)
+}
+
+pub fn i256(i: i64) -> I256 {
+    I256::try_from(i).unwrap()
+}
+
+pub fn tx(tx_hash: u64) -> TransactionSignedEcRecoveredWithBlobs {
+    TransactionSignedEcRecoveredWithBlobs {
+        tx: TransactionSignedEcRecovered::from_signed_transaction(
+            TransactionSigned {
+                hash: hash(tx_hash),
+                signature: Default::default(),
+                transaction: Default::default(),
+            },
+            Address::default(),
+        ),
+        blobs_sidecar: Arc::new(Default::default()),
+        metadata: Default::default(),
+    }
+}


### PR DESCRIPTION
## 📝 Summary

* derive info about landed bundle from the onchain block
* use landed bundle info for capping redistributions
* move redistribution algorithm into separate file and add tests

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
