### PR TITLE
Stream unsealed blocks

### DIFF
--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -43,9 +43,8 @@ use reth_db::{database::Database, DatabaseEnv};
 use tokio::{signal::ctrl_c, sync::broadcast};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, level_filters::LevelFilter};
-use url::Url;
 
-const RETH_DB_PATH: &str = "/mnt/md0/rethdata";
+const RETH_DB_PATH: &str = DEFAULT_RETH_DB_PATH;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -65,7 +64,7 @@ async fn main() -> eyre::Result<()> {
     let relay = MevBoostRelay::from_config(&relay_config)?;
 
     let payload_event = MevBoostSlotDataGenerator::new(
-        vec![Client::new(Url::parse("http://localhost:3500").unwrap())],
+        vec![Client::default()],
         vec![relay],
         Default::default(),
         cancel.clone(),

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -5,9 +5,10 @@ use reth::tasks::pool::BlockingTaskPool;
 use reth_db::database::Database;
 use reth_payload_builder::database::CachedReads;
 use reth_primitives::format_ether;
-use reth_provider::ProviderFactory;
+use reth_provider::{BlockNumReader, ProviderFactory};
 use time::OffsetDateTime;
-use tracing::trace;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, trace};
 
 use crate::{
     building::{
@@ -16,25 +17,65 @@ use crate::{
         EstimatePayoutGasErr, ExecutionError, ExecutionResult, FinalizeResult, PartialBlock,
         Sorting,
     },
-    live_builder::bidding::SlotBidder,
     primitives::SimulatedOrder,
     roothash::RootHashMode,
     telemetry,
 };
 
-use super::{finalize_block_execution, Block};
+use super::Block;
 
-/// Struct to help building blocks. It still needs to be finished by setting the payout tx and computing some extra stuff (eg: root hash).
-/// Txs can still be added before finishing it.
+/// Trait to help building blocks. It still needs to be finished (finalize_block) to set the payout tx and computing some extra stuff (eg: root hash).
+/// Txs can be added before finishing it.
 /// Typical usage:
-/// 1 - BlockBuildingHelper::new
-/// 2 - Call lots of commit_order
-/// 3 - Call set_trace_fill_time when you are done calling commit_order (we still have to review this step)
+/// 1 - Create it some how.
+/// 2 - Call lots of commit_order.
+/// 3 - Call set_trace_fill_time when you are done calling commit_order (we still have to review this step).
 /// 4 - Call finalize_block.
-pub struct BlockBuildingHelper<DB> {
+pub trait BlockBuildingHelper {
+    /// Tries to add an order to the end of the block.
+    /// Block state changes only on Ok(Ok)
+    fn commit_order(
+        &mut self,
+        order: &SimulatedOrder,
+    ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError>;
+
+    /// Call set the trace fill_time (we still have to review this)
+    fn set_trace_fill_time(&mut self, time: Duration);
+    /// If not set the trace will default to creation time.
+    fn set_trace_orders_closed_at(&mut self, orders_closed_at: OffsetDateTime);
+
+    /// Only if can_add_payout_tx you can pass Some(payout_tx_value) to finalize_block (a little ugly could be improved...)
+    fn can_add_payout_tx(&self) -> bool;
+
+    /// Accumulated coinbase delta - gas cost of final payout tx (if can_add_payout_tx).
+    /// This is the maximum profit that can reach the final fee recipient (max bid!).
+    /// Maximum payout_tx_value value to pass to finalize_block.
+    /// The main reason to get an error is if profit is so low that we can't pay the payout tx (that would mean negative block value!).
+    fn true_block_value(&self) -> Result<U256, BlockBuildingHelperError>;
+
+    /// Eats the BlockBuildingHelper since once it's finished you should not use it anymore.
+    /// payout_tx_value: If Some, added at the end of the block from coinbase to the final fee recipient.
+    ///     This only works if can_add_payout_tx.
+    fn finalize_block(
+        self: Box<Self>,
+        payout_tx_value: Option<U256>,
+    ) -> Result<FinalizeBlockResult, BlockBuildingHelperError>;
+
+    /// Useful if we want to give away this object but keep on building some other way.
+    fn clone_cached_reads(&self) -> CachedReads;
+
+    /// BuiltBlockTrace for current state.
+    fn built_block_trace(&self) -> &BuiltBlockTrace;
+
+    /// BlockBuildingContext used for building.
+    fn building_context(&self) -> &BlockBuildingContext;
+}
+
+/// Implementation of BlockBuildingHelper based on a ProviderFactory<DB>
+#[derive(Clone)]
+pub struct BlockBuildingHelperFromDB<DB> {
     /// Balance of fee recipient before we stared building.
-    /// Used to compute
-    fee_recipient_balance_start: U256,
+    _fee_recipient_balance_start: U256,
     /// Accumulated changes for the block (due to commit_order calls).
     block_state: BlockState,
     partial_block: PartialBlock<GasUsedSimulationTracer>,
@@ -48,6 +89,10 @@ pub struct BlockBuildingHelper<DB> {
     built_block_trace: BuiltBlockTrace,
     /// Needed to get the initial state and the final root hash calculation.
     provider_factory: ProviderFactory<DB>,
+    root_hash_task_pool: BlockingTaskPool,
+    root_hash_mode: RootHashMode,
+    /// Token to cancel in case of fatal error (if we believe that it's impossible to build for this block).
+    cancel_on_fatal_error: CancellationToken,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -64,16 +109,17 @@ pub enum BlockBuildingHelperError {
     BundleConsistencyCheckFailed(#[from] BuiltBlockTraceError),
     #[error("Error finalizing block (eg:root hash): {0}")]
     FinalizeError(#[from] eyre::Report),
+    #[error("Payout tx not allowed for block")]
+    PayoutTxNotAllowed,
 }
 
 pub struct FinalizeBlockResult {
-    /// None means the slot bidder told us to skip (probably this will soon change).
-    pub block: Option<Block>,
+    pub block: Block,
     /// Since finalize_block eats the object we need the cached_reads in case we create a new
     pub cached_reads: CachedReads,
 }
 
-impl<DB: Database + Clone + 'static> BlockBuildingHelper<DB> {
+impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
     /// allow_tx_skip: see [`PartialBlockFork`]
     /// Performs initialization:
     /// - Query fee_recipient_balance_start.
@@ -81,11 +127,14 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper<DB> {
     /// - Estimate payout tx cost.
     pub fn new(
         provider_factory: ProviderFactory<DB>,
+        root_hash_task_pool: BlockingTaskPool,
+        root_hash_mode: RootHashMode,
         building_ctx: BlockBuildingContext,
         cached_reads: Option<CachedReads>,
         builder_name: String,
         discard_txs: bool,
         enforce_sorting: Option<Sorting>,
+        cancel_on_fatal_error: CancellationToken,
     ) -> Result<Self, BlockBuildingHelperError> {
         // @Maybe an issue - we have 2 db txs here (one for hash and one for finalize)
         let state_provider =
@@ -113,7 +162,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper<DB> {
             Some(payout_tx_gas)
         };
         Ok(Self {
-            fee_recipient_balance_start,
+            _fee_recipient_balance_start: fee_recipient_balance_start,
             block_state,
             partial_block,
             payout_tx_gas,
@@ -121,115 +170,9 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper<DB> {
             building_ctx,
             built_block_trace: BuiltBlockTrace::new(),
             provider_factory,
-        })
-    }
-
-    /// Forwards to partial_block and updates trace.
-    pub fn commit_order(
-        &mut self,
-        order: &SimulatedOrder,
-    ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
-        let result =
-            self.partial_block
-                .commit_order(order, &self.building_ctx, &mut self.block_state);
-        match result {
-            Ok(ok_result) => match ok_result {
-                Ok(res) => {
-                    self.built_block_trace.add_included_order(res);
-                    Ok(Ok(self.built_block_trace.included_orders.last().unwrap()))
-                }
-                Err(err) => {
-                    self.built_block_trace
-                        .modify_payment_when_no_signer_error(&err);
-                    Ok(Err(err))
-                }
-            },
-            Err(e) => Err(e),
-        }
-    }
-
-    pub fn set_trace_fill_time(&mut self, time: Duration) {
-        self.built_block_trace.fill_time = time;
-    }
-
-    /// Eats the object. At some point we might make a version that doesn't so we can call finalize_block several times.
-    pub fn finalize_block(
-        mut self,
-        bidder: &dyn SlotBidder,
-        orders_closed_at: OffsetDateTime,
-        root_hash_task_pool: BlockingTaskPool,
-        root_hash_mode: RootHashMode,
-    ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
-        let start_time = Instant::now();
-        let fee_recipient_balance_after = self
-            .block_state
-            .state_provider()
-            .account_balance(self.building_ctx.attributes.suggested_fee_recipient)?
-            .unwrap_or_default();
-
-        let fee_recipient_balance_diff = fee_recipient_balance_after
-            .checked_sub(self.fee_recipient_balance_start)
-            .unwrap_or_default();
-
-        let should_finalize = finalize_block_execution(
-            &self.building_ctx,
-            &mut self.partial_block,
-            &mut self.block_state,
-            &mut self.built_block_trace,
-            self.payout_tx_gas,
-            bidder,
-            fee_recipient_balance_diff,
-        )?;
-
-        if !should_finalize {
-            trace!(
-                block = self.building_ctx.block_env.number.to::<u64>(),
-                builder_name = self.builder_name,
-                use_suggested_fee_recipient_as_coinbase =
-                    self.building_ctx.coinbase_is_suggested_fee_recipient(),
-                "Skipped block finalization",
-            );
-            let (cached_reads, _, _) = self.block_state.into_parts();
-            return Ok(FinalizeBlockResult {
-                block: None,
-                cached_reads,
-            });
-        }
-
-        // This could be moved outside of this func since I don´t think the payout tx can change much.
-        self.built_block_trace
-            .verify_bundle_consistency(&self.building_ctx.blocklist)?;
-
-        let sim_gas_used = self.partial_block.tracer.used_gas;
-        let finalized_block = self.partial_block.finalize(
-            &mut self.block_state,
-            &self.building_ctx,
-            self.provider_factory.clone(),
-            root_hash_mode,
             root_hash_task_pool,
-        )?;
-        self.built_block_trace
-            .update_orders_timestamps_after_block_sealed(orders_closed_at);
-
-        self.built_block_trace.finalize_time = start_time.elapsed();
-
-        Self::trace_finalized_block(
-            &finalized_block,
-            &self.builder_name,
-            &self.building_ctx,
-            &self.built_block_trace,
-            sim_gas_used,
-        );
-
-        let block = Block {
-            trace: self.built_block_trace,
-            sealed_block: finalized_block.sealed_block,
-            txs_blobs_sidecars: finalized_block.txs_blob_sidecars,
-            builder_name: self.builder_name.clone(),
-        };
-        Ok(FinalizeBlockResult {
-            block: Some(block),
-            cached_reads: finalized_block.cached_reads,
+            root_hash_mode,
+            cancel_on_fatal_error,
         })
     }
 
@@ -270,5 +213,172 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper<DB> {
                 building_ctx.coinbase_is_suggested_fee_recipient(),
             "Built block",
         );
+    }
+
+    /// Delta from self creation.
+    fn _fee_recipient_balance_diff(&self) -> Result<U256, BlockBuildingHelperError> {
+        let fee_recipient_balance_after = self
+            .block_state
+            .state_provider()
+            .account_balance(self.building_ctx.attributes.suggested_fee_recipient)?
+            .unwrap_or_default();
+
+        Ok(fee_recipient_balance_after
+            .checked_sub(self._fee_recipient_balance_start)
+            .unwrap_or_default())
+    }
+
+    /// Inserts payout tx if necessary and updates built_block_trace.
+    fn finalize_block_execution(
+        &mut self,
+        payout_tx_value: Option<U256>,
+    ) -> Result<(), BlockBuildingHelperError> {
+        let (bid_value, true_value) = if let (Some(payout_tx_gas), Some(payout_tx_value)) =
+            (self.payout_tx_gas, payout_tx_value)
+        {
+            match self.partial_block.insert_proposer_payout_tx(
+                payout_tx_gas,
+                payout_tx_value,
+                &self.building_ctx,
+                &mut self.block_state,
+            ) {
+                Ok(()) => (payout_tx_value, self.true_block_value()?),
+                Err(err) => return Err(err.into()),
+            }
+        } else {
+            (
+                self.partial_block.coinbase_profit,
+                self.partial_block.coinbase_profit,
+            )
+        };
+        self.built_block_trace.bid_value = bid_value;
+        self.built_block_trace.true_bid_value = true_value;
+        Ok(())
+    }
+}
+
+impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelperFromDB<DB> {
+    /// Forwards to partial_block and updates trace.
+    fn commit_order(
+        &mut self,
+        order: &SimulatedOrder,
+    ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
+        let result =
+            self.partial_block
+                .commit_order(order, &self.building_ctx, &mut self.block_state);
+        match result {
+            Ok(ok_result) => match ok_result {
+                Ok(res) => {
+                    self.built_block_trace.add_included_order(res);
+                    Ok(Ok(self.built_block_trace.included_orders.last().unwrap()))
+                }
+                Err(err) => {
+                    self.built_block_trace
+                        .modify_payment_when_no_signer_error(&err);
+                    Ok(Err(err))
+                }
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    fn set_trace_fill_time(&mut self, time: Duration) {
+        self.built_block_trace.fill_time = time;
+    }
+
+    fn set_trace_orders_closed_at(&mut self, orders_closed_at: OffsetDateTime) {
+        self.built_block_trace.orders_closed_at = orders_closed_at;
+    }
+
+    fn can_add_payout_tx(&self) -> bool {
+        !self.building_ctx.coinbase_is_suggested_fee_recipient()
+    }
+
+    fn true_block_value(&self) -> Result<U256, BlockBuildingHelperError> {
+        if let Some(payout_tx_gas) = self.payout_tx_gas {
+            return Ok(self
+                .partial_block
+                .get_proposer_payout_tx_value(payout_tx_gas, &self.building_ctx)?);
+        } else {
+            return Ok(self.partial_block.coinbase_profit);
+        }
+    }
+
+    fn finalize_block(
+        mut self: Box<Self>,
+        payout_tx_value: Option<U256>,
+    ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
+        if payout_tx_value.is_some() && self.building_ctx.coinbase_is_suggested_fee_recipient() {
+            return Err(BlockBuildingHelperError::PayoutTxNotAllowed);
+        }
+        let start_time = Instant::now();
+
+        self.finalize_block_execution(payout_tx_value)?;
+        // This could be moved outside of this func (pre finalize) since I don´t think the payout tx can change much.
+        self.built_block_trace
+            .verify_bundle_consistency(&self.building_ctx.blocklist)?;
+
+        let sim_gas_used = self.partial_block.tracer.used_gas;
+        let block_number = self.building_context().block();
+        let finalized_block = match self.partial_block.finalize(
+            &mut self.block_state,
+            &self.building_ctx,
+            self.provider_factory.clone(),
+            self.root_hash_mode,
+            self.root_hash_task_pool,
+        ) {
+            Ok(finalized_block) => finalized_block,
+            Err(err) => {
+                if err
+                    .to_string()
+                    .contains("failed to initialize consistent view")
+                {
+                    let last_block_number = self
+                        .provider_factory
+                        .last_block_number()
+                        .unwrap_or_default();
+                    debug!(
+                        block_number,
+                        last_block_number, "Can't build on this head, cancelling slot"
+                    );
+                    self.cancel_on_fatal_error.cancel();
+                }
+                return Err(BlockBuildingHelperError::FinalizeError(err));
+            }
+        };
+        self.built_block_trace.update_orders_sealed_at();
+
+        self.built_block_trace.finalize_time = start_time.elapsed();
+
+        Self::trace_finalized_block(
+            &finalized_block,
+            &self.builder_name,
+            &self.building_ctx,
+            &self.built_block_trace,
+            sim_gas_used,
+        );
+
+        let block = Block {
+            trace: self.built_block_trace,
+            sealed_block: finalized_block.sealed_block,
+            txs_blobs_sidecars: finalized_block.txs_blob_sidecars,
+            builder_name: self.builder_name.clone(),
+        };
+        Ok(FinalizeBlockResult {
+            block,
+            cached_reads: finalized_block.cached_reads,
+        })
+    }
+
+    fn clone_cached_reads(&self) -> CachedReads {
+        self.block_state.clone_cached_reads()
+    }
+
+    fn built_block_trace(&self) -> &BuiltBlockTrace {
+        &self.built_block_trace
+    }
+
+    fn building_context(&self) -> &BlockBuildingContext {
+        &self.building_ctx
     }
 }

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -125,6 +125,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
     /// - Query fee_recipient_balance_start.
     /// - pre_block_call.
     /// - Estimate payout tx cost.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         provider_factory: ProviderFactory<DB>,
         root_hash_task_pool: BlockingTaskPool,
@@ -296,11 +297,11 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelper
 
     fn true_block_value(&self) -> Result<U256, BlockBuildingHelperError> {
         if let Some(payout_tx_gas) = self.payout_tx_gas {
-            return Ok(self
+            Ok(self
                 .partial_block
-                .get_proposer_payout_tx_value(payout_tx_gas, &self.building_ctx)?);
+                .get_proposer_payout_tx_value(payout_tx_gas, &self.building_ctx)?)
         } else {
-            return Ok(self.partial_block.coinbase_profit);
+            Ok(self.partial_block.coinbase_profit)
         }
     }
 

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -3,20 +3,14 @@ pub mod block_building_helper;
 pub mod ordering_builder;
 
 use crate::{
-    building::{
-        tracers::SimulationTracer, BlockBuildingContext, BlockOrders, BlockState, BuiltBlockTrace,
-        InsertPayoutTxErr, PartialBlock, SimulatedOrderSink, Sorting,
-    },
-    live_builder::{
-        bidding::{SealInstruction, SlotBidder},
-        payload_events::MevBoostSlotData,
-        simulation::SimulatedOrderCommand,
-    },
+    building::{BlockBuildingContext, BlockOrders, BuiltBlockTrace, SimulatedOrderSink, Sorting},
+    live_builder::{payload_events::MevBoostSlotData, simulation::SimulatedOrderCommand},
     primitives::{AccountNonce, OrderId, SimulatedOrder},
-    utils::NonceCache,
+    utils::{is_provider_factory_health_error, NonceCache},
 };
 use ahash::HashSet;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256};
+use block_building_helper::BlockBuildingHelper;
 use reth::{
     primitives::{BlobTransactionSidecar, SealedBlock},
     providers::ProviderFactory,
@@ -24,13 +18,10 @@ use reth::{
 };
 use reth_db::database::Database;
 use reth_payload_builder::database::CachedReads;
-use std::{
-    cmp::max,
-    sync::{Arc, Mutex},
-};
+use std::sync::Arc;
 use tokio::sync::{broadcast, broadcast::error::TryRecvError};
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{error, warn};
 
 /// Block we built
 #[derive(Debug, Clone)]
@@ -42,53 +33,14 @@ pub struct Block {
     pub builder_name: String,
 }
 
-/// Contains the best block so far.
-/// Building updates via compare_and_update while relay submitter polls via take_best_block
-#[derive(Debug, Clone)]
-pub struct BestBlockCell {
-    val: Arc<Mutex<Option<Block>>>,
-}
-
-impl Default for BestBlockCell {
-    fn default() -> Self {
-        Self {
-            val: Arc::new(Mutex::new(None)),
-        }
-    }
-}
-
-impl BlockBuildingSink for BestBlockCell {
-    fn new_block(&self, block: Block) {
-        self.compare_and_update(block);
-    }
-}
-
-impl BestBlockCell {
-    pub fn compare_and_update(&self, block: Block) {
-        let mut best_block = self.val.lock().unwrap();
-        let old_value = best_block
-            .as_ref()
-            .map(|b| b.trace.bid_value)
-            .unwrap_or_default();
-        if block.trace.bid_value > old_value {
-            *best_block = Some(block);
-        }
-    }
-
-    pub fn take_best_block(&self) -> Option<Block> {
-        self.val.lock().unwrap().take()
-    }
-}
-
 #[derive(Debug)]
-pub struct LiveBuilderInput<DB: Database, SinkType: BlockBuildingSink> {
+pub struct LiveBuilderInput<DB: Database> {
     pub provider_factory: ProviderFactory<DB>,
     pub root_hash_task_pool: BlockingTaskPool,
     pub ctx: BlockBuildingContext,
     pub input: broadcast::Receiver<SimulatedOrderCommand>,
-    pub sink: SinkType,
+    pub sink: Arc<dyn UnfinishedBlockBuildingSink>,
     pub builder_name: String,
-    pub slot_bidder: Arc<dyn SlotBidder>,
     pub cancel: CancellationToken,
     pub sbundle_mergeabe_signers: Vec<Address>,
 }
@@ -230,73 +182,42 @@ impl<DB: Database + Clone> OrderIntakeConsumer<DB> {
     }
 }
 
-pub fn finalize_block_execution(
-    ctx: &BlockBuildingContext,
-    partial_block: &mut PartialBlock<impl SimulationTracer>,
-    state: &mut BlockState,
-    built_block_trace: &mut BuiltBlockTrace,
-    payout_tx_gas: Option<u64>,
-    bidder: &dyn SlotBidder,
-    fee_recipient_balance_diff: U256,
-) -> Result<bool, InsertPayoutTxErr> {
-    let (bid_value, true_value) = if let Some(payout_tx_gas) = payout_tx_gas {
-        let available_value = partial_block.get_proposer_payout_tx_value(payout_tx_gas, ctx)?;
-        let value = match bidder.seal_instruction(available_value, ctx.timestamp()) {
-            SealInstruction::Value(value) => value,
-            SealInstruction::Skip => return Ok(false),
-        };
-        match partial_block.insert_proposer_payout_tx(payout_tx_gas, value, ctx, state) {
-            Ok(()) => (value, available_value),
-            Err(InsertPayoutTxErr::ProfitTooLow) => return Ok(false),
-            Err(err) => return Err(err),
-        }
-    } else {
-        (partial_block.coinbase_profit, partial_block.coinbase_profit)
-    };
-    built_block_trace.bid_value = max(bid_value, fee_recipient_balance_diff);
-    built_block_trace.true_bid_value = true_value;
+/// Output of the BlockBuildingAlgorithm.
+pub trait UnfinishedBlockBuildingSink: std::fmt::Debug + Send + Sync {
+    fn new_block(&self, block: Box<dyn BlockBuildingHelper>);
 
-    Ok(true)
-}
-
-/// Output of the BlockBuildingAlgorithm
-pub trait BlockBuildingSink: std::fmt::Debug + Clone + Send + Sync {
-    fn new_block(&self, block: Block);
+    /// The sink may not like blocks where coinbase is the final fee_recipient (eg: this does not allows us to take profit!).
+    /// Not sure this is the right place for this func. Might move somewhere else.
+    fn can_use_suggested_fee_recipient_as_coinbase(&self) -> bool;
 }
 
 #[derive(Debug)]
-pub struct BlockBuildingAlgorithmInput<DB: Database, SinkType: BlockBuildingSink> {
+pub struct BlockBuildingAlgorithmInput<DB: Database> {
     pub provider_factory: ProviderFactory<DB>,
     pub ctx: BlockBuildingContext,
     pub input: broadcast::Receiver<SimulatedOrderCommand>,
     /// output for the blocks
-    pub sink: SinkType,
-    /// Needed to add the pay to validator tx (the bid!)
-    pub slot_bidder: Arc<dyn SlotBidder>,
+    pub sink: Arc<dyn UnfinishedBlockBuildingSink>,
     pub cancel: CancellationToken,
 }
 
 /// Algorithm to build blocks
 /// build_blocks should send block to input.sink until  input.cancel is cancelled.
 /// slot_bidder should be used to decide how much to bid.
-pub trait BlockBuildingAlgorithm<DB: Database, SinkType: BlockBuildingSink>:
-    std::fmt::Debug + Send + Sync
-{
+pub trait BlockBuildingAlgorithm<DB: Database>: std::fmt::Debug + Send + Sync {
     fn name(&self) -> String;
-    fn build_blocks(&self, input: BlockBuildingAlgorithmInput<DB, SinkType>);
+    fn build_blocks(&self, input: BlockBuildingAlgorithmInput<DB>);
 }
 
-/// Factory used to create BlockBuildingSink for builders when we are targeting blocks for slots.
-pub trait BuilderSinkFactory {
-    type SinkType: BlockBuildingSink + Clone;
-    /// # Arguments
-    /// slot_bidder: Not always needed but simplifies the design.
-    fn create_builder_sink(
-        &self,
+/// Factory used to create UnfinishedBlockBuildingSink for builders.
+pub trait UnfinishedBlockBuildingSinkFactory: std::fmt::Debug + Send + Sync {
+    /// Creates an UnfinishedBlockBuildingSink to receive block for slot_data.
+    /// cancel: If this is signaled the sink should cancel. If any unrecoverable situation is found signal cancel.
+    fn create_sink(
+        &mut self,
         slot_data: MevBoostSlotData,
-        slot_bidder: Arc<dyn SlotBidder>,
         cancel: CancellationToken,
-    ) -> Self::SinkType;
+    ) -> Arc<dyn UnfinishedBlockBuildingSink>;
 }
 
 /// Basic configuration to run a single block building with a BlockBuildingAlgorithm
@@ -307,4 +228,20 @@ pub struct BacktestSimulateBlockInput<'a, DB> {
     pub sim_orders: &'a Vec<SimulatedOrder>,
     pub provider_factory: ProviderFactory<DB>,
     pub cached_reads: Option<CachedReads>,
+}
+
+/// Handles error from block filling stage.
+/// Answers if block filling should continue.
+fn handle_building_error(err: eyre::Report) -> bool {
+    // @Types
+    let err_str = err.to_string();
+    if !err_str.contains("Profit too low") {
+        if is_provider_factory_health_error(&err) {
+            error!(?err, "Cancelling building due to provider factory error");
+            return false;
+        } else {
+            warn!(?err, "Error filling orders");
+        }
+    }
+    true
 }

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -14,29 +14,23 @@ use crate::{
         BlockBuildingContext, BlockOrders, ExecutionError, Sorting,
     },
     primitives::{AccountNonce, OrderId},
-    utils::is_provider_factory_health_error,
 };
 use ahash::{HashMap, HashSet};
 use alloy_primitives::Address;
-use reth::providers::{BlockNumReader, ProviderFactory};
+use reth::providers::ProviderFactory;
 use reth_db::database::Database;
+use tokio_util::sync::CancellationToken;
 
-use crate::{
-    live_builder::bidding::SlotBidder, roothash::RootHashMode, utils::check_provider_factory_health,
-};
+use crate::{roothash::RootHashMode, utils::check_provider_factory_health};
 use reth::tasks::pool::BlockingTaskPool;
 use reth_payload_builder::database::CachedReads;
 use serde::Deserialize;
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
-use time::OffsetDateTime;
-use tracing::{debug, error, info_span, trace, warn};
+use std::time::{Duration, Instant};
+use tracing::{error, info_span, trace};
 
 use super::{
+    block_building_helper::BlockBuildingHelperFromDB, handle_building_error,
     BacktestSimulateBlockInput, Block, BlockBuildingAlgorithm, BlockBuildingAlgorithmInput,
-    BlockBuildingSink,
 };
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -67,12 +61,10 @@ impl OrderingBuilderConfig {
     }
 }
 
-pub fn run_ordering_builder<DB: Database + Clone + 'static, SinkType: BlockBuildingSink>(
-    input: LiveBuilderInput<DB, SinkType>,
+pub fn run_ordering_builder<DB: Database + Clone + 'static>(
+    input: LiveBuilderInput<DB>,
     config: &OrderingBuilderConfig,
 ) {
-    let block_number = input.ctx.block_env.number.to::<u64>();
-    //
     let mut order_intake_consumer = OrderIntakeConsumer::new(
         input.provider_factory.clone(),
         input.input,
@@ -83,7 +75,6 @@ pub fn run_ordering_builder<DB: Database + Clone + 'static, SinkType: BlockBuild
 
     let mut builder = OrderingBuilderContext::new(
         input.provider_factory.clone(),
-        input.slot_bidder,
         input.root_hash_task_pool,
         input.builder_name,
         input.ctx,
@@ -111,35 +102,21 @@ pub fn run_ordering_builder<DB: Database + Clone + 'static, SinkType: BlockBuild
         }
 
         let orders = order_intake_consumer.current_block_orders();
-        match builder.build_block(orders, use_suggested_fee_recipient_as_coinbase) {
-            Ok(Some(block)) => {
-                if block.trace.got_no_signer_error {
+        match builder.build_block(
+            orders,
+            use_suggested_fee_recipient_as_coinbase
+                && input.sink.can_use_suggested_fee_recipient_as_coinbase(),
+            input.cancel.clone(),
+        ) {
+            Ok(block) => {
+                if block.built_block_trace().got_no_signer_error {
                     use_suggested_fee_recipient_as_coinbase = false;
                 }
                 input.sink.new_block(block);
             }
-            Ok(None) => {}
             Err(err) => {
-                // @Types
-                let err_str = err.to_string();
-                if err_str.contains("failed to initialize consistent view") {
-                    let last_block_number = input
-                        .provider_factory
-                        .last_block_number()
-                        .unwrap_or_default();
-                    debug!(
-                        block_number,
-                        last_block_number, "Can't build on this head, cancelling slot"
-                    );
-                    input.cancel.cancel();
+                if !handle_building_error(err) {
                     break 'building;
-                } else if !err_str.contains("Profit too low") {
-                    if is_provider_factory_health_error(&err) {
-                        error!(?err, "Cancelling building due to provider factory error");
-                        break 'building;
-                    } else {
-                        warn!(?err, "Error filling orders");
-                    }
                 }
             }
         }
@@ -166,7 +143,6 @@ pub fn backtest_simulate_block<DB: Database + Clone + 'static>(
     )?;
     let mut builder = OrderingBuilderContext::new(
         input.provider_factory.clone(),
-        Arc::new(()),
         BlockingTaskPool::build()?,
         input.builder_name,
         input.ctx.clone(),
@@ -174,10 +150,22 @@ pub fn backtest_simulate_block<DB: Database + Clone + 'static>(
     )
     .with_skip_root_hash()
     .with_cached_reads(input.cached_reads.unwrap_or_default());
-    let block = builder
-        .build_block(block_orders, use_suggested_fee_recipient_as_coinbase)?
-        .ok_or_else(|| eyre::eyre!("No block built"))?;
-    Ok((block, builder.take_cached_reads().unwrap_or_default()))
+    let block_builder = builder.build_block(
+        block_orders,
+        use_suggested_fee_recipient_as_coinbase,
+        CancellationToken::new(),
+    )?;
+
+    let payout_tx_value = if use_suggested_fee_recipient_as_coinbase {
+        None
+    } else {
+        Some(block_builder.true_block_value()?)
+    };
+    let finalize_block_result = block_builder.finalize_block(payout_tx_value)?;
+    Ok((
+        finalize_block_result.block,
+        finalize_block_result.cached_reads,
+    ))
 }
 
 #[derive(Debug)]
@@ -188,7 +176,6 @@ pub struct OrderingBuilderContext<DB> {
     ctx: BlockBuildingContext,
     config: OrderingBuilderConfig,
     root_hash_mode: RootHashMode,
-    slot_bidder: Arc<dyn SlotBidder>,
 
     // caches
     cached_reads: Option<CachedReads>,
@@ -201,7 +188,6 @@ pub struct OrderingBuilderContext<DB> {
 impl<DB: Database + Clone + 'static> OrderingBuilderContext<DB> {
     pub fn new(
         provider_factory: ProviderFactory<DB>,
-        slot_bidder: Arc<dyn SlotBidder>,
         root_hash_task_pool: BlockingTaskPool,
         builder_name: String,
         ctx: BlockBuildingContext,
@@ -214,7 +200,6 @@ impl<DB: Database + Clone + 'static> OrderingBuilderContext<DB> {
             ctx,
             config,
             root_hash_mode: RootHashMode::CorrectRoot,
-            slot_bidder,
             cached_reads: None,
             failed_orders: HashSet::default(),
             order_attempts: HashMap::default(),
@@ -247,10 +232,8 @@ impl<DB: Database + Clone + 'static> OrderingBuilderContext<DB> {
         &mut self,
         block_orders: BlockOrders,
         use_suggested_fee_recipient_as_coinbase: bool,
-    ) -> eyre::Result<Option<Block>> {
-        let use_suggested_fee_recipient_as_coinbase = use_suggested_fee_recipient_as_coinbase
-            && self.slot_bidder.is_pay_to_coinbase_allowed();
-
+        cancel_block: CancellationToken,
+    ) -> eyre::Result<Box<dyn BlockBuildingHelper>> {
         let build_attempt_id: u32 = rand::random();
         let span = info_span!("build_run", build_attempt_id);
         let _guard = span.enter();
@@ -258,7 +241,6 @@ impl<DB: Database + Clone + 'static> OrderingBuilderContext<DB> {
         check_provider_factory_health(self.ctx.block(), &self.provider_factory)?;
 
         let build_start = Instant::now();
-        let orders_closed_at = OffsetDateTime::now_utc();
 
         // Create a new ctx to remove builder_signer if necessary
         let mut new_ctx = self.ctx.clone();
@@ -268,31 +250,27 @@ impl<DB: Database + Clone + 'static> OrderingBuilderContext<DB> {
         self.failed_orders.clear();
         self.order_attempts.clear();
 
-        let mut block_building_helper = BlockBuildingHelper::new(
+        let mut block_building_helper = BlockBuildingHelperFromDB::new(
             self.provider_factory.clone(),
+            self.root_hash_task_pool.clone(),
+            self.root_hash_mode,
             new_ctx,
             self.cached_reads.take(),
             self.builder_name.clone(),
             self.config.discard_txs,
             self.config.sorting.into(),
+            cancel_block,
         )?;
 
         self.fill_orders(&mut block_building_helper, block_orders, build_start)?;
         block_building_helper.set_trace_fill_time(build_start.elapsed());
-
-        let finalize_block_result = block_building_helper.finalize_block(
-            self.slot_bidder.as_ref(),
-            orders_closed_at,
-            self.root_hash_task_pool.clone(),
-            self.root_hash_mode,
-        )?;
-        self.cached_reads = Some(finalize_block_result.cached_reads);
-        Ok(finalize_block_result.block)
+        self.cached_reads = Some(block_building_helper.clone_cached_reads());
+        Ok(Box::new(block_building_helper))
     }
 
     fn fill_orders(
         &mut self,
-        block_building_helper: &mut BlockBuildingHelper<DB>,
+        block_building_helper: &mut dyn BlockBuildingHelper,
         mut block_orders: BlockOrders,
         build_start: Instant,
     ) -> eyre::Result<()> {
@@ -381,14 +359,12 @@ impl OrderingBuildingAlgorithm {
     }
 }
 
-impl<DB: Database + Clone + 'static, SinkType: BlockBuildingSink>
-    BlockBuildingAlgorithm<DB, SinkType> for OrderingBuildingAlgorithm
-{
+impl<DB: Database + Clone + 'static> BlockBuildingAlgorithm<DB> for OrderingBuildingAlgorithm {
     fn name(&self) -> String {
         self.name.clone()
     }
 
-    fn build_blocks(&self, input: BlockBuildingAlgorithmInput<DB, SinkType>) {
+    fn build_blocks(&self, input: BlockBuildingAlgorithmInput<DB>) {
         let live_input = LiveBuilderInput {
             provider_factory: input.provider_factory,
             root_hash_task_pool: self.root_hash_task_pool.clone(),
@@ -396,7 +372,6 @@ impl<DB: Database + Clone + 'static, SinkType: BlockBuildingSink>
             input: input.input,
             sink: input.sink,
             builder_name: self.name.clone(),
-            slot_bidder: input.slot_bidder,
             cancel: input.cancel,
             sbundle_mergeabe_signers: self.sbundle_mergeabe_signers.clone(),
         };

--- a/crates/rbuilder/src/building/built_block_trace.rs
+++ b/crates/rbuilder/src/building/built_block_trace.rs
@@ -62,11 +62,7 @@ impl BuiltBlockTrace {
     /// Sets:
     /// orders_sealed_at to the current time
     /// orders_closed_at to the given time
-    pub fn update_orders_timestamps_after_block_sealed(
-        &mut self,
-        orders_closed_at: OffsetDateTime,
-    ) {
-        self.orders_closed_at = orders_closed_at;
+    pub fn update_orders_sealed_at(&mut self) {
         self.orders_sealed_at = OffsetDateTime::now_utc();
     }
 

--- a/crates/rbuilder/src/building/tracers.rs
+++ b/crates/rbuilder/src/building/tracers.rs
@@ -13,7 +13,7 @@ pub trait SimulationTracer {
 
 impl SimulationTracer for () {}
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct GasUsedSimulationTracer {
     pub used_gas: u64,
 }

--- a/crates/rbuilder/src/live_builder/block_output/bidding/mod.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding/mod.rs
@@ -45,7 +45,7 @@ impl SlotBidder for () {
     }
 }
 
-pub trait BiddingService: std::fmt::Debug {
+pub trait BiddingService: std::fmt::Debug + Send + Sync {
     fn create_slot_bidder(
         &mut self,
         block: u64,

--- a/crates/rbuilder/src/live_builder/block_output/block_finisher.rs
+++ b/crates/rbuilder/src/live_builder/block_output/block_finisher.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use tracing::{trace, warn};
+
+use crate::building::builders::{
+    block_building_helper::{BlockBuildingHelper, BlockBuildingHelperError},
+    UnfinishedBlockBuildingSink,
+};
+
+use super::{
+    bidding::{SealInstruction, SlotBidder},
+    relay_submit::BlockBuildingSink,
+};
+
+/// UnfinishedBlockBuildingSink that ask the bidder how much to bid (or skip the block), finishes the blocks and sends them to a BlockBuildingSink.
+#[derive(Debug)]
+pub struct BlockFinisher {
+    /// Bidder we ask how to finish the blocks.
+    bidder: Arc<dyn SlotBidder>,
+    /// Destination of the finished blocks.
+    sink: Arc<dyn BlockBuildingSink>,
+}
+
+impl BlockFinisher {
+    pub fn new(bidder: Arc<dyn SlotBidder>, sink: Arc<dyn BlockBuildingSink>) -> Self {
+        Self { bidder, sink }
+    }
+
+    fn finish_and_submit(
+        &self,
+        block: Box<dyn BlockBuildingHelper>,
+    ) -> Result<(), BlockBuildingHelperError> {
+        let payout_tx_value = if block.can_add_payout_tx() {
+            let available_value = block.true_block_value()?;
+            match self
+                .bidder
+                .seal_instruction(available_value, block.building_context().timestamp())
+            {
+                SealInstruction::Value(value) => Some(value),
+                SealInstruction::Skip => {
+                    trace!(
+                        block = block.building_context().block(),
+                        "Skipped block finalization",
+                    );
+                    return Ok(());
+                }
+            }
+        } else {
+            None
+        };
+        self.sink
+            .new_block(block.finalize_block(payout_tx_value)?.block);
+        Ok(())
+    }
+}
+
+impl UnfinishedBlockBuildingSink for BlockFinisher {
+    fn new_block(&self, block: Box<dyn BlockBuildingHelper>) {
+        if let Err(err) = self.finish_and_submit(block) {
+            warn!(?err, "Error finishing block");
+        }
+    }
+
+    fn can_use_suggested_fee_recipient_as_coinbase(&self) -> bool {
+        self.bidder.is_pay_to_coinbase_allowed()
+    }
+}

--- a/crates/rbuilder/src/live_builder/block_output/block_finisher_factory.rs
+++ b/crates/rbuilder/src/live_builder/block_output/block_finisher_factory.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    building::builders::{UnfinishedBlockBuildingSink, UnfinishedBlockBuildingSinkFactory},
+    live_builder::payload_events::MevBoostSlotData,
+};
+
+use super::{
+    bidding::{BiddingService, SlotBidder},
+    block_finisher::BlockFinisher,
+    relay_submit::BuilderSinkFactory,
+};
+
+#[derive(Debug)]
+pub struct BlockFinisherFactory {
+    bidding_service: Box<dyn BiddingService>,
+    /// Factory for the final destination for blocks.
+    block_sink_factory: Box<dyn BuilderSinkFactory>,
+}
+
+impl BlockFinisherFactory {
+    pub fn new(
+        bidding_service: Box<dyn BiddingService>,
+        block_sink_factory: Box<dyn BuilderSinkFactory>,
+    ) -> Self {
+        Self {
+            bidding_service,
+            block_sink_factory,
+        }
+    }
+}
+
+impl UnfinishedBlockBuildingSinkFactory for BlockFinisherFactory {
+    fn create_sink(
+        &mut self,
+        slot_data: MevBoostSlotData,
+        cancel: CancellationToken,
+    ) -> Arc<dyn UnfinishedBlockBuildingSink> {
+        let slot_bidder: Arc<dyn SlotBidder> = Arc::from(self.bidding_service.create_slot_bidder(
+            slot_data.block(),
+            slot_data.slot(),
+            slot_data.timestamp().unix_timestamp() as u64,
+        ));
+        let finished_block_sink = self.block_sink_factory.create_builder_sink(
+            slot_data,
+            slot_bidder.clone(),
+            cancel.clone(),
+        );
+
+        let res = BlockFinisher::new(slot_bidder, Arc::from(finished_block_sink));
+        Arc::new(res)
+    }
+}

--- a/crates/rbuilder/src/live_builder/block_output/block_finisher_factory.rs
+++ b/crates/rbuilder/src/live_builder/block_output/block_finisher_factory.rs
@@ -38,11 +38,11 @@ impl UnfinishedBlockBuildingSinkFactory for BlockFinisherFactory {
         slot_data: MevBoostSlotData,
         cancel: CancellationToken,
     ) -> Arc<dyn UnfinishedBlockBuildingSink> {
-        let slot_bidder: Arc<dyn SlotBidder> = Arc::from(self.bidding_service.create_slot_bidder(
+        let slot_bidder: Arc<dyn SlotBidder> = self.bidding_service.create_slot_bidder(
             slot_data.block(),
             slot_data.slot(),
             slot_data.timestamp().unix_timestamp() as u64,
-        ));
+        );
         let finished_block_sink = self.block_sink_factory.create_builder_sink(
             slot_data,
             slot_bidder.clone(),

--- a/crates/rbuilder/src/live_builder/block_output/mod.rs
+++ b/crates/rbuilder/src/live_builder/block_output/mod.rs
@@ -1,0 +1,4 @@
+pub mod bidding;
+mod block_finisher;
+pub mod block_finisher_factory;
+pub mod relay_submit;

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -1,12 +1,10 @@
-pub mod relay_submit;
-
 use std::{sync::Arc, time::Duration};
-
-pub use relay_submit::SubmissionConfig;
 
 use crate::{
     building::{
-        builders::{BlockBuildingAlgorithm, BlockBuildingAlgorithmInput, BuilderSinkFactory},
+        builders::{
+            BlockBuildingAlgorithm, BlockBuildingAlgorithmInput, UnfinishedBlockBuildingSinkFactory,
+        },
         BlockBuildingContext,
     },
     live_builder::{payload_events::MevBoostSlotData, simulation::SlotOrderSimResults},
@@ -18,7 +16,6 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, trace};
 
 use super::{
-    bidding::BiddingService,
     order_input::{
         self, order_replacement_manager::OrderReplacementManager, orderpool::OrdersForBlock,
     },
@@ -27,25 +24,19 @@ use super::{
 };
 
 #[derive(Debug)]
-pub struct BlockBuildingPool<DB, BuilderSinkFactoryType: BuilderSinkFactory> {
+pub struct BlockBuildingPool<DB> {
     provider_factory: ProviderFactoryReopener<DB>,
-    builders: Vec<Arc<dyn BlockBuildingAlgorithm<DB, BuilderSinkFactoryType::SinkType>>>,
-    sink_factory: BuilderSinkFactoryType,
-    bidding_service: Box<dyn BiddingService>,
+    builders: Vec<Arc<dyn BlockBuildingAlgorithm<DB>>>,
+    sink_factory: Box<dyn UnfinishedBlockBuildingSinkFactory>,
     orderpool_subscriber: order_input::OrderPoolSubscriber,
     order_simulation_pool: OrderSimulationPool<DB>,
 }
 
-impl<DB: Database + Clone + 'static, BuilderSinkFactoryType: BuilderSinkFactory>
-    BlockBuildingPool<DB, BuilderSinkFactoryType>
-where
-    <BuilderSinkFactoryType as BuilderSinkFactory>::SinkType: 'static,
-{
+impl<DB: Database + Clone + 'static> BlockBuildingPool<DB> {
     pub fn new(
         provider_factory: ProviderFactoryReopener<DB>,
-        builders: Vec<Arc<dyn BlockBuildingAlgorithm<DB, BuilderSinkFactoryType::SinkType>>>,
-        sink_factory: BuilderSinkFactoryType,
-        bidding_service: Box<dyn BiddingService>,
+        builders: Vec<Arc<dyn BlockBuildingAlgorithm<DB>>>,
+        sink_factory: Box<dyn UnfinishedBlockBuildingSinkFactory>,
         orderpool_subscriber: order_input::OrderPoolSubscriber,
         order_simulation_pool: OrderSimulationPool<DB>,
     ) -> Self {
@@ -53,7 +44,6 @@ where
             provider_factory,
             builders,
             sink_factory,
-            bidding_service,
             orderpool_subscriber,
             order_simulation_pool,
         }
@@ -105,16 +95,7 @@ where
         input: SlotOrderSimResults,
         cancel: CancellationToken,
     ) {
-        // @Todo keep handles
-        let slot_bidder = self.bidding_service.create_slot_bidder(
-            slot_data.block(),
-            slot_data.slot(),
-            slot_data.timestamp().unix_timestamp() as u64,
-        );
-
-        let builder_sink =
-            self.sink_factory
-                .create_builder_sink(slot_data, slot_bidder.clone(), cancel.clone());
+        let builder_sink = self.sink_factory.create_sink(slot_data, cancel.clone());
         let (broadcast_input, _) = broadcast::channel(10_000);
 
         let block_number = ctx.block_env.number.to::<u64>();
@@ -132,12 +113,11 @@ where
         for builder in self.builders.iter() {
             let builder_name = builder.name();
             debug!(block = block_number, builder_name, "Spawning builder job");
-            let input = BlockBuildingAlgorithmInput::<DB, BuilderSinkFactoryType::SinkType> {
+            let input = BlockBuildingAlgorithmInput::<DB> {
                 provider_factory: provider_factory.clone(),
                 ctx: ctx.clone(),
                 input: broadcast_input.subscribe(),
                 sink: builder_sink.clone(),
-                slot_bidder: slot_bidder.clone(),
                 cancel: cancel.clone(),
             };
             let builder = builder.clone();

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -15,7 +15,7 @@ use crate::{
     utils::build_info::Version,
 };
 
-use super::{base_config::BaseConfig, building::relay_submit::RelaySubmitSinkFactory, LiveBuilder};
+use super::{base_config::BaseConfig, LiveBuilder};
 
 #[derive(Parser, Debug)]
 enum Cli {
@@ -43,9 +43,7 @@ pub trait LiveBuilderConfig: std::fmt::Debug + serde::de::DeserializeOwned {
         &self,
         cancellation_token: CancellationToken,
     ) -> impl std::future::Future<
-        Output = eyre::Result<
-            LiveBuilder<Arc<DatabaseEnv>, RelaySubmitSinkFactory, MevBoostSlotDataGenerator>,
-        >,
+        Output = eyre::Result<LiveBuilder<Arc<DatabaseEnv>, MevBoostSlotDataGenerator>>,
     > + Send;
 
     /// Patch until we have a unified way of backtesting using the exact algorithms we use on the LiveBuilder.


### PR DESCRIPTION
## 📝 Summary

Introduced **BlockBuildingHelper**: A new refactoring structure that contains all the necessary state to build blocks. 

This pull request modifies **BlockBuildingAlgorithms** to output a **BlockBuildingHelper** instead of a **Block**, removing the finishing steps (payout transaction and root hash) from the algorithms.

A new layer has been introduced to transition from **BlockBuildingHelper** to **Block**, followed by the relay submission, specifically tailored for L1. This layer consists of the BlockFinisher, which communicates with the bidder to determine the next steps and, when necessary, propagates the block.

This change is nearly 100% backward compatible; the sequence of operations remains the same, although they are now executed by different objects.

## 💡 Motivation and Context

- Allow best bidding strategies (rebidding)
- Improve L2 compatibility (bidding is not part of the core anymore).
- Allow bottom of block building (a **BlockBuildingHelper** could be upgraded). 

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
