### PR TITLE
dont' recover signer in a hot loop

### DIFF
--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -420,8 +420,8 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         }
 
         let mut tx_env = TxEnv::default();
-        let tx_signed = tx_with_blobs.internal_tx_unsecure().clone().into_signed();
-        tx_signed.fill_tx_env(&mut tx_env, tx_signed.recover_signer().unwrap());
+        let tx_signed = tx_with_blobs.internal_tx_unsecure();
+        tx_signed.fill_tx_env(&mut tx_env, tx_signed.signer());
 
         let env = Env {
             cfg: ctx.initialized_cfg.cfg_env.clone(),


### PR DESCRIPTION
## 📝 Summary

This is pretty serious regression that I've missed while reviewing external PR on one of the reth upgrades. 

We need to be careful to not allow something like that slip in the future.

## 💡 Motivation and Context

calling recover_signer verifies transaction signature every time we try to executing something in the vm. 

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
