### PR TITLE
Remove tx default debug

### DIFF
--- a/crates/rbuilder/src/backtest/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_block.rs
@@ -243,8 +243,7 @@ fn print_order_and_timestamp(orders_with_ts: &[OrdersWithTimestamp], block_data:
             )
         );
         for (tx, optional) in owt.order.list_txs() {
-            let tx = &tx.tx;
-            println!("    {:?} {:?}", tx.hash, optional);
+            println!("    {:?} {:?}", tx.hash(), optional);
             println!(
                 "        from: {:?} to: {:?} nonce: {}",
                 tx.signer(),
@@ -326,7 +325,7 @@ fn print_onchain_block_data(
     let txs_to_idx: HashMap<_, _> = tx_sim_results
         .iter()
         .enumerate()
-        .map(|(idx, tx)| (tx.tx.hash(), idx))
+        .map(|(idx, tx)| (tx.hash(), idx))
         .collect();
 
     println!("Onchain block txs:");
@@ -334,7 +333,7 @@ fn print_onchain_block_data(
         println!(
             "{:>4}, {:>74} revert: {:>5} profit: {}",
             idx,
-            tx.tx.hash(),
+            tx.hash(),
             !tx.receipt.success,
             format_ether(tx.coinbase_profit)
         );
@@ -352,7 +351,7 @@ fn print_onchain_block_data(
             }
         }
         executed_orders.push(ExecutedBlockTx::new(
-            tx.tx.hash,
+            tx.hash(),
             tx.coinbase_profit,
             tx.receipt.success,
         ))

--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -247,7 +247,7 @@ fn restore_available_landed_orders(
     .into_iter()
     .map(|executed_tx| {
         ExecutedBlockTx::new(
-            executed_tx.tx.hash,
+            executed_tx.hash(),
             executed_tx.coinbase_profit,
             executed_tx.receipt.success,
         )
@@ -949,7 +949,7 @@ fn order_redistribution_address(order: &Order, protect_signers: &[Address]) -> O
         Some(signer) => signer,
         None => {
             return if order.is_tx() {
-                Some(order.list_txs().first()?.0.tx.signer())
+                Some(order.list_txs().first()?.0.signer())
             } else {
                 None
             }
@@ -964,7 +964,7 @@ fn order_redistribution_address(order: &Order, protect_signers: &[Address]) -> O
         Order::Bundle(bundle) => {
             // if its just a bundle we take origin tx of the first transaction
             let tx = bundle.txs.first()?;
-            Some(tx.tx.signer())
+            Some(tx.signer())
         }
         Order::ShareBundle(bundle) => {
             // if it is a share bundle we take either
@@ -977,7 +977,7 @@ fn order_redistribution_address(order: &Order, protect_signers: &[Address]) -> O
 
             let txs = bundle.list_txs();
             let (first_tx, _) = txs.first()?;
-            Some(first_tx.tx.signer())
+            Some(first_tx.signer())
         }
         Order::Tx(_) => {
             unreachable!("Mempool tx order can't have signer");

--- a/crates/rbuilder/src/backtest/restore_landed_orders/find_landed_orders.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/find_landed_orders.rs
@@ -36,7 +36,7 @@ impl SimplifiedOrder {
                         } else {
                             TxRevertBehavior::NotAllowed
                         };
-                        (tx.tx.hash, revert)
+                        (tx.hash(), revert)
                     })
                     .collect();
                 SimplifiedOrder::new(id, vec![OrderChunk::new(txs, false, 0)])

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -89,11 +89,7 @@ async fn main() -> eyre::Result<()> {
             let tx = tx
                 .try_ecrecovered()
                 .ok_or_else(|| eyre::eyre!("Failed to recover tx"))?;
-            let tx = TransactionSignedEcRecoveredWithBlobs {
-                tx,
-                blobs_sidecar: Default::default(),
-                metadata: Default::default(),
-            };
+            let tx = TransactionSignedEcRecoveredWithBlobs::new_for_testing(tx);
             let tx = MempoolTx::new(tx);
             Ok::<_, eyre::Error>(Order::Tx(tx))
         })

--- a/crates/rbuilder/src/building/built_block_trace.rs
+++ b/crates/rbuilder/src/building/built_block_trace.rs
@@ -116,7 +116,6 @@ impl BuiltBlockTrace {
                 &mut executed_tx_hashes_scratchpad
             };
             for (tx, receipt) in res.txs.iter().zip(res.receipts.iter()) {
-                let tx = &tx.tx;
                 executed_tx_hashes.push((tx.hash(), receipt.success));
                 if blocklist.contains(&tx.signer())
                     || tx.to().map(|to| blocklist.contains(&to)).unwrap_or(false)

--- a/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
+++ b/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
@@ -176,7 +176,7 @@ mod test {
         }
         .unwrap();
 
-        assert_eq!(tx_with_blobs.tx.hash(), *pending_tx.tx_hash());
+        assert_eq!(tx_with_blobs.hash(), *pending_tx.tx_hash());
         assert_eq!(tx_with_blobs.blobs_sidecar.blobs.len(), 1);
 
         // send another tx without blobs
@@ -198,7 +198,7 @@ mod test {
         }
         .unwrap();
 
-        assert_eq!(tx_without_blobs.tx.hash(), *pending_tx.tx_hash());
+        assert_eq!(tx_without_blobs.hash(), *pending_tx.tx_hash());
         assert_eq!(tx_without_blobs.blobs_sidecar.blobs.len(), 0);
     }
 }

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -397,10 +397,11 @@ impl ShareBundle {
 
 /// First idea to handle blobs might change.
 /// Don't like the fact that blobs_sidecar exists no matter if TransactionSignedEcRecovered contains a non blob tx.
+/// Great effort was put in avoiding simple access to the internal tx so we don't accidentally leak information on logs (particularly the tx sign).
 #[derive(Derivative)]
 #[derivative(Debug, Clone, PartialEq, Eq)]
 pub struct TransactionSignedEcRecoveredWithBlobs {
-    pub tx: TransactionSignedEcRecovered,
+    tx: TransactionSignedEcRecovered,
     /// Will have a non empty BlobTransactionSidecar if TransactionSignedEcRecovered is 4844
     pub blobs_sidecar: Arc<BlobTransactionSidecar>,
 
@@ -436,11 +437,16 @@ impl TransactionSignedEcRecoveredWithBlobs {
         if tx.transaction.blob_versioned_hashes().is_some() {
             return None;
         }
-        Some(Self {
+        Some(Self::new_for_testing(tx))
+    }
+
+    /// Creates a Self with empty blobs sidecar. No consistency check is performed,
+    pub fn new_for_testing(tx: TransactionSignedEcRecovered) -> Self {
+        Self {
             tx,
-            blobs_sidecar: Arc::new(BlobTransactionSidecar::default()),
+            blobs_sidecar: Default::default(),
             metadata: Default::default(),
-        })
+        }
     }
 
     pub fn hash(&self) -> TxHash {
@@ -451,8 +457,27 @@ impl TransactionSignedEcRecoveredWithBlobs {
         self.tx.signer()
     }
 
+    pub fn to(&self) -> Option<Address> {
+        self.tx.to()
+    }
+
+    pub fn nonce(&self) -> u64 {
+        self.tx.nonce()
+    }
+
+    /// USE CAREFULLY since this exposes the signed tx.
+    pub fn internal_tx_unsecure(&self) -> &TransactionSignedEcRecovered {
+        &self.tx
+    }
+
+    /// USE CAREFULLY since this exposes the signed tx.
+    pub fn into_internal_tx_unsecure(self) -> TransactionSignedEcRecovered {
+        self.tx
+    }
+
     /// Encodes the "raw" canonical format of transaction (NOT the one used in `eth_sendRawTransaction`) BLOB DATA IS NOT ENCODED.
     /// I intensionally omitted the version with blob data since we don't use it and may lead to confusions/bugs.
+    /// USE CAREFULLY since this exposes the signed tx.
     pub fn envelope_encoded_no_blobs(&self) -> Bytes {
         self.tx.envelope_encoded()
     }

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -395,11 +395,11 @@ impl ShareBundle {
     }
 }
 
-/// First idea to handle blobs might change.
+/// First idea to handle blobs, might change.
 /// Don't like the fact that blobs_sidecar exists no matter if TransactionSignedEcRecovered contains a non blob tx.
 /// Great effort was put in avoiding simple access to the internal tx so we don't accidentally leak information on logs (particularly the tx sign).
 #[derive(Derivative)]
-#[derivative(Debug, Clone, PartialEq, Eq)]
+#[derivative(Clone, PartialEq, Eq)]
 pub struct TransactionSignedEcRecoveredWithBlobs {
     tx: TransactionSignedEcRecovered,
     /// Will have a non empty BlobTransactionSidecar if TransactionSignedEcRecovered is 4844
@@ -409,15 +409,20 @@ pub struct TransactionSignedEcRecoveredWithBlobs {
     pub metadata: Metadata,
 }
 
-impl AsRef<TransactionSignedEcRecovered> for TransactionSignedEcRecoveredWithBlobs {
-    fn as_ref(&self) -> &TransactionSignedEcRecovered {
+impl AsRef<TransactionSigned> for TransactionSignedEcRecoveredWithBlobs {
+    fn as_ref(&self) -> &TransactionSigned {
         &self.tx
     }
 }
 
-impl AsRef<TransactionSigned> for TransactionSignedEcRecoveredWithBlobs {
-    fn as_ref(&self) -> &TransactionSigned {
-        &self.tx
+/// Custom fmt to avoid leaking information.
+impl std::fmt::Debug for TransactionSignedEcRecoveredWithBlobs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TransactionSignedEcRecoveredWithBlobs {{ hash: {} }}",
+            self.hash(),
+        )
     }
 }
 

--- a/crates/rbuilder/src/utils/test_utils.rs
+++ b/crates/rbuilder/src/utils/test_utils.rs
@@ -24,8 +24,8 @@ pub fn i256(i: i64) -> I256 {
 }
 
 pub fn tx(tx_hash: u64) -> TransactionSignedEcRecoveredWithBlobs {
-    TransactionSignedEcRecoveredWithBlobs {
-        tx: TransactionSignedEcRecovered::from_signed_transaction(
+    TransactionSignedEcRecoveredWithBlobs::new_for_testing(
+        TransactionSignedEcRecovered::from_signed_transaction(
             TransactionSigned {
                 hash: hash(tx_hash),
                 signature: Default::default(),
@@ -33,7 +33,5 @@ pub fn tx(tx_hash: u64) -> TransactionSignedEcRecoveredWithBlobs {
             },
             Address::default(),
         ),
-        blobs_sidecar: Arc::new(Default::default()),
-        metadata: Default::default(),
-    }
+    )
 }

--- a/crates/rbuilder/src/utils/test_utils.rs
+++ b/crates/rbuilder/src/utils/test_utils.rs
@@ -1,7 +1,6 @@
 use crate::primitives::{OrderId, TransactionSignedEcRecoveredWithBlobs};
 use alloy_primitives::{Address, B256, I256, U256};
 use reth_primitives::{TransactionSigned, TransactionSignedEcRecovered};
-use std::sync::Arc;
 
 pub fn order_id(id: u64) -> OrderId {
     OrderId::Tx(hash(id))


### PR DESCRIPTION
## 📝 Summary

This PR tries to minimize the access to TransactionSignedEcRecoveredWithBlobs::tx to avoid leaking information by mistake:
- tx is not pub anymore.
- Replaced the default fmt::Debug implementation for just the hash.
- Removed unnecessary AsRef


## 💡 Motivation and Context

We are trying to avoid leaking tx info for future TEE deployments.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
