### PR TITLE
Make e2e test more deterministic

### DIFF
--- a/crates/rbuilder/src/integration/playground.rs
+++ b/crates/rbuilder/src/integration/playground.rs
@@ -108,6 +108,10 @@ impl Playground {
         Ok(event)
     }
 
+    pub fn rbuilder_rpc_url(&self) -> &str {
+        "http://localhost:8645"
+    }
+
     pub fn el_url(&self) -> &str {
         "http://localhost:8545"
     }

--- a/crates/rbuilder/src/integration/simple.rs
+++ b/crates/rbuilder/src/integration/simple.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use alloy_network::TransactionBuilder;
     use alloy_primitives::U256;
-    use alloy_provider::{Provider, ProviderBuilder};
+    use alloy_provider::{PendingTransactionBuilder, Provider, ProviderBuilder};
     use alloy_rpc_types::TransactionRequest;
     use std::str::FromStr;
     use test_utils::ignore_if_env_not_set;
@@ -13,6 +13,7 @@ mod tests {
     #[ignore_if_env_not_set("PLAYGROUND_DIR")] // TODO: Change with a custom macro (i.e ignore_if_not_playground)
     #[tokio::test]
     async fn test_simple_example() {
+        // This test sends a transaction ONLY to the builder and waits for the block to be built with it.
         let srv = Playground::new().unwrap();
         srv.wait_for_next_slot().await.unwrap();
 
@@ -30,9 +31,23 @@ mod tests {
             .with_gas_price(gas_price)
             .with_gas_limit(21000);
 
-        let pending_tx = provider.send_transaction(tx).await.unwrap();
-        let receipt = pending_tx.get_receipt().await.unwrap();
+        let tx = provider.fill(tx).await.unwrap();
 
+        // send the transaction ONLY to the builder
+        let rbuilder_provider =
+            ProviderBuilder::new().on_http(Url::parse(srv.rbuilder_rpc_url()).unwrap());
+        let pending_tx = rbuilder_provider
+            .send_tx_envelope(tx.as_envelope().unwrap().clone())
+            .await
+            .unwrap();
+
+        // wait for the transaction in the el node since rbuilder does not implement
+        // the `eth_getTransactionReceipt` method.
+        let binding = ProviderBuilder::new().on_http(Url::parse(srv.el_url()).unwrap());
+        let pending_tx = PendingTransactionBuilder::new(&binding, *pending_tx.tx_hash())
+            .with_timeout(Some(std::time::Duration::from_secs(60)));
+
+        let receipt = pending_tx.get_receipt().await.unwrap();
         srv.validate_block_built(receipt.block_number.unwrap())
             .await
             .unwrap();


### PR DESCRIPTION
## 📝 Summary

This PR does not fix the e2e test but makes it a bit more deterministic to execute. I feel the problem is that due to https://github.com/flashbots/builder-playground/issues/14 issue, the `rbuilder` it not consistent in building blocks at the correct time for the playground. So, it misses building some blocks.

The previous e2e test would send the transaction to the EL node (to be picked up by the builder) and the acceptance condition was for the transaction to be mined and that block to be mined by the local builder. However, since the builder was not consistent, the transaction would be mined by the local EL node instead and trigger the acceptance check.

In this fix, I am only sending the transaction to the builder, so that the EL node cannot include it. Then, if the transaction gets mined, it was for sure done by the builder. I have tested it locally multiple times (>10) and it only failed once and I think due to https://github.com/flashbots/builder-playground/issues/14.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
