### PR TITLE
store_error feature optional.

### DIFF
--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -18,8 +18,8 @@ use rbuilder::{
     },
     live_builder::{
         base_config::{
-            DEFAULT_EL_NODE_IPC_PATH, DEFAULT_ERROR_STORAGE_PATH, DEFAULT_INCOMING_BUNDLES_PORT,
-            DEFAULT_IP, DEFAULT_RETH_DB_PATH,
+            DEFAULT_EL_NODE_IPC_PATH, DEFAULT_INCOMING_BUNDLES_PORT, DEFAULT_IP,
+            DEFAULT_RETH_DB_PATH,
         },
         config::create_provider_factory,
         order_input::{
@@ -72,7 +72,7 @@ async fn main() -> eyre::Result<()> {
 
     let builder = LiveBuilder::<Arc<DatabaseEnv>, MevBoostSlotDataGenerator> {
         watchdog_timeout: Duration::from_secs(10000),
-        error_storage_path: DEFAULT_ERROR_STORAGE_PATH.parse().unwrap(),
+        error_storage_path: None,
         simulation_threads: 1,
         blocks_source: payload_event,
         order_input_config: OrderInputConfig::new(

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -49,7 +49,7 @@ pub struct BaseConfig {
     log_level: EnvOrValue<String>,
     pub log_color: bool,
 
-    pub error_storage_path: PathBuf,
+    pub error_storage_path: Option<PathBuf>,
 
     coinbase_secret_key: EnvOrValue<String>,
 
@@ -358,7 +358,6 @@ where
     }
 }
 
-pub const DEFAULT_ERROR_STORAGE_PATH: &str = "/tmp/rbuilder-error.sqlite";
 pub const DEFAULT_CL_NODE_URL: &str = "http://127.0.0.1:3500";
 pub const DEFAULT_EL_NODE_IPC_PATH: &str = "/tmp/reth.ipc";
 pub const DEFAULT_INCOMING_BUNDLES_PORT: u16 = 8645;
@@ -372,7 +371,7 @@ impl Default for BaseConfig {
             log_json: false,
             log_level: "info".into(),
             log_color: false,
-            error_storage_path: DEFAULT_ERROR_STORAGE_PATH.parse().unwrap(),
+            error_storage_path: None,
             coinbase_secret_key: "".into(),
             flashbots_db: None,
             el_node_ipc_path: "/tmp/reth.ipc".parse().unwrap(),


### PR DESCRIPTION
## 📝 Summary

This PR allows to optionally disable the store_error feature since it allows storing arbitrary data for further analysis.
Sometimes it's even used to store fully sealed blocks.

## 💡 Motivation and Context

This change is needed to avoid data leaks in a TEE context.

## ✅ I have completed the following steps:

* [X ] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
