### PR TITLE
Root hash prefetcher + small things

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "eth-sparse-mpt"
 version = "0.1.0"
-source = "git+https://github.com/flashbots/eth-sparse-mpt?rev=664759b#664759b53d92e64d9a2e902100691b7ff4945ece"
+source = "git+https://github.com/flashbots/eth-sparse-mpt?rev=5e2713b#5e2713b36206b7a8af4614a69920d6e0bf9826e9"
 dependencies = [
  "alloy-primitives 0.8.0",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "eth-sparse-mpt"
 version = "0.1.0"
-source = "git+https://github.com/flashbots/eth-sparse-mpt?rev=d0d1ea2#d0d1ea2f23595dc9910587c2b215de1bdfc103c6"
+source = "git+https://github.com/flashbots/eth-sparse-mpt?rev=5d0da73#5d0da73e90933a899bad63da18e115fc806adf01"
 dependencies = [
  "alloy-primitives 0.8.0",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "eth-sparse-mpt"
 version = "0.1.0"
-source = "git+https://github.com/flashbots/eth-sparse-mpt?rev=5e2713b#5e2713b36206b7a8af4614a69920d6e0bf9826e9"
+source = "git+https://github.com/flashbots/eth-sparse-mpt?rev=d0d1ea2#d0d1ea2f23595dc9910587c2b215de1bdfc103c6"
 dependencies = [
  "alloy-primitives 0.8.0",
  "alloy-rlp",

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -124,7 +124,7 @@ mockall = "0.12.1"
 shellexpand = "3.1.0"
 async-trait = "0.1.80"
 
-eth-sparse-mpt = { git = "https://github.com/flashbots/eth-sparse-mpt", rev = "664759b" }
+eth-sparse-mpt = { git = "https://github.com/flashbots/eth-sparse-mpt", rev = "5e2713b" }
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2", "chrono"] }

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -124,7 +124,7 @@ mockall = "0.12.1"
 shellexpand = "3.1.0"
 async-trait = "0.1.80"
 
-eth-sparse-mpt = { git = "https://github.com/flashbots/eth-sparse-mpt", rev = "d0d1ea2" }
+eth-sparse-mpt = { git = "https://github.com/flashbots/eth-sparse-mpt", rev = "5d0da73" }
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2", "chrono"] }

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -124,7 +124,7 @@ mockall = "0.12.1"
 shellexpand = "3.1.0"
 async-trait = "0.1.80"
 
-eth-sparse-mpt = { git = "https://github.com/flashbots/eth-sparse-mpt", rev = "5e2713b" }
+eth-sparse-mpt = { git = "https://github.com/flashbots/eth-sparse-mpt", rev = "d0d1ea2" }
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2", "chrono"] }

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -99,6 +99,7 @@ async fn main() -> eyre::Result<()> {
         extra_rpc: RpcModule::new(()),
         sink_factory: Box::new(TraceBlockSinkFactory {}),
         builders: vec![Arc::new(DummyBuildingAlgorithm::new(10))],
+        run_sparse_trie_prefetcher: false,
     };
 
     let ctrlc = tokio::spawn(async move {

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -215,6 +215,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelperFromDB<DB> {
         telemetry::add_built_block_metrics(
             built_block_trace.fill_time,
             built_block_trace.finalize_time,
+            built_block_trace.root_hash_time,
             txs,
             blobs,
             gas_used,
@@ -363,6 +364,7 @@ impl<DB: Database + Clone + 'static> BlockBuildingHelper for BlockBuildingHelper
             }
         };
         self.built_block_trace.update_orders_sealed_at();
+        self.built_block_trace.root_hash_time = finalized_block.root_hash_time;
 
         self.built_block_trace.finalize_time = start_time.elapsed();
 

--- a/crates/rbuilder/src/building/built_block_trace.rs
+++ b/crates/rbuilder/src/building/built_block_trace.rs
@@ -22,6 +22,7 @@ pub struct BuiltBlockTrace {
     pub orders_sealed_at: OffsetDateTime,
     pub fill_time: Duration,
     pub finalize_time: Duration,
+    pub root_hash_time: Duration,
 }
 
 impl Default for BuiltBlockTrace {
@@ -55,6 +56,7 @@ impl BuiltBlockTrace {
             orders_sealed_at: OffsetDateTime::now_utc(),
             fill_time: Duration::from_secs(0),
             finalize_time: Duration::from_secs(0),
+            root_hash_time: Duration::from_secs(0),
         }
     }
 

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -213,6 +213,8 @@ impl BaseConfig {
             extra_rpc: RpcModule::new(()),
             sink_factory,
             builders: Vec::new(),
+
+            run_sparse_trie_prefetcher: self.root_hash_use_sparse_trie,
         })
     }
 

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -63,6 +63,7 @@ pub struct LiveBuilder<DB, BlocksSourceType: SlotSource> {
     pub simulation_threads: usize,
     pub order_input_config: OrderInputConfig,
     pub blocks_source: BlocksSourceType,
+    pub run_sparse_trie_prefetcher: bool,
 
     pub chain_chain_spec: Arc<ChainSpec>,
     pub provider_factory: ProviderFactoryReopener<DB>,
@@ -131,6 +132,7 @@ impl<DB: Database + Clone + 'static, BuilderSourceType: SlotSource>
             self.sink_factory,
             orderpool_subscriber,
             order_simulation_pool,
+            self.run_sparse_trie_prefetcher,
         );
 
         let watchdog_sender = spawn_watchdog_thread(self.watchdog_timeout)?;

--- a/crates/rbuilder/src/roothash/mod.rs
+++ b/crates/rbuilder/src/roothash/mod.rs
@@ -1,3 +1,5 @@
+mod prefetcher;
+
 use alloy_primitives::B256;
 use eth_sparse_mpt::reth_sparse_trie::{
     calculate_root_hash_with_sparse_trie, trie_fetcher::FetchNodeError, SparseTrieError,
@@ -11,6 +13,8 @@ use reth_db::database::Database;
 use reth_errors::ProviderError;
 use reth_trie_parallel::async_root::{AsyncStateRoot, AsyncStateRootError};
 use tracing::trace;
+
+pub use prefetcher::run_trie_prefetcher;
 
 #[derive(Debug, Clone, Copy)]
 pub enum RootHashMode {

--- a/crates/rbuilder/src/roothash/prefetcher.rs
+++ b/crates/rbuilder/src/roothash/prefetcher.rs
@@ -1,0 +1,136 @@
+use std::{iter, time::Instant};
+
+use ahash::{HashMap, HashSet};
+use alloy_primitives::{Address, B256};
+use eth_sparse_mpt::{
+    prefetch_tries_for_accounts,
+    reth_sparse_trie::{trie_fetcher::FetchNodeError, SparseTrieError, SparseTrieSharedCache},
+    ChangedAccountData,
+};
+use reth::providers::{providers::ConsistentDbView, ProviderFactory};
+use reth_db::database::Database;
+use reth_errors::ProviderError;
+use tokio::sync::broadcast::{self, error::TryRecvError};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, trace, warn};
+
+use crate::{building::evm_inspector::SlotKey, live_builder::simulation::SimulatedOrderCommand};
+
+const CONSUME_SIM_ORDERS_BATCH: usize = 128;
+
+/// Runs a process that prefetches pieces of the trie based on the slots used by the order in simulation
+/// Its a blocking call so it should be spawned on the separate thread.
+pub fn run_trie_prefetcher<DB: Database + Clone + 'static>(
+    parent_hash: B256,
+    shared_sparse_mpt_cache: SparseTrieSharedCache,
+    provider_factory: ProviderFactory<DB>,
+    mut simulated_orders: broadcast::Receiver<SimulatedOrderCommand>,
+    cancel: CancellationToken,
+) {
+    let consistent_db_view = ConsistentDbView::new(provider_factory, Some(parent_hash));
+
+    // here we mark data that was fetched for this slot before
+    let mut fetched_accounts: HashSet<Address> = HashSet::default();
+    let mut fetched_slots: HashSet<SlotKey> = HashSet::default();
+
+    // loop local variables
+    let mut used_state_traces = Vec::new();
+    let mut fetch_request: HashMap<Address, ChangedAccountData> = HashMap::default();
+    loop {
+        used_state_traces.clear();
+        fetch_request.clear();
+
+        if cancel.is_cancelled() {
+            return;
+        }
+
+        for _ in 0..CONSUME_SIM_ORDERS_BATCH {
+            match simulated_orders.try_recv() {
+                Ok(SimulatedOrderCommand::Simulation(sim)) => {
+                    if let Some(used_state_trace) = sim.used_state_trace {
+                        used_state_traces.push(used_state_trace);
+                    } else {
+                        continue;
+                    }
+                }
+                Ok(_) => continue,
+                Err(TryRecvError::Empty) => {
+                    break;
+                }
+                Err(TryRecvError::Closed) => {
+                    return;
+                }
+                Err(TryRecvError::Lagged(msg)) => {
+                    warn!(
+                        "State trie prefetching thread lagging on sim orders channel: {}",
+                        msg
+                    );
+                    break;
+                }
+            };
+        }
+
+        for used_state_trace in used_state_traces.drain(..) {
+            let changed_accounts_iter = used_state_trace
+                .received_amount
+                .keys()
+                .chain(used_state_trace.sent_amount.keys())
+                .zip(iter::repeat(false))
+                .chain(
+                    used_state_trace
+                        .destructed_contracts
+                        .iter()
+                        .zip(iter::repeat(true)),
+                );
+
+            for (address, destroyed) in changed_accounts_iter {
+                if fetched_accounts.contains(address) {
+                    continue;
+                }
+                fetched_accounts.insert(*address);
+                fetch_request
+                    .entry(*address)
+                    .or_insert_with(|| ChangedAccountData::new(*address, destroyed));
+            }
+
+            for (written_slot, value) in &used_state_trace.written_slot_values {
+                if fetched_slots.contains(written_slot) {
+                    continue;
+                }
+                fetched_slots.insert(written_slot.clone());
+                let account_request = fetch_request
+                    .entry(written_slot.address)
+                    .or_insert_with(|| ChangedAccountData::new(written_slot.address, false));
+                account_request
+                    .slots
+                    .push((written_slot.key, value.is_zero()));
+            }
+        }
+
+        if fetch_request.is_empty() {
+            continue;
+        }
+
+        let start = Instant::now();
+        match prefetch_tries_for_accounts(
+            consistent_db_view.clone(),
+            shared_sparse_mpt_cache.clone(),
+            fetch_request.values(),
+        ) {
+            Ok(()) => {}
+            Err(SparseTrieError::FetchNode(FetchNodeError::Provider(
+                ProviderError::ConsistentView(_),
+            ))) => {
+                return;
+            }
+            Err(err) => {
+                error!(?err, "Error while prefetching trie nodes");
+            }
+        }
+        trace!(
+            time_ms = start.elapsed().as_millis(),
+            accounts = fetch_request.len(),
+            "Prefetched trie nodes"
+        );
+    }
+}

--- a/crates/rbuilder/src/telemetry/metrics.rs
+++ b/crates/rbuilder/src/telemetry/metrics.rs
@@ -50,6 +50,12 @@ register_metrics! {
         &["builder_name"]
     )
     .unwrap();
+    pub static BLOCK_ROOT_HASH_TIME: HistogramVec = HistogramVec::new(
+        HistogramOpts::new("block_root_hash_time", "Block Root Hash Time (ms)")
+            .buckets(exponential_buckets_range(1.0, 2000.0, 100)),
+        &["builder_name"]
+    )
+    .unwrap();
     pub static BLOCK_BUILT_TXS: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_built_txs", "Transactions in the built block")
             .buckets(linear_buckets_range(1.0, 1000.0, 100)),
@@ -270,6 +276,7 @@ pub fn set_ordepool_count(txs: usize, bundles: usize) {
 pub fn add_built_block_metrics(
     build_time: Duration,
     finalize_time: Duration,
+    root_hash_time: Duration,
     txs: usize,
     blobs: usize,
     gas_used: u64,
@@ -290,6 +297,9 @@ pub fn add_built_block_metrics(
     BLOCK_FINALIZE_TIME
         .with_label_values(&[builder_name])
         .observe(finalize_time.as_millis() as f64);
+    BLOCK_ROOT_HASH_TIME
+        .with_label_values(&[builder_name])
+        .observe(root_hash_time.as_millis() as f64);
     BLOCK_BUILT_TXS
         .with_label_values(&[builder_name])
         .observe(txs as f64);

--- a/crates/rbuilder/src/validation_api_client.rs
+++ b/crates/rbuilder/src/validation_api_client.rs
@@ -101,7 +101,7 @@ impl ValidationAPIClient {
                 tokio::select! {
                     _ = cancellation_token.cancelled() => {
                     }
-                    result = provider.raw_request::<_, ()>(std::borrow::Cow::Borrowed(method), vec![request]) => {
+                    result = provider.raw_request::<_, serde_json::Value>(std::borrow::Cow::Borrowed(method), vec![request]) => {
                         _ = result_sender.send((i, result)).await;
                     }
                 }
@@ -113,7 +113,7 @@ impl ValidationAPIClient {
             let span = info_span!("block_validation", validation_node_idx = idx);
             let _span_guard = span.enter();
             match result {
-                Ok(()) => {
+                Ok(_) => {
                     // this means that block passed validation
                     add_block_validation_time(start.elapsed());
                     return Ok(());


### PR DESCRIPTION
## 📝 Summary

1. Adds sparse trie prefetcher
2. Fixes deser. error for validation request
3. Adds root hash metrics because finalize adds up to 60% to the root hash with sparse trie and its separates these two. 

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
