### PR TITLE
Add option to supply genesis fork version from config

### DIFF
--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -29,6 +29,8 @@ ignore_cancellable_orders = true
 
 max_concurrent_seals = 4
 
+# genesis_fork_version = "0x00112233"
+
 sbundle_mergeabe_signers = []
 # slot_delta_to_start_submits_ms is usually negative since we start bidding BEFORE the slot start
 # slot_delta_to_start_submits_ms = -5000


### PR DESCRIPTION
## 📝 Summary

This PR adds the option to supply the genesis fork version from a flag instead of querying the CL nodes which might not be active yet. 

Closes https://github.com/flashbots/rbuilder/pull/35

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
