### PR TITLE
Sparse trie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,6 +2826,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "eth-sparse-mpt"
+version = "0.1.0"
+source = "git+https://github.com/flashbots/eth-sparse-mpt?rev=664759b#664759b53d92e64d9a2e902100691b7ff4945ece"
+dependencies = [
+ "alloy-primitives 0.8.0",
+ "alloy-rlp",
+ "alloy-trie",
+ "hash-db",
+ "rayon",
+ "reth-db-api",
+ "reth-errors",
+ "reth-execution-errors",
+ "reth-provider",
+ "reth-trie",
+ "reth-trie-db",
+ "revm",
+ "revm-primitives",
+ "rustc-hash 2.0.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
+ "thiserror",
+ "triehash",
+]
+
+[[package]]
 name = "ethabi"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7000,6 +7027,7 @@ dependencies = [
  "csv",
  "ctor",
  "derivative",
+ "eth-sparse-mpt",
  "ethereum-consensus",
  "ethereum_ssz",
  "ethereum_ssz_derive",

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -124,6 +124,8 @@ mockall = "0.12.1"
 shellexpand = "3.1.0"
 async-trait = "0.1.80"
 
+eth-sparse-mpt = { git = "https://github.com/flashbots/eth-sparse-mpt", rev = "664759b" }
+
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2", "chrono"] }
 

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -1,31 +1,33 @@
 //! App to benchmark/test the tx block execution.
-//! It loads the last landed block and re-executes all the txs in it.
-use alloy_primitives::{B256, U256};
+//! This only works when reth node is stopped and the chain moved forward form its synced state
+//! It downloads block aftre the last one synced and re-executes all the txs in it.
+use alloy_provider::Provider;
 use clap::Parser;
+use eyre::Context;
 use itertools::Itertools;
 use rbuilder::{
-    building::{
-        sim::simulate_all_orders_with_sim_tree, BlockBuildingContext, BlockState, PartialBlock,
-    },
+    building::{BlockBuildingContext, BlockState, PartialBlock, PartialBlockFork},
     live_builder::{base_config::load_config_toml_and_env, cli::LiveBuilderConfig, config::Config},
-    primitives::{MempoolTx, Order, TransactionSignedEcRecoveredWithBlobs},
-    roothash::RootHashMode,
-    utils::{default_cfg_env, Signer},
+    utils::{extract_onchain_block_txs, find_suggested_fee_recipient, http_provider},
 };
-use reth::{
-    payload::PayloadId,
-    providers::{BlockNumReader, BlockReader},
-};
-use reth_payload_builder::{database::CachedReads, EthPayloadBuilderAttributes};
+use reth::providers::BlockNumReader;
+use reth_payload_builder::database::CachedReads;
 use reth_provider::StateProvider;
-use revm_primitives::{BlobExcessGasAndPrice, BlockEnv, SpecId};
 use std::{path::PathBuf, sync::Arc, time::Instant};
+use tracing::{debug, info};
 
 #[derive(Parser, Debug)]
 struct Cli {
     #[clap(long, help = "bench iterations", default_value = "20")]
     iters: usize,
-    #[clap(help = "Config file path")]
+    #[clap(
+        long,
+        help = "external block provider",
+        env = "RPC_URL",
+        default_value = "http://127.0.0.1:8545"
+    )]
+    rpc_url: String,
+    #[clap(long, help = "Config file path", env = "RBUILDER_CONFIG")]
     config: PathBuf,
 }
 
@@ -36,7 +38,9 @@ async fn main() -> eyre::Result<()> {
     let config: Config = load_config_toml_and_env(cli.config)?;
     config.base_config().setup_tracing_subsriber()?;
 
-    let chain = config.base_config().chain_spec()?;
+    let rpc = http_provider(cli.rpc_url.parse()?);
+
+    let chain_spec = config.base_config().chain_spec()?;
 
     let factory = config
         .base_config()
@@ -44,99 +48,96 @@ async fn main() -> eyre::Result<()> {
         .provider_factory_unchecked();
 
     let last_block = factory.last_block_number()?;
-    let block_data = factory
-        .block_by_number(last_block)?
-        .ok_or_else(|| eyre::eyre!("Block not found"))?;
 
-    let signer = Signer::try_from_secret(B256::random())?;
+    let onchain_block = rpc
+        .get_block_by_number((last_block + 1).into(), true)
+        .await?
+        .ok_or_else(|| eyre::eyre!("block not found on rpc"))?;
 
-    let cfg_env = default_cfg_env(&chain, block_data.timestamp);
-
-    let ctx = BlockBuildingContext {
-        block_env: BlockEnv {
-            number: U256::from(block_data.number),
-            coinbase: signer.address,
-            timestamp: U256::from(block_data.timestamp),
-            gas_limit: U256::from(block_data.gas_limit),
-            basefee: U256::from(block_data.base_fee_per_gas.unwrap_or_default()),
-            difficulty: Default::default(),
-            prevrandao: Some(block_data.difficulty.into()),
-            blob_excess_gas_and_price: block_data.excess_blob_gas.map(BlobExcessGasAndPrice::new),
-        },
-        initialized_cfg: cfg_env,
-        attributes: EthPayloadBuilderAttributes {
-            id: PayloadId::new([0u8; 8]),
-            parent: block_data.parent_hash,
-            timestamp: block_data.timestamp,
-            suggested_fee_recipient: Default::default(),
-            prev_randao: Default::default(),
-            withdrawals: block_data.withdrawals.clone().unwrap_or_default(),
-            parent_beacon_block_root: block_data.parent_beacon_block_root,
-        },
-        chain_spec: chain.clone(),
-        builder_signer: Some(signer),
-        extra_data: Vec::new(),
-        blocklist: Default::default(),
-        excess_blob_gas: block_data.excess_blob_gas,
-        spec_id: SpecId::LATEST,
-    };
-
-    // Get the landed orders (all Order::Tx) from the block
-    let orders = block_data
-        .body
-        .iter()
-        .map(|tx| {
-            let tx = tx
-                .try_ecrecovered()
-                .ok_or_else(|| eyre::eyre!("Failed to recover tx"))?;
-            let tx = TransactionSignedEcRecoveredWithBlobs::new_for_testing(tx);
-            let tx = MempoolTx::new(tx);
-            Ok::<_, eyre::Error>(Order::Tx(tx))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let mut state_provider =
-        Arc::<dyn StateProvider>::from(factory.history_by_block_number(block_data.number - 1)?);
-    let (sim_orders, _) = simulate_all_orders_with_sim_tree(factory.clone(), &ctx, &orders, false)?;
-
-    tracing::info!(
-        "Block: {}, simulated orders: {}",
-        block_data.number,
-        sim_orders.len()
+    let txs = extract_onchain_block_txs(&onchain_block)?;
+    let suggested_fee_recipient = find_suggested_fee_recipient(&onchain_block, &txs);
+    info!(
+        "Block number: {}, txs: {}",
+        onchain_block.header.number,
+        txs.len()
     );
 
-    let mut build_times_mus = Vec::new();
-    let mut finalize_time_mus = Vec::new();
+    let coinbase = onchain_block.header.miner;
+
+    let ctx = BlockBuildingContext::from_onchain_block(
+        onchain_block,
+        chain_spec,
+        None,
+        Default::default(),
+        coinbase,
+        suggested_fee_recipient,
+        None,
+    );
+
+    // let signer = Signer::try_from_secret(B256::random())?;
+
+    let state_provider =
+        Arc::<dyn StateProvider>::from(factory.history_by_block_number(last_block)?);
+
+    let mut build_times_ms = Vec::new();
+    let mut finalize_time_ms = Vec::new();
     let mut cached_reads = Some(CachedReads::default());
     for _ in 0..cli.iters {
-        let mut partial_block = PartialBlock::new(true, None);
-        let mut block_state =
-            BlockState::new_arc(state_provider).with_cached_reads(cached_reads.unwrap_or_default());
-        let build_time = Instant::now();
-        partial_block.pre_block_call(&ctx, &mut block_state)?;
-        for order in &sim_orders {
-            let _ = partial_block.commit_order(order, &ctx, &mut block_state)?;
-        }
-        let build_time = build_time.elapsed();
+        let ctx = ctx.clone();
+        let txs = txs.clone();
+        let state_provider = state_provider.clone();
+        let factory = factory.clone();
+        let config = config.clone();
+        let root_hash_config = config.base_config.live_root_hash_config()?;
+        let (new_cached_reads, build_time, finalize_time) =
+            tokio::task::spawn_blocking(move || -> eyre::Result<_> {
+                let partial_block = PartialBlock::new(true, None);
+                let mut state = BlockState::new_arc(state_provider)
+                    .with_cached_reads(cached_reads.unwrap_or_default());
 
-        let finalize_time = Instant::now();
-        let finalized_block = partial_block.finalize(
-            &mut block_state,
-            &ctx,
-            factory.clone(),
-            RootHashMode::IgnoreParentHash,
-            config.base_config().root_hash_task_pool()?,
-        )?;
-        let finalize_time = finalize_time.elapsed();
+                let build_time = Instant::now();
 
-        cached_reads = Some(finalized_block.cached_reads);
+                let mut cumulative_gas_used = 0;
+                let mut cumulative_blob_gas_used = 0;
+                for (idx, tx) in txs.into_iter().enumerate() {
+                    let result = {
+                        let mut fork = PartialBlockFork::new(&mut state);
+                        fork.commit_tx(&tx, &ctx, cumulative_gas_used, 0, cumulative_blob_gas_used)?
+                            .with_context(|| {
+                                format!("Failed to commit tx: {} {:?}", idx, tx.hash())
+                            })?
+                    };
+                    cumulative_gas_used += result.gas_used;
+                    cumulative_blob_gas_used += result.blob_gas_used;
+                }
 
-        build_times_mus.push(build_time.as_micros());
-        finalize_time_mus.push(finalize_time.as_micros());
-        state_provider = block_state.into_provider();
+                let build_time = build_time.elapsed();
+
+                let finalize_time = Instant::now();
+                let finalized_block = partial_block.finalize(
+                    &mut state,
+                    &ctx,
+                    factory.clone(),
+                    root_hash_config.clone(),
+                    config.base_config().root_hash_task_pool()?,
+                )?;
+                let finalize_time = finalize_time.elapsed();
+
+                debug!(
+                    "Calculated root hash: {:?}",
+                    finalized_block.sealed_block.state_root
+                );
+
+                Ok((finalized_block.cached_reads, build_time, finalize_time))
+            })
+            .await??;
+
+        cached_reads = Some(new_cached_reads);
+        build_times_ms.push(build_time.as_millis());
+        finalize_time_ms.push(finalize_time.as_millis());
     }
-    report_time_data("build", &build_times_mus);
-    report_time_data("finalize", &finalize_time_mus);
+    report_time_data("build", &build_times_ms);
+    report_time_data("finalize", &finalize_time_ms);
 
     Ok(())
 }

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -34,7 +34,7 @@ use rbuilder::{
         mev_boost::{MevBoostRelay, RelayConfig},
         SimulatedOrder,
     },
-    roothash::RootHashMode,
+    roothash::RootHashConfig,
     utils::Signer,
 };
 use reth::{providers::ProviderFactory, tasks::pool::BlockingTaskPool};
@@ -199,7 +199,7 @@ impl DummyBuildingAlgorithm {
         let mut block_building_helper = BlockBuildingHelperFromDB::new(
             provider_factory.clone(),
             self.root_hash_task_pool.clone(),
-            RootHashMode::CorrectRoot,
+            RootHashConfig::live_config(false, false),
             ctx.clone(),
             None,
             BUILDER_NAME.to_string(),

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -21,7 +21,7 @@ use crate::{
         Sorting,
     },
     primitives::SimulatedOrder,
-    roothash::RootHashMode,
+    roothash::RootHashConfig,
     telemetry,
 };
 
@@ -95,7 +95,7 @@ pub struct BlockBuildingHelperFromDB<DB> {
     /// Needed to get the initial state and the final root hash calculation.
     provider_factory: ProviderFactory<DB>,
     root_hash_task_pool: BlockingTaskPool,
-    root_hash_mode: RootHashMode,
+    root_hash_config: RootHashConfig,
     /// Token to cancel in case of fatal error (if we believe that it's impossible to build for this block).
     cancel_on_fatal_error: CancellationToken,
 }
@@ -134,7 +134,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
     pub fn new(
         provider_factory: ProviderFactory<DB>,
         root_hash_task_pool: BlockingTaskPool,
-        root_hash_mode: RootHashMode,
+        root_hash_config: RootHashConfig,
         building_ctx: BlockBuildingContext,
         cached_reads: Option<CachedReads>,
         builder_name: String,
@@ -177,7 +177,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
             built_block_trace: BuiltBlockTrace::new(),
             provider_factory,
             root_hash_task_pool,
-            root_hash_mode,
+            root_hash_config,
             cancel_on_fatal_error,
         })
     }
@@ -325,7 +325,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelper
             &mut self.block_state,
             &self.building_ctx,
             self.provider_factory.clone(),
-            self.root_hash_mode,
+            self.root_hash_config,
             self.root_hash_task_pool,
         ) {
             Ok(finalized_block) => finalized_block,

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     building::{BlockBuildingContext, BlockOrders, BuiltBlockTrace, SimulatedOrderSink, Sorting},
     live_builder::{payload_events::MevBoostSlotData, simulation::SimulatedOrderCommand},
     primitives::{AccountNonce, OrderId, SimulatedOrder},
+    roothash::RootHashConfig,
     utils::{is_provider_factory_health_error, NonceCache},
 };
 use ahash::HashSet;
@@ -37,6 +38,7 @@ pub struct Block {
 #[derive(Debug)]
 pub struct LiveBuilderInput<DB: Database> {
     pub provider_factory: ProviderFactory<DB>,
+    pub root_hash_config: RootHashConfig,
     pub root_hash_task_pool: BlockingTaskPool,
     pub ctx: BlockBuildingContext,
     pub input: broadcast::Receiver<SimulatedOrderCommand>,

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -11,11 +11,12 @@ pub mod sim;
 pub mod testing;
 pub mod tracers;
 pub use block_orders::BlockOrders;
+use eth_sparse_mpt::SparseTrieSharedCache;
 use reth_primitives::proofs::calculate_requests_root;
 
 use crate::{
     primitives::{Order, OrderId, SimValue, SimulatedOrder, TransactionSignedEcRecoveredWithBlobs},
-    roothash::calculate_state_root,
+    roothash::{calculate_state_root, RootHashConfig},
     utils::{a2r_withdrawal, calc_gas_limit, timestamp_as_u64, Signer},
 };
 use ahash::HashSet;
@@ -50,7 +51,7 @@ use thiserror::Error;
 use time::OffsetDateTime;
 
 use self::tracers::SimulationTracer;
-use crate::{roothash::RootHashMode, utils::default_cfg_env};
+use crate::utils::default_cfg_env;
 pub use block_orders::*;
 pub use built_block_trace::*;
 #[cfg(test)]
@@ -76,6 +77,7 @@ pub struct BlockBuildingContext {
     pub excess_blob_gas: Option<u64>,
     /// Version of the EVM that we are going to use
     pub spec_id: SpecId,
+    pub shared_sparse_mpt_cache: SparseTrieSharedCache,
 }
 
 impl BlockBuildingContext {
@@ -141,6 +143,7 @@ impl BlockBuildingContext {
             extra_data,
             excess_blob_gas,
             spec_id,
+            shared_sparse_mpt_cache: Default::default(),
         }
     }
 
@@ -225,6 +228,7 @@ impl BlockBuildingContext {
             extra_data: Vec::new(),
             excess_blob_gas: onchain_block.header.excess_blob_gas.map(|b| b as u64),
             spec_id,
+            shared_sparse_mpt_cache: Default::default(),
         }
     }
 
@@ -555,7 +559,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         state: &mut BlockState,
         ctx: &BlockBuildingContext,
         provider_factory: ProviderFactory<DB>,
-        root_hash_mode: RootHashMode,
+        root_hash_config: RootHashConfig,
         root_hash_task_pool: BlockingTaskPool,
     ) -> eyre::Result<FinalizeResult> {
         let (withdrawals_root, withdrawals) = {
@@ -619,8 +623,9 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             provider_factory,
             ctx.attributes.parent,
             &execution_outcome,
-            root_hash_mode,
             root_hash_task_pool,
+            ctx.shared_sparse_mpt_cache.clone(),
+            root_hash_config,
         )?;
 
         // create the block header

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -28,6 +28,7 @@ use crate::{
     },
     mev_boost::BLSBlockSigner,
     primitives::mev_boost::{MevBoostRelay, RelayConfig},
+    roothash::RootHashConfig,
     utils::{build_info::rbuilder_version, ProviderFactoryReopener, Signer},
     validation_api_client::ValidationAPIClient,
 };
@@ -294,9 +295,11 @@ impl LiveBuilderConfig for Config {
             .base_config
             .create_builder(cancellation_token, sink_factory, payload_event)
             .await?;
+        let root_hash_config = self.base_config.live_root_hash_config()?;
         let root_hash_task_pool = self.base_config.root_hash_task_pool()?;
         let builders = create_builders(
             self.live_builders()?,
+            root_hash_config,
             root_hash_task_pool,
             self.base_config.sbundle_mergeabe_signers(),
         );
@@ -423,23 +426,33 @@ pub fn coinbase_signer_from_secret_key(secret_key: &str) -> eyre::Result<Signer>
 
 fn create_builders(
     configs: Vec<BuilderConfig>,
+    root_hash_config: RootHashConfig,
     root_hash_task_pool: BlockingTaskPool,
     sbundle_mergeabe_signers: Vec<Address>,
 ) -> Vec<Arc<dyn BlockBuildingAlgorithm<Arc<DatabaseEnv>>>> {
     configs
         .into_iter()
-        .map(|cfg| create_builder(cfg, &root_hash_task_pool, &sbundle_mergeabe_signers))
+        .map(|cfg| {
+            create_builder(
+                cfg,
+                &root_hash_config,
+                &root_hash_task_pool,
+                &sbundle_mergeabe_signers,
+            )
+        })
         .collect()
 }
 
 fn create_builder(
     cfg: BuilderConfig,
+    root_hash_config: &RootHashConfig,
     root_hash_task_pool: &BlockingTaskPool,
     sbundle_mergeabe_signers: &[Address],
 ) -> Arc<dyn BlockBuildingAlgorithm<Arc<DatabaseEnv>>> {
     match cfg.builder {
         SpecificBuilderConfig::OrderingBuilder(order_cfg) => {
             Arc::new(OrderingBuildingAlgorithm::new(
+                root_hash_config.clone(),
                 root_hash_task_pool.clone(),
                 sbundle_mergeabe_signers.to_vec(),
                 order_cfg,

--- a/crates/rbuilder/src/roothash/mod.rs
+++ b/crates/rbuilder/src/roothash/mod.rs
@@ -1,10 +1,14 @@
 use alloy_primitives::B256;
+use eth_sparse_mpt::reth_sparse_trie::{
+    calculate_root_hash_with_sparse_trie, SparseTrieError, SparseTrieSharedCache,
+};
 use reth::{
     providers::{providers::ConsistentDbView, ExecutionOutcome, ProviderFactory},
     tasks::pool::BlockingTaskPool,
 };
 use reth_db::database::Database;
 use reth_trie_parallel::async_root::{AsyncStateRoot, AsyncStateRootError};
+use tracing::trace;
 
 #[derive(Debug, Clone, Copy)]
 pub enum RootHashMode {
@@ -19,15 +23,51 @@ pub enum RootHashMode {
     SkipRootHash,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum RootHashError {
+    #[error("Async state root: {0:?}")]
+    AsyncStateRoot(#[from] AsyncStateRootError),
+    #[error("Sparse state root: {0:?}")]
+    SparseStateRoot(#[from] SparseTrieError),
+    #[error("State root verification error")]
+    Verification,
+}
+
+#[derive(Debug, Clone)]
+pub struct RootHashConfig {
+    pub mode: RootHashMode,
+    pub use_sparse_trie: bool,
+    pub compare_sparse_trie_output: bool,
+}
+
+impl RootHashConfig {
+    pub fn skip_root_hash() -> Self {
+        Self {
+            mode: RootHashMode::SkipRootHash,
+            use_sparse_trie: false,
+            compare_sparse_trie_output: false,
+        }
+    }
+
+    pub fn live_config(use_sparse_trie: bool, compare_sparse_trie_output: bool) -> Self {
+        Self {
+            mode: RootHashMode::CorrectRoot,
+            use_sparse_trie,
+            compare_sparse_trie_output,
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn calculate_state_root<DB: Database + Clone + 'static>(
     provider_factory: ProviderFactory<DB>,
     parent_hash: B256,
     outcome: &ExecutionOutcome,
-    mode: RootHashMode,
     blocking_task_pool: BlockingTaskPool,
-) -> Result<B256, AsyncStateRootError> {
-    let consistent_db_view = match mode {
+    sparse_trie_shared_cache: SparseTrieSharedCache,
+    config: RootHashConfig,
+) -> Result<B256, RootHashError> {
+    let consistent_db_view = match config.mode {
         RootHashMode::CorrectRoot => ConsistentDbView::new(provider_factory, Some(parent_hash)),
         RootHashMode::IgnoreParentHash => ConsistentDbView::new_with_latest_tip(provider_factory)
             .map_err(AsyncStateRootError::Provider)?,
@@ -36,11 +76,40 @@ pub fn calculate_state_root<DB: Database + Clone + 'static>(
         }
     };
 
-    let hashed_post_state = outcome.hash_state_slow();
+    let reference_root_hash = if config.compare_sparse_trie_output {
+        let hashed_post_state = outcome.hash_state_slow();
 
-    let async_root_calculator =
-        AsyncStateRoot::new(consistent_db_view, blocking_task_pool, hashed_post_state);
-    let root = futures::executor::block_on(async_root_calculator.incremental_root())?;
+        let async_root_calculator = AsyncStateRoot::new(
+            consistent_db_view.clone(),
+            blocking_task_pool.clone(),
+            hashed_post_state.clone(),
+        );
+
+        futures::executor::block_on(async_root_calculator.incremental_root())?
+    } else {
+        B256::ZERO
+    };
+
+    let root = if config.use_sparse_trie {
+        let (root, metrics) = calculate_root_hash_with_sparse_trie(
+            consistent_db_view,
+            outcome,
+            sparse_trie_shared_cache,
+        );
+        trace!(?metrics, "Sparse trie metrics");
+        root?
+    } else {
+        let hashed_post_state = outcome.hash_state_slow();
+
+        let async_root_calculator =
+            AsyncStateRoot::new(consistent_db_view, blocking_task_pool, hashed_post_state);
+
+        futures::executor::block_on(async_root_calculator.incremental_root())?
+    };
+
+    if config.compare_sparse_trie_output && reference_root_hash != root {
+        return Err(RootHashError::Verification);
+    }
 
     Ok(root)
 }

--- a/crates/rbuilder/src/utils/mod.rs
+++ b/crates/rbuilder/src/utils/mod.rs
@@ -14,19 +14,22 @@ pub mod test_utils;
 pub mod tracing;
 
 use alloy_network::Ethereum;
-use alloy_primitives::{Sign, I256, U256};
+use alloy_primitives::{Address, Sign, I256, U256};
 use alloy_provider::RootProvider;
 use alloy_transport::BoxTransport;
 
-use reth_chainspec::ChainSpec;
-use reth_evm_ethereum::revm_spec_by_timestamp_after_merge;
-use revm_primitives::{CfgEnv, CfgEnvWithHandlerCfg};
-use std::cmp::{max, min};
-
+use crate::primitives::serialize::{RawTx, TxEncoding};
+use crate::primitives::TransactionSignedEcRecoveredWithBlobs;
+use alloy_consensus::TxEnvelope;
+use alloy_eips::eip2718::Encodable2718;
 pub use noncer::{NonceCache, NonceCacheRef};
 pub use provider_factory_reopen::{
     check_provider_factory_health, is_provider_factory_health_error, ProviderFactoryReopener,
 };
+use reth_chainspec::ChainSpec;
+use reth_evm_ethereum::revm_spec_by_timestamp_after_merge;
+use revm_primitives::{CfgEnv, CfgEnvWithHandlerCfg};
+use std::cmp::{max, min};
 pub use test_data_generator::TestDataGenerator;
 use time::OffsetDateTime;
 pub use tx_signer::Signer;
@@ -199,6 +202,40 @@ pub fn signed_uint_delta(a: U256, b: U256) -> I256 {
     let a = I256::checked_from_sign_and_abs(Sign::Positive, a).expect("A is too big");
     let b = I256::checked_from_sign_and_abs(Sign::Positive, b).expect("B is too big");
     a.checked_sub(b).expect("Subtraction overflow")
+}
+
+pub fn find_suggested_fee_recipient(
+    block: &alloy_rpc_types::Block,
+    txs: &[TransactionSignedEcRecoveredWithBlobs],
+) -> Address {
+    let coinbase = block.header.miner;
+    let (last_tx_signer, last_tx_to) = if let Some((signer, to)) = txs
+        .last()
+        .map(|tx| (tx.signer(), tx.to().unwrap_or_default()))
+    {
+        (signer, to)
+    } else {
+        return coinbase;
+    };
+
+    if last_tx_signer == coinbase {
+        last_tx_to
+    } else {
+        coinbase
+    }
+}
+
+pub fn extract_onchain_block_txs(
+    onchain_block: &alloy_rpc_types::Block,
+) -> eyre::Result<Vec<TransactionSignedEcRecoveredWithBlobs>> {
+    let mut result = Vec::new();
+    for tx in onchain_block.transactions.clone().into_transactions() {
+        let tx_envelope: TxEnvelope = tx.try_into()?;
+        let encoded = tx_envelope.encoded_2718();
+        let tx = RawTx { tx: encoded.into() }.decode(TxEncoding::NoBlobData)?;
+        result.push(tx.tx_with_blobs);
+    }
+    Ok(result)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Faster root hash

This pr introduces option to use sparse merkle trie implementation for the root hash calculation.

This implementation fetches relevant pieces of the trie into memory making subsequent root hash calculations faster.

On my PC reference implementation takes about 150ms to calculate hash and the new one when everything is prefetched around 5ms. 

Fetching proof for data for one uncached account takes about 0.25ms.

There are things to improve in implementation itself but the basic interface for the integration into the builder will be the same. 


## debug-bench-machine

This PR also redoes debug-bench-machine.  Now you need to stop reth node and provide external rpc for it to work. 

The reason is that reth has trie only for the last block. Previous implementation used last block to generate changes and it applied that changes to the trie after the last block. Trie would already have these changes but default reth root hash does not care about that discrepancy and it would evaluate anyway, this was used as a hack to benchmark trie even though it would give incorrect results. 

Sparse trie implemenation would not work like that because it would detect errors such as removing key that was already removed from the trie. 

The benefit of this is that we can actually check correctness of the root hash on historical block.



---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
