### PR TITLE
Filter external logs

### DIFF
--- a/crates/rbuilder/src/lib.rs
+++ b/crates/rbuilder/src/lib.rs
@@ -5,6 +5,7 @@ pub mod integration;
 pub mod live_builder;
 pub mod mev_boost;
 pub mod primitives;
+pub mod privacy;
 pub mod roothash;
 pub mod telemetry;
 pub mod utils;

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -48,6 +48,8 @@ pub struct BaseConfig {
     pub log_json: bool,
     log_level: EnvOrValue<String>,
     pub log_color: bool,
+    /// Enables dynamic logging (saving logs to a file)
+    pub log_enable_dynamic: bool,
 
     pub error_storage_path: Option<PathBuf>,
 
@@ -371,6 +373,7 @@ impl Default for BaseConfig {
             log_json: false,
             log_level: "info".into(),
             log_color: false,
+            log_enable_dynamic: false,
             error_storage_path: None,
             coinbase_secret_key: "".into(),
             flashbots_db: None,

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -26,7 +26,7 @@ use std::{
 };
 use tokio::time::{sleep, Instant};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info_span, trace, warn, Instrument, Level};
+use tracing::{debug, error, event, info_span, trace, warn, Instrument, Level};
 
 use super::bid_observer::BidObserver;
 

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -83,6 +83,7 @@ pub async fn run<ConfigType: LiveBuilderConfig>(
     spawn_telemetry_server(
         config.base_config().telemetry_address(),
         config.version_for_telemetry(),
+        config.base_config().log_enable_dynamic,
     )
     .await?;
     let builder = config.create_builder(cancel.clone()).await?;

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -28,6 +28,7 @@ use crate::{
     },
     mev_boost::BLSBlockSigner,
     primitives::mev_boost::{MevBoostRelay, RelayConfig},
+    privacy::error_redactor::ErrorRedactor,
     utils::{build_info::rbuilder_version, ProviderFactoryReopener, Signer},
     validation_api_client::ValidationAPIClient,
 };
@@ -240,6 +241,7 @@ impl L1Config {
         &self,
         chain_spec: Arc<ChainSpec>,
         bid_observer: Box<dyn BidObserver + Send + Sync>,
+        redactor: Arc<ErrorRedactor>,
     ) -> eyre::Result<(Box<dyn BuilderSinkFactory>, Vec<MevBoostRelay>)> {
         let submission_config = self.submission_config(chain_spec, bid_observer)?;
         info!(
@@ -261,6 +263,7 @@ impl L1Config {
         let sink_factory: Box<dyn BuilderSinkFactory> = Box::new(RelaySubmitSinkFactory::new(
             submission_config,
             relays.clone(),
+            redactor,
         ));
         Ok((sink_factory, relays))
     }
@@ -275,9 +278,11 @@ impl LiveBuilderConfig for Config {
         &self,
         cancellation_token: tokio_util::sync::CancellationToken,
     ) -> eyre::Result<super::LiveBuilder<Arc<DatabaseEnv>, MevBoostSlotDataGenerator>> {
+        let error_redactor = self.base_config().create_error_redactor();
         let (sink_sealed_factory, relays) = self.l1_config.create_relays_sealed_sink_factory(
             self.base_config.chain_spec()?,
             Box::new(NullBidObserver {}),
+            error_redactor,
         )?;
         let sink_factory = Box::new(BlockFinisherFactory::new(
             Box::new(DummyBiddingService {}),

--- a/crates/rbuilder/src/privacy/error_redactor.rs
+++ b/crates/rbuilder/src/privacy/error_redactor.rs
@@ -1,0 +1,36 @@
+use crate::validation_api_client::ValidationError;
+
+use super::validation::{SecureValidationErrorRedactor, ShowAllValidationErrorRedactor};
+
+/// Entry point struct for all errors.
+pub struct ErrorRedactor {
+    validation: Box<dyn ValidationErrorRedactor>,
+}
+
+impl std::fmt::Debug for ErrorRedactor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ErrorRedactor")
+    }
+}
+
+impl ErrorRedactor {
+    pub fn new_show_all() -> Self {
+        Self {
+            validation: Box::new(ShowAllValidationErrorRedactor {}),
+        }
+    }
+
+    pub fn new_secure() -> Self {
+        Self {
+            validation: Box::new(SecureValidationErrorRedactor {}),
+        }
+    }
+
+    pub fn validation(&self) -> &dyn ValidationErrorRedactor {
+        self.validation.as_ref()
+    }
+}
+
+pub trait ValidationErrorRedactor: Sync + Send {
+    fn redact(&self, err: ValidationError) -> ValidationError;
+}

--- a/crates/rbuilder/src/privacy/error_redactor.rs
+++ b/crates/rbuilder/src/privacy/error_redactor.rs
@@ -1,10 +1,16 @@
-use crate::validation_api_client::ValidationError;
+use std::sync::Arc;
 
-use super::validation::{SecureValidationErrorRedactor, ShowAllValidationErrorRedactor};
+use crate::{mev_boost::SubmitBlockErr, validation_api_client::ValidationError};
+
+use super::{
+    relay::{SecureRelayErrorRedactor, ShowAllRelayErrorRedactor},
+    validation::{SecureValidationErrorRedactor, ShowAllValidationErrorRedactor},
+};
 
 /// Entry point struct for all errors.
 pub struct ErrorRedactor {
-    validation: Box<dyn ValidationErrorRedactor>,
+    validation: Arc<dyn ValidationErrorRedactor>,
+    relay: Arc<dyn RelayErrorRedactor>,
 }
 
 impl std::fmt::Debug for ErrorRedactor {
@@ -16,21 +22,32 @@ impl std::fmt::Debug for ErrorRedactor {
 impl ErrorRedactor {
     pub fn new_show_all() -> Self {
         Self {
-            validation: Box::new(ShowAllValidationErrorRedactor {}),
+            validation: Arc::new(ShowAllValidationErrorRedactor {}),
+            relay: Arc::new(ShowAllRelayErrorRedactor {}),
         }
     }
 
     pub fn new_secure() -> Self {
         Self {
-            validation: Box::new(SecureValidationErrorRedactor {}),
+            validation: Arc::new(SecureValidationErrorRedactor {}),
+            relay: Arc::new(SecureRelayErrorRedactor {}),
         }
     }
 
-    pub fn validation(&self) -> &dyn ValidationErrorRedactor {
-        self.validation.as_ref()
+    pub fn validation(&self) -> Arc<dyn ValidationErrorRedactor> {
+        self.validation.clone()
+    }
+
+    pub fn relay(&self) -> Arc<dyn RelayErrorRedactor> {
+        self.relay.clone()
     }
 }
 
 pub trait ValidationErrorRedactor: Sync + Send {
     fn redact(&self, err: ValidationError) -> ValidationError;
+}
+
+pub trait RelayErrorRedactor: Sync + Send {
+    fn redact(&self, err: SubmitBlockErr) -> SubmitBlockErr;
+    fn redact_sim_error(&self, err: String) -> String;
 }

--- a/crates/rbuilder/src/privacy/mod.rs
+++ b/crates/rbuilder/src/privacy/mod.rs
@@ -2,6 +2,7 @@
 //! This module contains all redacting stuff to achieve that.
 //! We try to keep this redacting always configurable so we can have the full data for development.
 pub mod error_redactor;
+pub mod relay;
 pub mod validation;
 
 /// Constant for redacted content

--- a/crates/rbuilder/src/privacy/mod.rs
+++ b/crates/rbuilder/src/privacy/mod.rs
@@ -1,0 +1,8 @@
+//! In some installations (eg: TDX) we may want to avoid ever exposing some information.
+//! This module contains all redacting stuff to achieve that.
+//! We try to keep this redacting always configurable so we can have the full data for development.
+pub mod error_redactor;
+pub mod validation;
+
+/// Constant for redacted content
+const REDACTED: &str = "[REDACTED]";

--- a/crates/rbuilder/src/privacy/relay.rs
+++ b/crates/rbuilder/src/privacy/relay.rs
@@ -1,0 +1,66 @@
+use crate::mev_boost::{get_reqwest_error_kind, RelayError, SubmitBlockErr};
+
+use super::{error_redactor::RelayErrorRedactor, REDACTED};
+
+/// Struct representing a redactor that shows all relay errors without modification.
+pub struct ShowAllRelayErrorRedactor {}
+
+/// Implementation of RelayErrorRedactor for ShowAllRelayErrorRedactor.
+impl RelayErrorRedactor for ShowAllRelayErrorRedactor {
+    /// Redact method that simply returns the error without any modification.
+    fn redact(&self, err: SubmitBlockErr) -> SubmitBlockErr {
+        err
+    }
+
+    fn redact_sim_error(&self, err: String) -> String {
+        err
+    }
+}
+
+/// Struct representing a redactor that avoids exposing any info about txs.
+/// Every string with unpredictable content is redacted.
+pub struct SecureRelayErrorRedactor {}
+
+impl RelayErrorRedactor for SecureRelayErrorRedactor {
+    fn redact(&self, err: SubmitBlockErr) -> SubmitBlockErr {
+        match err {
+            SubmitBlockErr::RelayError(err) => SubmitBlockErr::RelayError(redact_relay_error(err)),
+            SubmitBlockErr::PayloadAttributesNotKnown => SubmitBlockErr::PayloadAttributesNotKnown,
+            SubmitBlockErr::PastSlot => SubmitBlockErr::PastSlot,
+            SubmitBlockErr::PayloadDelivered => SubmitBlockErr::PayloadDelivered,
+            SubmitBlockErr::BidBelowFloor => SubmitBlockErr::BidBelowFloor,
+            SubmitBlockErr::SimError(text) => SubmitBlockErr::SimError(self.redact_sim_error(text)),
+            SubmitBlockErr::RPCConversionError(err) => SubmitBlockErr::RPCConversionError(err),
+            SubmitBlockErr::RPCSerializationError(_) => {
+                SubmitBlockErr::RPCSerializationError(REDACTED.to_string())
+            }
+            SubmitBlockErr::InvalidHeader => SubmitBlockErr::InvalidHeader,
+            SubmitBlockErr::BlockKnown => SubmitBlockErr::BlockKnown,
+        }
+    }
+
+    fn redact_sim_error(&self, _: String) -> String {
+        REDACTED.to_string()
+    }
+}
+
+/// Redacts sensitive information from RelayError variants.
+/// This function ensures that no potentially sensitive data is exposed in error messages.
+fn redact_relay_error(err: RelayError) -> RelayError {
+    match err {
+        RelayError::RequestError(err) => {
+            RelayError::RedactedRequestError(get_reqwest_error_kind(&err))
+        }
+        RelayError::InvalidHeader => RelayError::InvalidHeader,
+        RelayError::RelayError(error) => {
+            RelayError::RelayError(error.with_message(REDACTED.to_string()))
+        }
+        RelayError::UnknownRelayError(status, _) => {
+            RelayError::UnknownRelayError(status, REDACTED.to_string())
+        }
+        RelayError::TooManyRequests => RelayError::TooManyRequests,
+        RelayError::ConnectionError => RelayError::ConnectionError,
+        RelayError::InternalError => RelayError::InternalError,
+        RelayError::RedactedRequestError(kind) => RelayError::RedactedRequestError(kind),
+    }
+}

--- a/crates/rbuilder/src/privacy/validation.rs
+++ b/crates/rbuilder/src/privacy/validation.rs
@@ -1,0 +1,40 @@
+use alloy_json_rpc::ErrorPayload;
+
+use crate::validation_api_client::ValidationError;
+
+use super::{error_redactor::ValidationErrorRedactor, REDACTED};
+
+/// Struct representing a redactor that shows all validation errors without modification.
+pub struct ShowAllValidationErrorRedactor {}
+
+/// Implementation of ValidationErrorRedactor for ShowAllValidationErrorRedactor.
+impl ValidationErrorRedactor for ShowAllValidationErrorRedactor {
+    /// Redact method that simply returns the error without any modification.
+    fn redact(&self, err: ValidationError) -> ValidationError {
+        err
+    }
+}
+
+/// Struct representing a redactor that avoids exposing any info about txs.
+/// Every string with unpredictable content is redacted.
+pub struct SecureValidationErrorRedactor {}
+
+impl ValidationErrorRedactor for SecureValidationErrorRedactor {
+    fn redact(&self, err: ValidationError) -> ValidationError {
+        match err {
+            ValidationError::NoValidationNodes => err,
+            ValidationError::FailedToSerializeRequest => err,
+            ValidationError::NoValidResponseFromValidationNodes => err,
+            ValidationError::ValidationFailed(payload) => {
+                ValidationError::ValidationFailed(ErrorPayload {
+                    code: payload.code,
+                    message: REDACTED.to_string(),
+                    data: None,
+                })
+            }
+            ValidationError::LocalUsageError(_) => {
+                ValidationError::LocalUsageError(Box::from(REDACTED))
+            }
+        }
+    }
+}

--- a/crates/rbuilder/src/telemetry/mod.rs
+++ b/crates/rbuilder/src/telemetry/mod.rs
@@ -54,20 +54,24 @@ async fn reset_log_handle() -> Result<impl Reply, Rejection> {
     }
 }
 
-pub async fn spawn_telemetry_server(addr: SocketAddr, version: Version) -> eyre::Result<()> {
+pub async fn spawn_telemetry_server(
+    addr: SocketAddr,
+    version: Version,
+    enable_dynamic_log: bool,
+) -> eyre::Result<()> {
     set_version(version);
-
     // metrics over /debug/metrics/prometheus
     let metrics_route = warp::path!("debug" / "metrics" / "prometheus").and_then(metrics_handler);
 
-    let log_set_route = warp::path!("debug" / "log" / "set" / String)
-        .and(warp::query::<LogQuery>())
-        .and_then(set_rust_log_handle);
-    let log_reset_route = warp::path!("debug" / "log" / "reset").and_then(reset_log_handle);
-
-    let route = metrics_route.or(log_set_route).or(log_reset_route);
-
-    tokio::spawn(warp::serve(route).run(addr));
+    if enable_dynamic_log {
+        let log_set_route = warp::path!("debug" / "log" / "set" / String)
+            .and(warp::query::<LogQuery>())
+            .and_then(set_rust_log_handle);
+        let log_reset_route = warp::path!("debug" / "log" / "reset").and_then(reset_log_handle);
+        tokio::spawn(warp::serve(metrics_route.or(log_set_route).or(log_reset_route)).run(addr));
+    } else {
+        tokio::spawn(warp::serve(metrics_route).run(addr));
+    }
 
     Ok(())
 }

--- a/crates/rbuilder/src/utils/mod.rs
+++ b/crates/rbuilder/src/utils/mod.rs
@@ -11,6 +11,7 @@ mod tx_signer;
 
 #[cfg(test)]
 pub mod test_utils;
+pub mod tracing;
 
 use alloy_network::Ethereum;
 use alloy_primitives::{Sign, I256, U256};

--- a/crates/rbuilder/src/utils/tracing.rs
+++ b/crates/rbuilder/src/utils/tracing.rs
@@ -1,0 +1,15 @@
+/// Allows to call event! with level as a parameter (event! only allows constants as level parameter)
+#[macro_export]
+macro_rules! dynamic_event {
+    ($level:expr, $($arg:tt)+) => {
+        match $level {
+            Level::TRACE => event!(Level::TRACE, $($arg)+),
+            Level::DEBUG => event!(Level::DEBUG, $($arg)+),
+            Level::INFO => event!(Level::INFO, $($arg)+),
+            Level::WARN => event!(Level::WARN, $($arg)+),
+            Level::ERROR => event!(Level::ERROR, $($arg)+),
+        }
+    };
+}
+
+pub use dynamic_event;

--- a/docs/LOGS_PRIVACY.md
+++ b/docs/LOGS_PRIVACY.md
@@ -1,0 +1,45 @@
+# Logs Privacy in rbuilder
+
+## Introduction
+
+Log privacy in rbuilder refers to the level of data exposed in logs via macros like `error!`. A key principle in rbuilder is that we never log a full order, as this information could be harmful to the order sender.
+
+### Why is this important?
+
+- A non-landed order, if logged in full, could potentially be executed in a later block, causing losses for the order owner.
+- Even if an order has built-in protections against unexpected executions, the order owner might still incur gas fees.
+
+## External Error Redaction
+
+While we don't log full orders ourselves, we sometimes interact with external systems and log their error codes. Since some of these may contain plain strings, we offer an option to redact any error before logging.
+
+### Enabling Error Redaction
+
+To enable external error redaction add the following flag to your configuration:
+   ```
+   redact_errors = true
+   ```
+
+### Example of Error Redaction
+
+Consider this error enum:
+
+```rust
+pub enum SubmitBlockErr {
+    ...
+    RPCSerializationError(String),
+    ...
+}
+
+```
+
+the redaction match branch for this code is:
+
+```rust
+SubmitBlockErr::RPCSerializationError(plain_text) => SubmitBlockErr::RPCSerializationError(REDACTED.to_string())
+```
+
+Where
+```rust
+const REDACTED: &str = "[REDACTED]";
+```


### PR DESCRIPTION
## 📝 Summary
This goes on top of https://github.com/flashbots/rbuilder/pull/171.

This PRs allows a new config:
```
redact_errors = true
```
to allow external systems errors to be redacted.

See https://github.com/flashbots/rbuilder/blob/filter-external-logs/docs/LOGS_PRIVACY.md for more details.

## 💡 Motivation and Context

Protect order senders.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
