### PR TITLE
fix(startup): Remove static_file_provider checks create_provider_factory

### DIFF
--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -16,8 +16,6 @@ use reth::tasks::pool::BlockingTaskPool;
 use reth_chainspec::ChainSpec;
 use reth_db::DatabaseEnv;
 use reth_node_core::args::utils::chain_value_parser;
-use reth_primitives::StaticFileSegment;
-use reth_provider::StaticFileProviderFactory;
 use serde::{Deserialize, Deserializer};
 use serde_with::{serde_as, DeserializeAs};
 use sqlx::PgPool;
@@ -482,15 +480,6 @@ pub fn create_provider_factory(
 
     let provider_factory_reopener =
         ProviderFactoryReopener::new(db, chain_spec, reth_static_files_path)?;
-
-    if provider_factory_reopener
-        .provider_factory_unchecked()
-        .static_file_provider()
-        .get_highest_static_file_block(StaticFileSegment::Headers)
-        .is_none()
-    {
-        eyre::bail!("No headers in static files. Check your static files path configuration.");
-    }
 
     Ok(provider_factory_reopener)
 }

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -47,8 +47,6 @@ use reth::tasks::pool::BlockingTaskPool;
 use reth_chainspec::{Chain, ChainSpec, NamedChain};
 use reth_db::DatabaseEnv;
 use reth_payload_builder::database::CachedReads;
-use reth_primitives::StaticFileSegment;
-use reth_provider::StaticFileProviderFactory;
 use serde::Deserialize;
 use serde_with::{serde_as, OneOrMany};
 use std::{
@@ -442,15 +440,6 @@ pub fn create_provider_factory(
 
     let provider_factory_reopener =
         ProviderFactoryReopener::new(db, chain_spec, reth_static_files_path)?;
-
-    if provider_factory_reopener
-        .provider_factory_unchecked()
-        .static_file_provider()
-        .get_highest_static_file_block(StaticFileSegment::Headers)
-        .is_none()
-    {
-        eyre::bail!("No headers in static files. Check your static files path configuration.");
-    }
 
     Ok(provider_factory_reopener)
 }

--- a/crates/rbuilder/src/utils/provider_factory_reopen.rs
+++ b/crates/rbuilder/src/utils/provider_factory_reopen.rs
@@ -44,6 +44,7 @@ impl<DB: Database + Clone> ProviderFactoryReopener<DB> {
     ) -> RethResult<Self> {
         let chain_spec = provider_factory.chain_spec();
         let static_files_path = provider_factory.static_file_provider().path().to_path_buf();
+
         Ok(Self {
             provider_factory: Arc::new(Mutex::new(provider_factory)),
             chain_spec,


### PR DESCRIPTION
## 📝 Summary

This PR removes the calls to `static_file_provider().get_highest_static_file_block(..)` since it appears we no longer actively use the static file provider in our code.


## 💡 Motivation and Context

As far as I can tell, we no longer really use the static_file_provider inside the `ProviderFactoryReopener`, but the check in `create_provider_factory` causes circular dependencies related to #199 or https://github.com/ethpandaops/ethereum-package/pull/786.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
