### PR TITLE
reference removed

### DIFF
--- a/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
@@ -44,7 +44,7 @@ pub fn sim_historical_block(
 
     let state_provider = provider_factory.history_by_block_hash(ctx.attributes.parent)?;
     let mut partial_block = PartialBlock::new(true, None);
-    let mut state = BlockState::new(&state_provider);
+    let mut state = BlockState::new(state_provider);
 
     partial_block
         .pre_block_call(&ctx, &mut state)

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -200,7 +200,7 @@ impl DummyBuildingAlgorithm {
     ) -> eyre::Result<Option<Block>> {
         let mut partial_block = PartialBlock::new(false, None);
         let state_provider = provider_factory.history_by_block_hash(ctx.attributes.parent)?;
-        let mut state = BlockState::new(&state_provider);
+        let mut state = BlockState::new(state_provider);
 
         partial_block.pre_block_call(ctx, &mut state)?;
         for order in orders {
@@ -221,7 +221,7 @@ impl DummyBuildingAlgorithm {
             return Ok(None);
         }
         let finalized_block = partial_block.finalize(
-            state,
+            &mut state,
             ctx,
             provider_factory.clone(),
             RootHashMode::CorrectRoot,

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -528,7 +528,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
     #[allow(clippy::too_many_arguments)]
     pub fn finalize<DB: reth_db::database::Database + Clone + 'static>(
         self,
-        mut state: BlockState,
+        state: &mut BlockState,
         ctx: &BlockBuildingContext,
         provider_factory: ProviderFactory<DB>,
         root_hash_mode: RootHashMode,
@@ -549,7 +549,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             (withdrawals_root, withdrawals)
         };
 
-        let (cached_reads, bundle) = state.clone().into_parts();
+        let (cached_reads, bundle) = state.clone_bundle_and_cache();
 
         let (requests, requests_root) = if ctx
             .chain_spec

--- a/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
@@ -207,7 +207,7 @@ impl TestSetup {
     }
     fn try_commit_order(&mut self) -> eyre::Result<Result<ExecutionResult, ExecutionError>> {
         let state_provider = self.test_chain.provider_factory().latest()?;
-        let mut block_state = BlockState::new(&state_provider)
+        let mut block_state = BlockState::new(state_provider)
             .with_bundle_state(self.bundle_state.take().unwrap_or_default())
             .with_cached_reads(self.cached_reads.take().unwrap_or_default());
 
@@ -224,7 +224,7 @@ impl TestSetup {
             &mut block_state,
         )?;
 
-        let (cached_reads, bundle_state) = block_state.into_parts();
+        let (cached_reads, bundle_state, _) = block_state.into_parts();
         self.cached_reads = Some(cached_reads);
         self.bundle_state = Some(bundle_state);
 
@@ -277,7 +277,7 @@ impl TestSetup {
 
     pub fn current_nonce(&self, named_addr: NamedAddr) -> eyre::Result<u64> {
         let state_provider = self.test_chain.provider_factory().latest()?;
-        let mut block_state = BlockState::new(&state_provider)
+        let mut block_state = BlockState::new(state_provider)
             .with_bundle_state(self.bundle_state.clone().unwrap_or_default())
             .with_cached_reads(self.cached_reads.clone().unwrap_or_default());
 

--- a/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
+++ b/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
@@ -73,7 +73,7 @@ pub fn run_sim_worker<DB: Database + Clone + Send + 'static>(
                 }
             };
             let start_time = Instant::now();
-            let mut block_state = BlockState::new(&state_provider).with_cached_reads(cached_reads);
+            let mut block_state = BlockState::new(state_provider).with_cached_reads(cached_reads);
             let sim_result = simulate_order(
                 task.parents.clone(),
                 task.order,
@@ -111,7 +111,7 @@ pub fn run_sim_worker<DB: Database + Clone + Send + 'static>(
                     break;
                 }
             }
-            (cached_reads, _) = block_state.into_parts();
+            (cached_reads, _, _) = block_state.into_parts();
 
             last_sim_finished = Instant::now();
             let sim_thread_work_time = sim_start.elapsed();


### PR DESCRIPTION
## 📝 Summary

BlockState used to contain a &'a StateProviderBox which would make really hard to propagate the BlockState (for a future PR).

## 💡 Motivation and Context

Avoid getting into self-referenced struct hell since I would have to propagate BlockState  + &StateProviderBox somehow.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
