### PR TITLE
removes nonce struct in favor of bundledtxinfo

### DIFF
--- a/crates/rbuilder/src/backtest/fetch/mod.rs
+++ b/crates/rbuilder/src/backtest/fetch/mod.rs
@@ -155,14 +155,14 @@ impl HistoricalDataFetcher {
                     for nonce in nonces {
                         let mut res_onchain_nonce: Option<u64> = None;
                         if let Ok(nonce_cache) = nonce_cache.read() {
-                            if let Some(onchain_nonce) = nonce_cache.get(&nonce.address) {
+                            if let Some(onchain_nonce) = nonce_cache.get(&nonce.nonce.account) {
                                 res_onchain_nonce = Some(*onchain_nonce);
                             }
                         }
                         let res_onchain_nonce = if let Some(res_onchain_nonce) = res_onchain_nonce {
                             res_onchain_nonce
                         } else {
-                            let address = nonce.address;
+                            let address = nonce.nonce.account;
                             let onchain_nonce = self
                                 .eth_provider
                                 .get_transaction_count(address)
@@ -176,11 +176,11 @@ impl HistoricalDataFetcher {
                             onchain_nonce
                         };
 
-                        if res_onchain_nonce > nonce.nonce && !nonce.optional {
+                        if res_onchain_nonce > nonce.nonce.nonce && !nonce.optional {
                             trace!(
                                 "Order nonce too low, order: {:?}, nonce: {}, onchain tx count: {}",
                                 id,
-                                nonce.nonce,
+                                nonce.nonce.nonce,
                                 res_onchain_nonce,
                             );
                             return Ok(());

--- a/crates/rbuilder/src/backtest/mod.rs
+++ b/crates/rbuilder/src/backtest/mod.rs
@@ -192,7 +192,7 @@ impl BlockData {
                 .filter(|tx| {
                     !available_accounts
                         .iter()
-                        .any(|x| x.nonce == tx.nonce && x.address == tx.from)
+                        .any(|x| x.nonce.nonce == tx.nonce && x.nonce.account == tx.from)
                 })
                 .map(|tx| {
                     (

--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -302,7 +302,7 @@ impl AvailableOrders {
                     if n.optional {
                         return None;
                     }
-                    Some(n.address)
+                    Some(n.nonce.account)
                 })
                 .collect();
             (mandatory_nonces, order.replacement_key())

--- a/crates/rbuilder/src/building/block_orders/mod.rs
+++ b/crates/rbuilder/src/building/block_orders/mod.rs
@@ -199,10 +199,10 @@ pub fn block_orders_from_sim_orders(
     for order in sim_orders {
         for nonce in order.order.nonces() {
             let value = state_provider
-                .account_nonce(nonce.address)?
+                .account_nonce(nonce.nonce.account)?
                 .unwrap_or_default();
             onchain_nonces.push(AccountNonce {
-                account: nonce.address,
+                account: nonce.nonce.account,
                 nonce: value,
             });
         }

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -156,15 +156,15 @@ impl<DB: Database + Clone> OrderIntakeConsumer<DB> {
         let mut nonces = Vec::new();
         for new_order in new_orders {
             for nonce in new_order.order.nonces() {
-                if self.onchain_nonces_updated.contains(&nonce.address) {
+                if self.onchain_nonces_updated.contains(&nonce.nonce.account) {
                     continue;
                 }
-                let onchain_nonce = nonce_db_ref.nonce(nonce.address)?;
+                let onchain_nonce = nonce_db_ref.nonce(nonce.nonce.account)?;
                 nonces.push(AccountNonce {
-                    account: nonce.address,
+                    account: nonce.nonce.account,
                     nonce: onchain_nonce,
                 });
-                self.onchain_nonces_updated.insert(nonce.address);
+                self.onchain_nonces_updated.insert(nonce.nonce.account);
             }
         }
         self.block_orders.update_onchain_nonces(&nonces);

--- a/crates/rbuilder/src/building/conflict.rs
+++ b/crates/rbuilder/src/building/conflict.rs
@@ -57,17 +57,17 @@ pub fn find_conflict_slow(
         let pair = (order1.id(), order2.id());
         let mut nonce_map = HashMap::new();
         order1.nonces().into_iter().for_each(|nonce| {
-            nonce_map.insert(nonce.address, nonce);
+            nonce_map.insert(nonce.nonce.account, nonce);
         });
         if let Some(nonce) = order2.nonces().into_iter().find(|nonce| {
-            if let Some(nonce_map) = nonce_map.get(&nonce.address) {
+            if let Some(nonce_map) = nonce_map.get(&nonce.nonce.account) {
                 let optional = nonce.optional || nonce_map.optional;
-                !optional && nonce.address == nonce_map.address
+                !optional && nonce.nonce.account == nonce_map.nonce.account
             } else {
                 false
             }
         }) {
-            results.insert(pair, Conflict::Nonce(nonce.address));
+            results.insert(pair, Conflict::Nonce(nonce.nonce.account));
             continue;
         }
 

--- a/crates/rbuilder/src/building/sim.rs
+++ b/crates/rbuilder/src/building/sim.rs
@@ -149,12 +149,12 @@ impl<DB: Database> SimTree<DB> {
         let mut parent_orders = Vec::new();
 
         for nonce in order.nonces() {
-            let onchain_nonce = nonces.nonce(nonce.address)?;
+            let onchain_nonce = nonces.nonce(nonce.nonce.account)?;
 
-            match onchain_nonce.cmp(&nonce.nonce) {
+            match onchain_nonce.cmp(&nonce.nonce.nonce) {
                 Ordering::Equal => {
                     // nonce, valid
-                    onchain_nonces_incremented.insert(nonce.address);
+                    onchain_nonces_incremented.insert(nonce.nonce.account);
                     continue;
                 }
                 Ordering::Greater => {
@@ -173,16 +173,16 @@ impl<DB: Database> SimTree<DB> {
                     }
                 }
                 Ordering::Less => {
-                    if onchain_nonces_incremented.contains(&nonce.address) {
+                    if onchain_nonces_incremented.contains(&nonce.nonce.account) {
                         // we already considered this account nonce
                         continue;
                     }
                     // mark this nonce as considered
-                    onchain_nonces_incremented.insert(nonce.address);
+                    onchain_nonces_incremented.insert(nonce.nonce.account);
 
                     let nonce_key = NonceKey {
-                        address: nonce.address,
-                        nonce: nonce.nonce,
+                        address: nonce.nonce.account,
+                        nonce: nonce.nonce.nonce,
                     };
 
                     if let Some(sim_id) = self.sims_that_update_one_nonce.get(&nonce_key) {

--- a/crates/rbuilder/src/live_builder/order_input/orderpool.rs
+++ b/crates/rbuilder/src/live_builder/order_input/orderpool.rs
@@ -234,11 +234,11 @@ impl OrderPool {
                     continue;
                 }
                 let onchain_nonce = new_state
-                    .account_nonce(nonce.address)
+                    .account_nonce(nonce.nonce.account)
                     .map_err(|e| error!("Failed to get a nonce: {}", e))
                     .unwrap_or_default()
                     .unwrap_or_default();
-                if onchain_nonce > nonce.nonce {
+                if onchain_nonce > nonce.nonce.nonce {
                     return false;
                 }
             }


### PR DESCRIPTION
## 📝 Summary

I've been reading through the `primitives` module and found this `Nonce` struct to be redundant and marked for deletion. This change so far does just a primitive replacement with `BundledTxInfo`. It probably also needs:

* renaming of variables from `nonce` to something more relevant
* getters on the struct to make stuff like `nonce.nonce.nonce` more readable.

Let me know what you think.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
