### PR TITLE
Dynamic log optional

### DIFF
--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -50,6 +50,8 @@ pub struct BaseConfig {
     pub log_json: bool,
     log_level: EnvOrValue<String>,
     pub log_color: bool,
+    /// Enables dynamic logging (saving logs to a file)
+    pub log_enable_dynamic: bool,
 
     pub error_storage_path: Option<PathBuf>,
 
@@ -389,6 +391,7 @@ impl Default for BaseConfig {
             log_json: false,
             log_level: "info".into(),
             log_color: false,
+            log_enable_dynamic: false,
             error_storage_path: None,
             coinbase_secret_key: "".into(),
             flashbots_db: None,

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -88,6 +88,7 @@ pub async fn run<ConfigType: LiveBuilderConfig>(
     telemetry::servers::full::spawn(
         config.base_config().full_telemetry_server_address(),
         config.version_for_telemetry(),
+        config.base_config().log_enable_dynamic,
     )
     .await?;
     let builder = config.create_builder(cancel.clone()).await?;


### PR DESCRIPTION
Goes on top of https://github.com/flashbots/rbuilder/pull/169.
## 📝 Summary

Allows to disable dynamic logs.

## 💡 Motivation and Context

In some contexts (eg: TEE) they might be a security leak.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
