### PR TITLE
Don't consider profit too low and consistent db err as errors.

### DIFF
--- a/crates/rbuilder/src/live_builder/block_output/bidding/sequential_sealer_bid_maker.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding/sequential_sealer_bid_maker.rs
@@ -95,11 +95,15 @@ impl SequentialSealerBidMakerProcess {
             match tokio::task::spawn_blocking(move || block.finalize_block(payout_tx_val)).await {
                 Ok(finalize_res) => match finalize_res {
                     Ok(res) => self.sink.new_block(res.block),
-                    Err(error) => error!(
-                        block_number,
-                        ?error,
-                        "Error on finalize_block on SequentialSealerBidMaker"
-                    ),
+                    Err(error) => {
+                        if error.is_critical() {
+                            error!(
+                                block_number,
+                                ?error,
+                                "Error on finalize_block on SequentialSealerBidMaker"
+                            )
+                        }
+                    }
                 },
                 Err(error) => error!(
                     block_number,


### PR DESCRIPTION
## 📝 Summary

Currently we log errors that can happen normally
* profit too low (that happens if we don't have enough eth on coinbase yet)
* consisent db view error (that happens if block that we are building for is proposed)


## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
