### PR TITLE
feat: Allow for changing cached reads inside of BlockBuildingHelperFromDB

### DIFF
--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -259,11 +259,6 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
         self.built_block_trace.true_bid_value = true_value;
         Ok(())
     }
-
-    /// Updates the cached reads for the block state.
-    pub fn update_cached_reads(&mut self, cached_reads: CachedReads) {
-        self.block_state = self.block_state.clone().with_cached_reads(cached_reads);
-    }
 }
 
 impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelperFromDB<DB> {
@@ -396,6 +391,6 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelper
     }
 
     fn update_cached_reads(&mut self, cached_reads: CachedReads) {
-        self.update_cached_reads(cached_reads);
+        self.block_state = self.block_state.clone().with_cached_reads(cached_reads);
     }
 }

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -74,6 +74,9 @@ pub trait BlockBuildingHelper: Send {
 
     /// BlockBuildingContext used for building.
     fn building_context(&self) -> &BlockBuildingContext;
+
+    /// Updates the cached reads for the block state.
+    fn update_cached_reads(&mut self, cached_reads: CachedReads);
 }
 
 /// Implementation of BlockBuildingHelper based on a ProviderFactory<DB>
@@ -256,6 +259,11 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
         self.built_block_trace.true_bid_value = true_value;
         Ok(())
     }
+
+    /// Updates the cached reads for the block state.
+    pub fn update_cached_reads(&mut self, cached_reads: CachedReads) {
+        self.block_state = self.block_state.clone().with_cached_reads(cached_reads);
+    }
 }
 
 impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelperFromDB<DB> {
@@ -385,5 +393,9 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelper
 
     fn box_clone(&self) -> Box<dyn BlockBuildingHelper> {
         Box::new(self.clone())
+    }
+
+    fn update_cached_reads(&mut self, cached_reads: CachedReads) {
+        self.update_cached_reads(cached_reads);
     }
 }

--- a/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
@@ -100,4 +100,8 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
     fn building_context(&self) -> &BlockBuildingContext {
         &self.block_building_context
     }
+
+    fn update_cached_reads(&mut self, _cached_reads: CachedReads) {
+        unimplemented!()
+    }
 }


### PR DESCRIPTION
#178 

- Added `update_cached_reads` method to the `BlockBuildingHelper` trait
- Implemented `update_cached_reads` for `BlockBuildingHelperFromDB`
- Updated `MockBlockBuildingHelper` to include an unimplemented `update_cached_reads` method

## ✅ I have completed the following steps:

* [ ✅] Run `make lint`
* [✅ ] Run `make test`
