### PR TITLE
Changes to allow easier testing in bidding.

### DIFF
--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -34,7 +34,9 @@ use super::Block;
 /// 2 - Call lots of commit_order.
 /// 3 - Call set_trace_fill_time when you are done calling commit_order (we still have to review this step).
 /// 4 - Call finalize_block.
-pub trait BlockBuildingHelper {
+pub trait BlockBuildingHelper: Send {
+    fn box_clone(&self) -> Box<dyn BlockBuildingHelper>;
+
     /// Tries to add an order to the end of the block.
     /// Block state changes only on Ok(Ok)
     fn commit_order(
@@ -379,5 +381,9 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelper
 
     fn building_context(&self) -> &BlockBuildingContext {
         &self.building_ctx
+    }
+
+    fn box_clone(&self) -> Box<dyn BlockBuildingHelper> {
+        Box::new(self.clone())
     }
 }

--- a/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
@@ -1,0 +1,103 @@
+use crate::{
+    building::{
+        BlockBuildingContext, BuiltBlockTrace, CriticalCommitOrderError, ExecutionError,
+        ExecutionResult,
+    },
+    primitives::SimulatedOrder,
+};
+use alloy_primitives::U256;
+use reth_payload_builder::database::CachedReads;
+use reth_primitives::SealedBlock;
+use time::OffsetDateTime;
+
+use super::{
+    block_building_helper::{BlockBuildingHelper, BlockBuildingHelperError, FinalizeBlockResult},
+    Block,
+};
+
+/// Extremely dumb object for test. Adding orders (commit_order) is not allowed.
+/// Is has a predefined true_block_value and the only useful thing that generates on finalize_block is the bid value.
+#[derive(Clone, Debug)]
+pub struct MockBlockBuildingHelper {
+    built_block_trace: BuiltBlockTrace,
+    block_building_context: BlockBuildingContext,
+    can_add_payout_tx: bool,
+}
+
+impl MockBlockBuildingHelper {
+    pub fn new(true_block_value: U256, can_add_payout_tx: bool) -> Self {
+        let built_block_trace = BuiltBlockTrace {
+            true_bid_value: true_block_value,
+            ..Default::default()
+        };
+        Self {
+            built_block_trace,
+            block_building_context: BlockBuildingContext::dummy_for_testing(),
+            can_add_payout_tx,
+        }
+    }
+}
+
+impl BlockBuildingHelper for MockBlockBuildingHelper {
+    fn box_clone(&self) -> Box<dyn BlockBuildingHelper> {
+        Box::new(self.clone())
+    }
+
+    fn commit_order(
+        &mut self,
+        _order: &SimulatedOrder,
+    ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
+        unimplemented!()
+    }
+
+    fn set_trace_fill_time(&mut self, time: std::time::Duration) {
+        self.built_block_trace.fill_time = time;
+    }
+
+    fn set_trace_orders_closed_at(&mut self, orders_closed_at: OffsetDateTime) {
+        self.built_block_trace.orders_closed_at = orders_closed_at;
+    }
+
+    fn can_add_payout_tx(&self) -> bool {
+        self.can_add_payout_tx
+    }
+
+    fn true_block_value(&self) -> Result<U256, BlockBuildingHelperError> {
+        Ok(self.built_block_trace.true_bid_value)
+    }
+
+    fn finalize_block(
+        mut self: Box<Self>,
+        payout_tx_value: Option<U256>,
+    ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
+        self.built_block_trace.update_orders_sealed_at();
+        self.built_block_trace.bid_value = if let Some(payout_tx_value) = payout_tx_value {
+            payout_tx_value
+        } else {
+            self.built_block_trace.true_bid_value
+        };
+        let block = Block {
+            trace: self.built_block_trace,
+            sealed_block: SealedBlock::default(),
+            txs_blobs_sidecars: Vec::new(),
+            builder_name: "BlockBuildingHelper".to_string(),
+        };
+
+        Ok(FinalizeBlockResult {
+            block,
+            cached_reads: CachedReads::default(),
+        })
+    }
+
+    fn clone_cached_reads(&self) -> CachedReads {
+        CachedReads::default()
+    }
+
+    fn built_block_trace(&self) -> &BuiltBlockTrace {
+        &self.built_block_trace
+    }
+
+    fn building_context(&self) -> &BlockBuildingContext {
+        &self.block_building_context
+    }
+}

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -1,5 +1,6 @@
 //! builders is a subprocess that builds a block
 pub mod block_building_helper;
+pub mod mock_block_building_helper;
 pub mod ordering_builder;
 
 use crate::{

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -228,6 +228,21 @@ impl BlockBuildingContext {
         }
     }
 
+    /// Useless BlockBuildingContext for testing in contexts where we can't avoid having a BlockBuildingContext.
+    pub fn dummy_for_testing() -> Self {
+        let mut onchain_block = alloy_rpc_types::Block::default();
+        onchain_block.header.base_fee_per_gas = Some(0);
+        BlockBuildingContext::from_onchain_block(
+            onchain_block,
+            reth_chainspec::MAINNET.clone(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        )
+    }
+
     pub fn modify_use_suggested_fee_recipient_as_coinbase(&mut self) {
         self.builder_signer = None;
         self.block_env.coinbase = self.attributes.suggested_fee_recipient;

--- a/crates/rbuilder/src/live_builder/block_output/bidding/mod.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding/mod.rs
@@ -22,9 +22,6 @@ pub trait SlotBidder: Send + Sync + std::fmt::Debug {
         unsealed_block_profit: U256,
         slot_timestamp: time::OffsetDateTime,
     ) -> SealInstruction;
-
-    /// Returns best bid value available on the relays.
-    fn best_bid_value(&self) -> Option<U256>;
 }
 
 impl SlotBidder for () {
@@ -38,10 +35,6 @@ impl SlotBidder for () {
         _slot_timestamp: time::OffsetDateTime,
     ) -> SealInstruction {
         SealInstruction::Value(unsealed_block_profit)
-    }
-
-    fn best_bid_value(&self) -> Option<U256> {
-        None
     }
 }
 

--- a/crates/rbuilder/src/live_builder/block_output/block_finisher_factory.rs
+++ b/crates/rbuilder/src/live_builder/block_output/block_finisher_factory.rs
@@ -10,7 +10,7 @@ use crate::{
 use super::{
     bidding::{BiddingService, SlotBidder},
     block_finisher::BlockFinisher,
-    relay_submit::BuilderSinkFactory,
+    relay_submit::{BuilderSinkFactory, NullBestBidSource},
 };
 
 #[derive(Debug)]
@@ -45,7 +45,7 @@ impl UnfinishedBlockBuildingSinkFactory for BlockFinisherFactory {
         );
         let finished_block_sink = self.block_sink_factory.create_builder_sink(
             slot_data,
-            slot_bidder.clone(),
+            Arc::new(NullBestBidSource {}),
             cancel.clone(),
         );
 


### PR DESCRIPTION
Changes to allow easier testing in bidding.
Decoupled BestBidSource from SlotBidder.

## 📝 Summary

These are really simple changes:
- Added some #[automock] to traits.
- Created a Mock BlockBuildingHelper to play with block flow without having blocks.
- Decoupled BestBidSource from SlotBidder since it was only used on the relay submit.

## 💡 Motivation and Context

Any programmer making a real bidder would struggle without this stuff.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
