### PR TITLE
 returns None on empty vec

### DIFF
--- a/crates/rbuilder/src/building/block_orders/mod.rs
+++ b/crates/rbuilder/src/building/block_orders/mod.rs
@@ -88,7 +88,7 @@ impl SimulatedOrderStore {
 
     /// Allows to get new adds ONLY if no remove_order was received
     pub fn drain_new_orders(&mut self) -> Option<Vec<SimulatedOrder>> {
-        self.new_orders.replace(Vec::new())
+        self.new_orders.take().filter(|v| !v.is_empty())
     }
 }
 


### PR DESCRIPTION
## 📝 Summary

Changed `drain_new_orders` implementation.
Now it returns `None` if new_orders is an empty Vec

in reference to #180 
