### PR TITLE
WIP feat(Dockerfile): Add reth to container image so we can run both in same container for kurtosis.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,18 +57,15 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
     cargo build --release --features="$FEATURES"
 
+FROM ethpandaops/reth:main-d6113e1 as reth
 #
-# Runtime container
-#
-FROM gcr.io/distroless/cc-debian12
+## Runtime container with both rbuilder and reth + entrypoint script
+##
+FROM ubuntu:latest AS runtime
 
 WORKDIR /app
 
-# RUN apk add libssl3 ca-certificates
-# RUN apt-get update \
-#     && apt-get install -y libssl3 ca-certificates \
-#     && rm -rf /var/lib/apt/lists/*
-
 COPY --from=builder /app/target/release/rbuilder /app/rbuilder
+COPY --from=reth /usr/local/bin/reth /app/reth
 
-ENTRYPOINT ["/app/rbuilder"]
+EXPOSE 30303 30303/udp 9001 8545 8546


### PR DESCRIPTION

## 📝 Summary

This is a very quick work-around for #199 mainly to unblock @parithosh so he can work on the entrypoint script to start and monitor both binaries.  I used a recent ethpandaops/reth container

Definitely at this point still a draft PR.

At a minimum this still needs:

- [ ] figure out how better to parameterize which reth image to use as the builder container source.
- [ ] add an `ENTRYPOINT`

## 💡 Motivation and Context

The EF devops and reth teams are trying to get `rbuilder` working in kurtosis for pectra `devnet-4`

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
