### PR TITLE
Add relay_secret_key in live example

### DIFF
--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -10,6 +10,7 @@ reth_datadir = "/mnt/data/reth"
 
 coinbase_secret_key = "env:COINBASE_SECRET_KEY"
 relay_secret_key = "env:RELAY_SECRET_KEY"
+optimistic_relay_secret_key = "env:OPTIMISTIC_RELAY_SECRET_KEY"
 
 # cl_node_url can be a single value, array of values, or passed by an environment variables with values separated with a comma
 # cl_node_url = "http://localhost:3500"

--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -9,6 +9,7 @@ chain = "mainnet"
 reth_datadir = "/mnt/data/reth"
 
 coinbase_secret_key = "env:COINBASE_SECRET_KEY"
+relay_secret_key = "env:RELAY_SECRET_KEY"
 
 # cl_node_url can be a single value, array of values, or passed by an environment variables with values separated with a comma
 # cl_node_url = "http://localhost:3500"


### PR DESCRIPTION
## 📝 Summary

`config-live-example.toml` file does not have RELAY_SECRET_KEY which is required to run rbuilder. added this to make example file easier to run.

## 💡 Motivation and Context

Makes documentation clearer

## ✅ I have completed the following steps:

* [x ] Run `make lint`
* [x ] Run `make test`
