### PR TITLE
Improve metrics developer experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,6 +2563,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+dependencies = [
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "ctr"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5806,6 +5816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "mev-share-sse"
 version = "0.1.6"
 source = "git+https://github.com/paradigmxyz/mev-share-rs?rev=9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8#9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8"
@@ -7605,6 +7624,7 @@ dependencies = [
  "criterion",
  "crossbeam-queue",
  "csv",
+ "ctor",
  "derivative",
  "ethereum-consensus",
  "ethereum_ssz",
@@ -7624,6 +7644,7 @@ dependencies = [
  "lru",
  "lz4_flex",
  "mempool-dumpster",
+ "metrics_macros",
  "mev-share-sse",
  "mockall",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = [
     "crates/rbuilder",
-    "crates/rbuilder/src/test_utils"
+    "crates/rbuilder/src/test_utils",
+    "crates/rbuilder/src/telemetry/metrics_macros"
 ]
 resolver = "2"
 

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -55,6 +55,7 @@ ethereum_ssz_derive.workspace = true
 ethereum_ssz.workspace = true
 
 test_utils = { path = "src/test_utils" }
+metrics_macros = { path = "src/telemetry/metrics_macros" }
 
 reqwest = { version = "0.11.20", features = ["blocking"] }
 serde_with = { version = "3.8.1", features = ["time_0_3"] }
@@ -102,6 +103,7 @@ prometheus = "0.13.4"
 hyper = { version = "1.3.1", features = ["server", "full"] }
 warp = "0.3.7"
 lazy_static = "1.4.0"
+ctor = "0.2"
 toml = "0.8.8"
 ahash = "0.8.6"
 rand = "0.8.5"

--- a/crates/rbuilder/src/telemetry/metrics.rs
+++ b/crates/rbuilder/src/telemetry/metrics.rs
@@ -10,7 +10,9 @@ use crate::{
 };
 use alloy_primitives::{utils::Unit, U256};
 use bigdecimal::num_traits::Pow;
+use ctor::ctor;
 use lazy_static::lazy_static;
+use metrics_macros::register_metrics;
 use prometheus::{
     Counter, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
     Registry,
@@ -33,37 +35,40 @@ const BLOCK_METRICS_TIMESTAMP_UPPER_DELTA: time::Duration = time::Duration::seco
 
 lazy_static! {
     pub static ref REGISTRY: Registry = Registry::new();
-    pub static ref BLOCK_FILL_TIME: HistogramVec = HistogramVec::new(
+}
+
+register_metrics! {
+    pub static BLOCK_FILL_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_fill_time", "Block Fill Times (ms)")
             .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
         &["builder_name"]
     )
     .unwrap();
-    pub static ref BLOCK_FINALIZE_TIME: HistogramVec = HistogramVec::new(
+    pub static BLOCK_FINALIZE_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_finalize_time", "Block Finalize Times (ms)")
             .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
         &["builder_name"]
     )
     .unwrap();
-    pub static ref BLOCK_BUILT_TXS: HistogramVec = HistogramVec::new(
+    pub static BLOCK_BUILT_TXS: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_built_txs", "Transactions in the built block")
             .buckets(linear_buckets_range(1.0, 1000.0, 100)),
         &["builder_name"]
     )
     .unwrap();
-    pub static ref BLOCK_BUILT_BLOBS: HistogramVec = HistogramVec::new(
+    pub static BLOCK_BUILT_BLOBS: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_built_blobs", "Blobs in the built block")
             .buckets(linear_buckets_range(1.0, 32.0, 100)),
         &["builder_name"]
     )
     .unwrap();
-    pub static ref BLOCK_BUILT_GAS_USED: HistogramVec = HistogramVec::new(
+    pub static BLOCK_BUILT_GAS_USED: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_built_gas_used", "Gas used in the built block")
             .buckets(exponential_buckets_range(21_000.0, 30_000_000.0, 100)),
         &["builder_name"]
     )
     .unwrap();
-    pub static ref BLOCK_BUILT_SIM_GAS_USED: HistogramVec = HistogramVec::new(
+    pub static BLOCK_BUILT_SIM_GAS_USED: HistogramVec = HistogramVec::new(
         HistogramOpts::new(
             "block_built_sim_gas_used",
             "Gas used in the built block including failing bundles"
@@ -72,7 +77,7 @@ lazy_static! {
         &["builder_name"]
     )
     .unwrap();
-    pub static ref BLOCK_BUILT_MGAS_PER_SECOND: HistogramVec = HistogramVec::new(
+    pub static BLOCK_BUILT_MGAS_PER_SECOND: HistogramVec = HistogramVec::new(
         HistogramOpts::new(
             "block_built_mgas_per_second",
             "MGas/s for the built block (including failing txs)"
@@ -81,42 +86,42 @@ lazy_static! {
         &["builder_name"]
     )
     .unwrap();
-    pub static ref BLOCK_VALIDATION_TIME: HistogramVec = HistogramVec::new(
+    pub static BLOCK_VALIDATION_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_validation_time", "Block Validation Times (ms)")
             .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
         &["builder_name"]
     )
     .unwrap();
-    pub static ref CURRENT_BLOCK: IntGauge =
+    pub static CURRENT_BLOCK: IntGauge =
         IntGauge::new("current_block", "Current Block").unwrap();
-    pub static ref ORDERPOOL_TXS: IntGauge =
+    pub static ORDERPOOL_TXS: IntGauge =
         IntGauge::new("orderpool_txs", "Transactions In The Orderpool").unwrap();
-    pub static ref ORDERPOOL_BUNDLES: IntGauge =
+    pub static ORDERPOOL_BUNDLES: IntGauge =
         IntGauge::new("orderpool_bundles", "Bundles In The Orderpool").unwrap();
-    pub static ref RELAY_ERRORS: IntCounterVec = IntCounterVec::new(
+    pub static RELAY_ERRORS: IntCounterVec = IntCounterVec::new(
         Opts::new("relay_errors", "counter of relay errors"),
         &["relay", "kind"]
     )
     .unwrap();
-    pub static ref BLOCK_SIM_ERRORS: IntCounterVec = IntCounterVec::new(
+    pub static BLOCK_SIM_ERRORS: IntCounterVec = IntCounterVec::new(
         Opts::new("block_sim_errors", "counter of block simulation errors"),
         &[]
     )
     .unwrap();
-    pub static ref BLOCK_API_ERRORS: IntCounterVec = IntCounterVec::new(
+    pub static BLOCK_API_ERRORS: IntCounterVec = IntCounterVec::new(
         Opts::new("block_api_errors", "counter of the block processor errors"),
         &[]
     )
     .unwrap();
-    pub static ref SIMULATED_OK_ORDERS: IntCounter =
+    pub static SIMULATED_OK_ORDERS: IntCounter =
         IntCounter::new("simulated_ok_orders", "Simulated succeeded orders").unwrap();
-    pub static ref SIMULATED_FAILED_ORDERS: IntCounter =
+    pub static SIMULATED_FAILED_ORDERS: IntCounter =
         IntCounter::new("simulated_failed_orders", "Simulated failed orders").unwrap();
-    pub static ref SIMULATION_GAS_USED: IntCounter =
+    pub static SIMULATION_GAS_USED: IntCounter =
         IntCounter::new("simulation_gas_used", "Simulation gas used").unwrap();
-    pub static ref ACTIVE_SLOTS: IntCounter =
+    pub static ACTIVE_SLOTS: IntCounter =
         IntCounter::new("active_slots", "Slots when builder was active").unwrap();
-    pub static ref INITIATED_SUBMISSIONS: IntCounterVec = IntCounterVec::new(
+    pub static INITIATED_SUBMISSIONS: IntCounterVec = IntCounterVec::new(
         Opts::new(
             "initiated_submissions",
             "Number of initiated submissions to the relays"
@@ -124,18 +129,18 @@ lazy_static! {
         &["optimistic"],
     )
     .unwrap();
-    pub static ref RELAY_SUBMIT_TIME: HistogramVec = HistogramVec::new(
+    pub static RELAY_SUBMIT_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new("relay_submit_time", "Time to send bid to the relay (ms)")
             .buckets(linear_buckets_range(0.0, 3000.0, 50)),
         &["relay"],
     )
     .unwrap();
-    pub static ref VERSION: IntGaugeVec = IntGaugeVec::new(
+    pub static VERSION: IntGaugeVec = IntGaugeVec::new(
         Opts::new("version", "Version of the builder"),
         &["git", "git_ref", "build_time_utc"]
     )
     .unwrap();
-    pub static ref RELAY_ACCEPTED_SUBMISSIONS: IntCounterVec = IntCounterVec::new(
+    pub static RELAY_ACCEPTED_SUBMISSIONS: IntCounterVec = IntCounterVec::new(
         Opts::new(
             "relay_accepted_submissions",
             "Number of accepted submissions"
@@ -143,7 +148,7 @@ lazy_static! {
         &["relay", "optimistic"]
     )
     .unwrap();
-    pub static ref SIMULATION_THREAD_WORK_TIME: IntCounterVec = IntCounterVec::new(
+    pub static SIMULATION_THREAD_WORK_TIME: IntCounterVec = IntCounterVec::new(
         Opts::new(
             "simulation_thread_work_time",
             "Time spent working in simulation thread (mus)"
@@ -151,7 +156,7 @@ lazy_static! {
         &["worker_id"]
     )
     .unwrap();
-    pub static ref SIMULATION_THREAD_WAIT_TIME: IntCounterVec = IntCounterVec::new(
+    pub static SIMULATION_THREAD_WAIT_TIME: IntCounterVec = IntCounterVec::new(
         Opts::new(
             "simulation_thread_wait_time",
             "Time spent waiting for input in simulation thread (mus)"
@@ -159,7 +164,7 @@ lazy_static! {
         &["worker_id"]
     )
     .unwrap();
-    pub static ref ORDERS_IN_LAST_BUILT_BLOCK_E2E_LAT_MS: HistogramVec = HistogramVec::new(
+    pub static ORDERS_IN_LAST_BUILT_BLOCK_E2E_LAT_MS: HistogramVec = HistogramVec::new(
         HistogramOpts::new(
             "orders_in_last_built_block_e2e_lat",
             "For all blocks that are ready for submission to the relay its = min over orders (submission start - order received)"
@@ -169,16 +174,16 @@ lazy_static! {
     )
     .unwrap();
 
-    pub static ref PROVIDER_REOPEN_COUNTER: IntCounter = IntCounter::new(
+    pub static PROVIDER_REOPEN_COUNTER: IntCounter = IntCounter::new(
         "provider_reopen_counter", "Counter of provider reopens").unwrap();
 
-    pub static ref PROVIDER_BAD_REOPEN_COUNTER: IntCounter = IntCounter::new(
+    pub static PROVIDER_BAD_REOPEN_COUNTER: IntCounter = IntCounter::new(
         "provider_bad_reopen_counter", "Counter of provider reopens").unwrap();
 
-    pub static ref TXFETCHER_TRANSACTION_COUNTER: IntCounter = IntCounter::new(
+    pub static TXFETCHER_TRANSACTION_COUNTER: IntCounter = IntCounter::new(
         "txfetcher_transaction_counter", "Counter of transactions fetched by txfetcher service").unwrap();
 
-    pub static ref TXFETCHER_TRANSACTION_QUERY_TIME: HistogramVec = HistogramVec::new(
+    pub static TXFETCHER_TRANSACTION_QUERY_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new("txfetcher_transaction_query_time", "Time to retrieve a transaction from the txpool (ms)")
             .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
         &[],
@@ -189,7 +194,7 @@ lazy_static! {
      /////////////////////////////////
 
     /// We decide this at the end of the submission to relays
-    pub static ref SUBSIDIZED_BLOCK_COUNT: IntCounterVec = IntCounterVec::new(
+    pub static SUBSIDIZED_BLOCK_COUNT: IntCounterVec = IntCounterVec::new(
         Opts::new(
             "subsidized_block_count",
             "Subsidized block count"
@@ -200,14 +205,14 @@ lazy_static! {
     /// We decide this at the end of the submission to relays
     /// We expect to see values around .001
     /// We only count subsidized blocks.
-    pub static ref SUBSIDY_VALUE: HistogramVec = HistogramVec::new(
+    pub static SUBSIDY_VALUE: HistogramVec = HistogramVec::new(
             HistogramOpts::new("subsidy_value", "Subsidy value")
                 .buckets(exponential_buckets_range(0.0001, 0.05, 1000)),
         &["kind"],
         )
         .unwrap();
 
-    pub static ref TOTAL_LANDED_SUBSIDIES_SUM: Counter =
+    pub static TOTAL_LANDED_SUBSIDIES_SUM: Counter =
         Counter::new("total_landed_subsidies_sum", "Sum of all total landed subsidies").unwrap();
 }
 
@@ -417,90 +422,6 @@ pub fn add_subsidy_value(value: U256, landed: bool) {
     if landed {
         TOTAL_LANDED_SUBSIDIES_SUM.inc_by(value_float);
     }
-}
-
-pub(super) fn register_custom_metrics() {
-    REGISTRY
-        .register(Box::new(BLOCK_FILL_TIME.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(BLOCK_FINALIZE_TIME.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(BLOCK_VALIDATION_TIME.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(BLOCK_BUILT_TXS.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(BLOCK_BUILT_GAS_USED.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(BLOCK_BUILT_SIM_GAS_USED.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(BLOCK_BUILT_MGAS_PER_SECOND.clone()))
-        .unwrap();
-    REGISTRY.register(Box::new(CURRENT_BLOCK.clone())).unwrap();
-    REGISTRY.register(Box::new(ORDERPOOL_TXS.clone())).unwrap();
-    REGISTRY
-        .register(Box::new(ORDERPOOL_BUNDLES.clone()))
-        .unwrap();
-    REGISTRY.register(Box::new(RELAY_ERRORS.clone())).unwrap();
-    REGISTRY
-        .register(Box::new(BLOCK_SIM_ERRORS.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(BLOCK_API_ERRORS.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(SIMULATED_FAILED_ORDERS.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(SIMULATED_OK_ORDERS.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(SIMULATION_GAS_USED.clone()))
-        .unwrap();
-    REGISTRY.register(Box::new(ACTIVE_SLOTS.clone())).unwrap();
-    REGISTRY
-        .register(Box::new(INITIATED_SUBMISSIONS.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(RELAY_SUBMIT_TIME.clone()))
-        .unwrap();
-    REGISTRY.register(Box::new(VERSION.clone())).unwrap();
-    REGISTRY
-        .register(Box::new(RELAY_ACCEPTED_SUBMISSIONS.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(SIMULATION_THREAD_WORK_TIME.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(SIMULATION_THREAD_WAIT_TIME.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(ORDERS_IN_LAST_BUILT_BLOCK_E2E_LAT_MS.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(SUBSIDIZED_BLOCK_COUNT.clone()))
-        .unwrap();
-    REGISTRY.register(Box::new(SUBSIDY_VALUE.clone())).unwrap();
-    REGISTRY
-        .register(Box::new(TOTAL_LANDED_SUBSIDIES_SUM.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(PROVIDER_REOPEN_COUNTER.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(PROVIDER_BAD_REOPEN_COUNTER.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(TXFETCHER_TRANSACTION_COUNTER.clone()))
-        .unwrap();
-    REGISTRY
-        .register(Box::new(TXFETCHER_TRANSACTION_QUERY_TIME.clone()))
-        .unwrap();
 }
 
 pub(super) fn gather_prometheus_metrics() -> String {

--- a/crates/rbuilder/src/telemetry/metrics_macros/Cargo.toml
+++ b/crates/rbuilder/src/telemetry/metrics_macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "metrics_macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }

--- a/crates/rbuilder/src/telemetry/metrics_macros/src/lib.rs
+++ b/crates/rbuilder/src/telemetry/metrics_macros/src/lib.rs
@@ -1,0 +1,107 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Item};
+
+/// Generates and registers the given static Prometheus metrics to a static
+/// Registry named REGISTRY.
+///
+/// This avoids the need for the caller to manually initialize the registry
+/// and call REGISTERY.register on every metric.
+///
+/// Metrics are eagerly initialized when the program starts with `ctor`,
+/// so they will show up in the Prometheus metrics endpoint immediately.
+///
+/// Note: `lazy_static::lazy_static` and `ctor::ctor` must be in scope.
+///
+/// # Example
+///
+/// ```ignore
+/// register_metrics! {
+///     pub static CURRENT_BLOCK: IntGauge = IntGauge::new("current_block", "Current Block").unwrap();
+///
+///     pub static BLOCK_FILL_TIME: HistogramVec = HistogramVec::new(
+///         HistogramOpts::new("block_fill_time", "Block Fill Times (ms)")
+///             .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
+///         &["builder_name"]
+///     )
+///     .unwrap();
+/// }
+/// ```
+///
+/// expands to
+///
+/// ```ignore
+/// lazy_static! {
+///     pub static ref CURRENT_BLOCK: IntGauge = {
+///         let metric = IntGauge::new("current_block", "Current Block").unwrap();
+///         REGISTRY.register(Box::new(metric.clone())).unwrap();
+///         metric
+///     };
+///
+///     pub static ref BLOCK_FILL_TIME: HistogramVec = {
+///         let metric = HistogramVec::new(
+///             HistogramOpts::new("block_fill_time", "Block Fill Times (ms)")
+///                 .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
+///             &["builder_name"]
+///         ).unwrap();
+///         REGISTRY.register(Box::new(metric.clone())).expect("Failed to register metric");
+///         metric
+///     };
+/// }
+///
+/// #[ctor]
+/// fn initialize_metrics() {
+///     // Force initialization of lazy statics
+///     let _ = *CURRENT_BLOCK;
+///     let _ = *BLOCK_FILL_TIME;
+/// }
+/// ```
+#[proc_macro]
+pub fn register_metrics(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::File);
+
+    // Stuff to put in lazy_static!
+    let mut metrics = quote! {};
+
+    // Stuff to put in ctor
+    let mut initializers = quote! {};
+
+    for item in input.items {
+        if let Item::Static(static_item) = item {
+            let vis = &static_item.vis;
+            let ident = &static_item.ident;
+            let ty = &static_item.ty;
+            let expr = &static_item.expr;
+
+            // Create the static metric call REGISTER.register with it.
+            metrics.extend(quote! {
+                #vis static ref #ident: #ty = {
+                    let metric = #expr;
+                    REGISTRY.register(Box::new(metric.clone())).expect("Failed to register metric");
+                    metric
+                };
+            });
+
+            // Make sure the metric is eagerly initialized
+            initializers.extend(quote! {
+                let _ = *#ident;
+            });
+        } else {
+            panic!("register_metrics! only supports static items");
+        }
+    }
+
+    let out = quote! {
+        lazy_static! {
+            #metrics
+        }
+
+        #[ctor]
+        fn initialize_metrics() {
+            #initializers
+        }
+    };
+
+    TokenStream::from(out)
+}

--- a/crates/rbuilder/src/telemetry/mod.rs
+++ b/crates/rbuilder/src/telemetry/mod.rs
@@ -55,8 +55,6 @@ async fn reset_log_handle() -> Result<impl Reply, Rejection> {
 }
 
 pub async fn spawn_telemetry_server(addr: SocketAddr, version: Version) -> eyre::Result<()> {
-    register_custom_metrics();
-
     set_version(version);
 
     // metrics over /debug/metrics/prometheus


### PR DESCRIPTION
Currently, to add a new metric code needs to be modified in two places:
1. The big lazy_static declaring metrics
2. Inside `fn register_custom_metrics` to register it

This PR adds a macro `register_metrics` we can use in place of `lazy_static` when declaring metrics, which handles registering the declared metrics and therefore removing the requirement for `fn register_custom_metrics` entirely. 

Metrics are eagerly initialised with `ctor` so they will show up in the Prometheus metrics endpoint immediately.

I decided on this approach rather than switch to an entirely different framework like what reth uses so it would slot into the existing pattern with minimal changes.

# Usage

```rust
register_metrics! {
    pub static CURRENT_BLOCK: IntGauge = IntGauge::new("current_block", "Current Block").unwrap();

    pub static BLOCK_FILL_TIME: HistogramVec = HistogramVec::new(
        HistogramOpts::new("block_fill_time", "Block Fill Times (ms)")
            .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
        &["builder_name"]
    )
    .unwrap();
}
```

expands to

```rust
lazy_static! {
    pub static ref CURRENT_BLOCK: IntGauge = {
        let metric = IntGauge::new("current_block", "Current Block").unwrap();
        REGISTRY.register(Box::new(metric.clone())).unwrap();
        metric
    };

    pub static ref BLOCK_FILL_TIME: HistogramVec = {
        let metric = HistogramVec::new(
            HistogramOpts::new("block_fill_time", "Block Fill Times (ms)")
                .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
            &["builder_name"]
        ).unwrap();
        REGISTRY.register(Box::new(metric.clone())).unwrap();
        metric
    };
}

#[ctor]
fn initialize_metrics() {
    let _ = *CURRENT_BLOCK;
    let _ = *BLOCK_FILL_TIME;
}

