### PR TITLE
Use root playgroung config toml file

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -95,23 +95,25 @@ jobs:
         run: cargo build
 
       - name: Run the playground
-        run: builder-playground --output /tmp/playground &
+        run: builder-playground &
 
       - name: Run integration tests
         run: cargo test --package rbuilder --lib -- integration
         env:
-          PLAYGROUND_DIR: /tmp/playground
+          PLAYGROUND: TRUE
 
-      - name: Move test integration logs to playground logs to archive
+      - name: Aggregate playground logs
         # This steps fails if the test fails early and the playground logs dir has not been created
         if: ${{ failure() }}
         run: |
-          mv integration_logs /tmp/playground/logs
+          mkdir /tmp/playground-logs
+          mv $HOME/.playground/devnet/logs /tmp/playground-logs
+          mv integration_logs /tmp/playground-logs
 
       - name: Archive playground logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: playground-logs
-          path: /tmp/playground/logs
+          path: /tmp/playground-logs
           retention-days: 5

--- a/crates/rbuilder/src/integration/simple.rs
+++ b/crates/rbuilder/src/integration/simple.rs
@@ -10,7 +10,7 @@ mod tests {
     use test_utils::ignore_if_env_not_set;
     use url::Url;
 
-    #[ignore_if_env_not_set("PLAYGROUND_DIR")] // TODO: Change with a custom macro (i.e ignore_if_not_playground)
+    #[ignore_if_env_not_set("PLAYGROUND")] // TODO: Change with a custom macro (i.e ignore_if_not_playground)
     #[tokio::test]
     async fn test_simple_example() {
         // This test sends a transaction ONLY to the builder and waits for the block to be built with it.


### PR DESCRIPTION
## 📝 Summary

This PR uses the root playground config TOML file for the playground integration tests instead of creating one ad-hoc for the test. It had to be like that before because `rbuilder` could not expand $HOME in the config file, but, that was resolved in #114.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [] Added tests (if applicable)
