### PR TITLE
fix: fetch cached_reads & bundlestate after withdrawl requests contra…

### DIFF
--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -559,8 +559,6 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             (withdrawals_root, withdrawals)
         };
 
-        let (cached_reads, bundle) = state.clone_bundle_and_cache();
-
         let (requests, requests_root) = if ctx
             .chain_spec
             .is_prague_active_at_timestamp(ctx.attributes.timestamp())
@@ -583,6 +581,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             (None, None)
         };
 
+        let (cached_reads, bundle) = state.clone_bundle_and_cache();
         let execution_outcome = ExecutionOutcome::new(
             bundle,
             Receipts::from(vec![self


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
This is a very small change where we fetch cached_reads & bundlestate after withdrawl requests contract call. 

cc: @ZanCorDX 

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->
Closes #123 
---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
