### PR TITLE
New parameter for max concurrent seals

### DIFF
--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -27,6 +27,8 @@ dry_run_validation_url = "http://localhost:8545"
 
 ignore_cancellable_orders = true
 
+max_concurrent_seals = 4
+
 sbundle_mergeabe_signers = []
 # slot_delta_to_start_submits_ms is usually negative since we start bidding BEFORE the slot start
 # slot_delta_to_start_submits_ms = -5000


### PR DESCRIPTION
## 📝 Summary

Adds max_concurrent_seals to the cfg.
1 -> uses SequentialSealerBidMaker
>1 -> uses ParallelSealerBidMaker(max_concurrent_seals)

## 💡 Motivation and Context

Needed to polish the optimal cfg for the new roothash algo.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)

