### PR TITLE
Generic provider

### DIFF
--- a/crates/rbuilder/src/backtest/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_block.rs
@@ -8,14 +8,14 @@
 use ahash::HashMap;
 use alloy_primitives::utils::format_ether;
 
-use crate::backtest::restore_landed_orders::{
-    restore_landed_orders, sim_historical_block, ExecutedBlockTx, ExecutedTxs, SimplifiedOrder,
-};
-use crate::backtest::OrdersWithTimestamp;
 use crate::{
     backtest::{
         execute::{backtest_prepare_ctx_for_block, BacktestBlockInput},
-        BlockData, HistoricalDataStorage,
+        restore_landed_orders::{
+            restore_landed_orders, sim_historical_block, ExecutedBlockTx, ExecutedTxs,
+            SimplifiedOrder,
+        },
+        BlockData, HistoricalDataStorage, OrdersWithTimestamp,
     },
     building::builders::BacktestSimulateBlockInput,
     live_builder::{base_config::load_config_toml_and_env, cli::LiveBuilderConfig},
@@ -58,7 +58,10 @@ struct Cli {
     block: u64,
 }
 
-pub async fn run_backtest_build_block<ConfigType: LiveBuilderConfig>() -> eyre::Result<()> {
+pub async fn run_backtest_build_block<ConfigType>() -> eyre::Result<()>
+where
+    ConfigType: LiveBuilderConfig,
+{
     let cli = Cli::parse();
 
     let config: ConfigType = load_config_toml_and_env(cli.config)?;
@@ -85,10 +88,7 @@ pub async fn run_backtest_build_block<ConfigType: LiveBuilderConfig>() -> eyre::
         print_order_and_timestamp(&block_data.available_orders, &block_data);
     }
 
-    let provider_factory = config
-        .base_config()
-        .provider_factory()?
-        .provider_factory_unchecked();
+    let provider_factory = config.base_config().create_provider_factory()?;
     let chain_spec = config.base_config().chain_spec()?;
     let sbundle_mergeabe_signers = config.base_config().sbundle_mergeabe_signers();
 
@@ -126,7 +126,7 @@ pub async fn run_backtest_build_block<ConfigType: LiveBuilderConfig>() -> eyre::
                     builder_name: builder_name.clone(),
                     sbundle_mergeabe_signers: sbundle_mergeabe_signers.clone(),
                     sim_orders: &sim_orders,
-                    provider_factory: provider_factory.clone(),
+                    provider: provider_factory.clone(),
                     cached_reads: None,
                 };
                 let build_res = config.build_backtest_block(builder_name, input);

--- a/crates/rbuilder/src/backtest/backtest_build_range.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_range.rs
@@ -24,8 +24,7 @@ use clap::Parser;
 use rayon::prelude::*;
 use std::{
     fs::File,
-    io,
-    io::Write,
+    io::{self, Write},
     path::{Path, PathBuf},
 };
 use time::format_description::well_known::Rfc3339;
@@ -63,8 +62,10 @@ struct Cli {
     blocks: Vec<u64>,
 }
 
-pub async fn run_backtest_build_range<ConfigType: LiveBuilderConfig + Send + Sync>(
-) -> eyre::Result<()> {
+pub async fn run_backtest_build_range<ConfigType>() -> eyre::Result<()>
+where
+    ConfigType: LiveBuilderConfig,
+{
     let cli = Cli::parse();
 
     if cli.store_backtest && cli.compare_backtest {
@@ -110,10 +111,7 @@ pub async fn run_backtest_build_range<ConfigType: LiveBuilderConfig + Send + Syn
         result
     };
 
-    let provider_factory = config
-        .base_config()
-        .provider_factory()?
-        .provider_factory_unchecked();
+    let provider_factory = config.base_config().create_provider_factory()?;
     let chain_spec = config.base_config().chain_spec()?;
 
     let mut profits = Vec::new();

--- a/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
@@ -1,15 +1,16 @@
-use crate::building::evm_inspector::SlotKey;
-use crate::building::tracers::AccumulatorSimulationTracer;
-use crate::building::{BlockBuildingContext, BlockState, PartialBlock, PartialBlockFork};
-use crate::utils::signed_uint_delta;
-use crate::utils::{extract_onchain_block_txs, find_suggested_fee_recipient};
+use crate::{
+    building::{
+        evm_inspector::SlotKey, tracers::AccumulatorSimulationTracer, BlockBuildingContext,
+        BlockState, PartialBlock, PartialBlockFork,
+    },
+    utils::{extract_onchain_block_txs, find_suggested_fee_recipient, signed_uint_delta},
+};
 use ahash::{HashMap, HashSet};
 use alloy_primitives::{B256, I256};
 use eyre::Context;
 use reth_chainspec::ChainSpec;
-use reth_db::DatabaseEnv;
 use reth_primitives::{Receipt, TransactionSignedEcRecovered, TxHash};
-use reth_provider::ProviderFactory;
+use reth_provider::StateProviderFactory;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -26,11 +27,14 @@ impl ExecutedTxs {
     }
 }
 
-pub fn sim_historical_block(
-    provider_factory: ProviderFactory<Arc<DatabaseEnv>>,
+pub fn sim_historical_block<P>(
+    provider: P,
     chain_spec: Arc<ChainSpec>,
     onchain_block: alloy_rpc_types::Block,
-) -> eyre::Result<Vec<ExecutedTxs>> {
+) -> eyre::Result<Vec<ExecutedTxs>>
+where
+    P: StateProviderFactory,
+{
     let mut results = Vec::new();
 
     let txs = extract_onchain_block_txs(&onchain_block)?;
@@ -48,7 +52,7 @@ pub fn sim_historical_block(
         None,
     );
 
-    let state_provider = provider_factory.history_by_block_hash(ctx.attributes.parent)?;
+    let state_provider = provider.history_by_block_hash(ctx.attributes.parent)?;
     let mut partial_block = PartialBlock::new(true, None);
     let mut state = BlockState::new(state_provider);
 

--- a/crates/rbuilder/src/building/sim.rs
+++ b/crates/rbuilder/src/building/sim.rs
@@ -10,11 +10,9 @@ use crate::{
 use ahash::{HashMap, HashSet};
 use alloy_primitives::{Address, B256};
 use rand::seq::SliceRandom;
-use reth::providers::ProviderFactory;
-use reth_db::database::Database;
 use reth_errors::ProviderError;
 use reth_payload_builder::database::CachedReads;
-use reth_provider::StateProvider;
+use reth_provider::{StateProvider, StateProviderFactory};
 use std::{
     cmp::{max, min, Ordering},
     collections::hash_map::Entry,
@@ -68,9 +66,9 @@ pub struct SimulatedResult {
 
 // @Feat replaceable orders
 #[derive(Debug)]
-pub struct SimTree<DB> {
+pub struct SimTree<P> {
     // fields for nonce management
-    nonce_cache: NonceCache<DB>,
+    nonce_cache: NonceCache<P>,
 
     sims: HashMap<SimulationId, SimulatedResult>,
     sims_that_update_one_nonce: HashMap<NonceKey, SimulationId>,
@@ -88,9 +86,12 @@ enum OrderNonceState {
     Ready(Vec<Order>),
 }
 
-impl<DB: Database> SimTree<DB> {
-    pub fn new(provider_factory: ProviderFactory<DB>, parent_block: B256) -> Self {
-        let nonce_cache = NonceCache::new(provider_factory, parent_block);
+impl<P> SimTree<P>
+where
+    P: StateProviderFactory + Clone + 'static,
+{
+    pub fn new(provider: P, parent_block: B256) -> Self {
+        let nonce_cache = NonceCache::new(provider, parent_block);
         Self {
             nonce_cache,
             sims: HashMap::default(),
@@ -306,13 +307,16 @@ impl<DB: Database> SimTree<DB> {
 /// Non-interactive usage of sim tree that will simply simulate all orders.
 /// `randomize_insertion` is used to debug if sim tree works correctly when orders are inserted in a different order
 /// outputs should be independent of this arg.
-pub fn simulate_all_orders_with_sim_tree<DB: Database + Clone>(
-    factory: ProviderFactory<DB>,
+pub fn simulate_all_orders_with_sim_tree<P>(
+    provider: P,
     ctx: &BlockBuildingContext,
     orders: &[Order],
     randomize_insertion: bool,
-) -> Result<(Vec<SimulatedOrder>, Vec<OrderErr>), CriticalCommitOrderError> {
-    let mut sim_tree = SimTree::new(factory.clone(), ctx.attributes.parent);
+) -> Result<(Vec<SimulatedOrder>, Vec<OrderErr>), CriticalCommitOrderError>
+where
+    P: StateProviderFactory + Clone + 'static,
+{
+    let mut sim_tree = SimTree::new(provider.clone(), ctx.attributes.parent);
 
     let mut orders = orders.to_vec();
     let random_insert_size = max(orders.len() / 20, 1);
@@ -326,7 +330,7 @@ pub fn simulate_all_orders_with_sim_tree<DB: Database + Clone>(
 
     let mut sim_errors = Vec::new();
     let mut state_for_sim =
-        Arc::<dyn StateProvider>::from(factory.history_by_block_hash(ctx.attributes.parent)?);
+        Arc::<dyn StateProvider>::from(provider.history_by_block_hash(ctx.attributes.parent)?);
     let mut cache_reads = Some(CachedReads::default());
     loop {
         // mix new orders into the sim_tree

--- a/crates/rbuilder/src/live_builder/simulation/simulation_job.rs
+++ b/crates/rbuilder/src/live_builder/simulation/simulation_job.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use ahash::HashSet;
 use alloy_primitives::utils::format_ether;
-use reth_db::database::Database;
+use reth_provider::StateProviderFactory;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace, warn};
@@ -25,7 +25,7 @@ use super::SimulatedOrderCommand;
 /// If we get a cancellation and the order is in in_flight_orders we just remove it from in_flight_orders.
 /// Only SimulatedOrders still in in_flight_orders are delivered.
 /// @Pending: implement cancellations in the SimTree.
-pub struct SimulationJob<DB> {
+pub struct SimulationJob<P> {
     block_cancellation: CancellationToken,
     /// Input orders to be simulated
     new_order_sub: mpsc::UnboundedReceiver<OrderPoolCommand>,
@@ -35,7 +35,7 @@ pub struct SimulationJob<DB> {
     sim_results_receiver: mpsc::Receiver<SimulatedResult>,
     /// Output of the simulations
     slot_sim_results_sender: mpsc::Sender<SimulatedOrderCommand>,
-    sim_tree: SimTree<DB>,
+    sim_tree: SimTree<P>,
 
     orders_received: OrderCounter,
     orders_simulated_ok: OrderCounter,
@@ -56,14 +56,17 @@ pub struct SimulationJob<DB> {
     not_cancelled_sent_simulated_orders: HashSet<OrderId>,
 }
 
-impl<DB: Database + Clone + Send + 'static> SimulationJob<DB> {
+impl<P> SimulationJob<P>
+where
+    P: StateProviderFactory + Clone + 'static,
+{
     pub fn new(
         block_cancellation: CancellationToken,
         new_order_sub: mpsc::UnboundedReceiver<OrderPoolCommand>,
         sim_req_sender: flume::Sender<SimulationRequest>,
         sim_results_receiver: mpsc::Receiver<SimulatedResult>,
         slot_sim_results_sender: mpsc::Sender<SimulatedOrderCommand>,
-        sim_tree: SimTree<DB>,
+        sim_tree: SimTree<P>,
     ) -> Self {
         Self {
             block_cancellation,

--- a/crates/rbuilder/src/primitives/serialize.rs
+++ b/crates/rbuilder/src/primitives/serialize.rs
@@ -262,6 +262,7 @@ pub struct CancelShareBundle {
     pub key: ShareBundleReplacementKey,
 }
 /// Since we use the same API (mev_sendBundle) to get new bundles and also to cancel them we need this struct
+#[allow(clippy::large_enum_variant)]
 pub enum RawShareBundleDecodeResult {
     NewShareBundle(ShareBundle),
     CancelShareBundle(CancelShareBundle),

--- a/crates/rbuilder/src/utils/provider_factory_reopen.rs
+++ b/crates/rbuilder/src/utils/provider_factory_reopen.rs
@@ -77,7 +77,7 @@ impl<DB: Database + Clone> ProviderFactoryReopener<DB> {
     pub fn check_consistency_and_reopen_if_needed(&self) -> eyre::Result<ProviderFactory<DB>> {
         let best_block_number = self
             .provider_factory_unchecked()
-            .best_block_number()
+            .last_block_number()
             .map_err(|err| eyre::eyre!("Error getting best block number: {:?}", err))?;
         let mut provider_factory = self.provider_factory.lock().unwrap();
 

--- a/crates/rbuilder/src/utils/provider_factory_reopen.rs
+++ b/crates/rbuilder/src/utils/provider_factory_reopen.rs
@@ -1,12 +1,20 @@
 use crate::telemetry::{inc_provider_bad_reopen_counter, inc_provider_reopen_counter};
+use alloy_eips::{BlockNumHash, BlockNumberOrTag};
 use reth::providers::{BlockHashReader, ChainSpecProvider, ProviderFactory};
-use reth_chainspec::ChainSpec;
-use reth_db::database::Database;
-use reth_errors::RethResult;
-use reth_provider::{providers::StaticFileProvider, StaticFileProviderFactory};
+use reth_chainspec::{ChainInfo, ChainSpec};
+use reth_db::{database::Database, DatabaseError};
+use reth_errors::{ProviderError, ProviderResult, RethResult};
+use reth_primitives::{BlockHash, BlockNumber, Header, SealedHeader};
+use reth_provider::{
+    providers::StaticFileProvider, BlockIdReader, BlockNumReader, DatabaseProviderFactory,
+    DatabaseProviderRO, HeaderProvider, StateProviderBox, StateProviderFactory,
+    StaticFileProviderFactory,
+};
+use revm_primitives::{B256, U256};
 use std::{
+    ops::RangeBounds,
     path::PathBuf,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
 };
 use tracing::debug;
 
@@ -19,6 +27,8 @@ pub struct ProviderFactoryReopener<DB> {
     provider_factory: Arc<Mutex<ProviderFactory<DB>>>,
     chain_spec: Arc<ChainSpec>,
     static_files_path: PathBuf,
+    /// Last block the Reopener verified consistency for.
+    last_consistent_block: Arc<RwLock<Option<BlockNumber>>>,
     /// Patch to disable checking on test mode. Is ugly but ProviderFactoryReopener should die shortly (5/24/2024).
     testing_mode: bool,
 }
@@ -36,12 +46,11 @@ impl<DB: Database + Clone> ProviderFactoryReopener<DB> {
             chain_spec,
             static_files_path,
             testing_mode: false,
+            last_consistent_block: Arc::new(RwLock::new(None)),
         })
     }
 
-    pub fn new_from_existing_for_testing(
-        provider_factory: ProviderFactory<DB>,
-    ) -> RethResult<Self> {
+    pub fn new_from_existing(provider_factory: ProviderFactory<DB>) -> RethResult<Self> {
         let chain_spec = provider_factory.chain_spec();
         let static_files_path = provider_factory.static_file_provider().path().to_path_buf();
         Ok(Self {
@@ -49,6 +58,7 @@ impl<DB: Database + Clone> ProviderFactoryReopener<DB> {
             chain_spec,
             static_files_path,
             testing_mode: true,
+            last_consistent_block: Arc::new(RwLock::new(None)),
         })
     }
 
@@ -61,13 +71,23 @@ impl<DB: Database + Clone> ProviderFactoryReopener<DB> {
     /// This will check if historical block hashes for the given block is correct and if not it will reopen
     /// provider fatory.
     /// This should be used when consistency is required: e.g. building blocks.
-    pub fn check_consistency_and_reopen_if_needed(
-        &self,
-        current_block_number: u64,
-    ) -> eyre::Result<ProviderFactory<DB>> {
+    ///
+    /// If the current block number is already known at the time of calling this method, you may pass it to
+    /// avoid an additional DB lookup for the latest block number.
+    pub fn check_consistency_and_reopen_if_needed(&self) -> eyre::Result<ProviderFactory<DB>> {
+        let best_block_number = self
+            .provider_factory_unchecked()
+            .best_block_number()
+            .map_err(|err| eyre::eyre!("Error getting best block number: {:?}", err))?;
         let mut provider_factory = self.provider_factory.lock().unwrap();
-        if !self.testing_mode {
-            match check_provider_factory_health(current_block_number, &provider_factory) {
+
+        // Don't need to check consistency for the block that was just checked.
+        let last_consistent_block_guard = self.last_consistent_block.read().unwrap();
+        let last_consistent_block = *last_consistent_block_guard;
+        // Drop before write might be attempted to avoid deadlock!
+        drop(last_consistent_block_guard);
+        if !self.testing_mode && last_consistent_block != Some(best_block_number) {
+            match check_provider_factory_health(best_block_number, &provider_factory) {
                 Ok(()) => {}
                 Err(err) => {
                     debug!(?err, "Provider factory is inconsistent, reopening");
@@ -81,7 +101,7 @@ impl<DB: Database + Clone> ProviderFactoryReopener<DB> {
                 }
             }
 
-            match check_provider_factory_health(current_block_number, &provider_factory) {
+            match check_provider_factory_health(best_block_number, &provider_factory) {
                 Ok(()) => {}
                 Err(err) => {
                     inc_provider_bad_reopen_counter();
@@ -92,6 +112,9 @@ impl<DB: Database + Clone> ProviderFactoryReopener<DB> {
                     );
                 }
             }
+
+            let mut last_consistent_block = self.last_consistent_block.write().unwrap();
+            *last_consistent_block = Some(best_block_number);
         }
         Ok(provider_factory.clone())
     }
@@ -128,4 +151,169 @@ pub fn check_provider_factory_health<DB: Database>(
     }
 
     Ok(())
+}
+
+// Implement reth db traits on the ProviderFactoryReopener, allowing generic
+// DB access. Consistency checks are required only if the operations may be
+// performed on historical state.
+//
+// ProviderFactory only has access to disk state, therefore cannot implement methods
+// that require the blockchain tree (pending state etc.).
+
+impl<DB: Database + Clone> DatabaseProviderFactory<DB> for ProviderFactoryReopener<DB> {
+    fn database_provider_ro(&self) -> ProviderResult<DatabaseProviderRO<DB>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.database_provider_ro()
+    }
+}
+
+impl<DB: Database + Clone> HeaderProvider for ProviderFactoryReopener<DB> {
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.header(block_hash)
+    }
+
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.header_by_number(num)
+    }
+
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.header_td(hash)
+    }
+
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.header_td_by_number(number)
+    }
+
+    fn headers_range(&self, range: impl RangeBounds<BlockNumber>) -> ProviderResult<Vec<Header>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.headers_range(range)
+    }
+
+    fn sealed_header(&self, number: BlockNumber) -> ProviderResult<Option<SealedHeader>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.sealed_header(number)
+    }
+
+    fn sealed_headers_while(
+        &self,
+        range: impl RangeBounds<BlockNumber>,
+        predicate: impl FnMut(&SealedHeader) -> bool,
+    ) -> ProviderResult<Vec<SealedHeader>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.sealed_headers_while(range, predicate)
+    }
+}
+
+impl<DB: Database + Clone> BlockHashReader for ProviderFactoryReopener<DB> {
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.block_hash(number)
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        start: BlockNumber,
+        end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.canonical_hashes_range(start, end)
+    }
+}
+
+impl<DB: Database + Clone> BlockNumReader for ProviderFactoryReopener<DB> {
+    fn chain_info(&self) -> ProviderResult<ChainInfo> {
+        self.provider_factory_unchecked().chain_info()
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.provider_factory_unchecked().best_block_number()
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.provider_factory_unchecked().last_block_number()
+    }
+
+    fn block_number(&self, hash: B256) -> ProviderResult<Option<BlockNumber>> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.block_number(hash)
+    }
+}
+
+impl<DB: Database + Clone> BlockIdReader for ProviderFactoryReopener<DB> {
+    fn pending_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
+        unimplemented!("This method is not supported by ProviderFactoryReopener. Please consider using a BlockchainProvider.");
+    }
+
+    fn safe_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
+        unimplemented!("This method is not supported by ProviderFactoryReopener. Please consider using a BlockchainProvider.");
+    }
+
+    fn finalized_block_num_hash(&self) -> ProviderResult<Option<BlockNumHash>> {
+        unimplemented!("This method is not supported by ProviderFactoryReopener. Please consider using a BlockchainProvider.");
+    }
+}
+
+impl<DB: Database + Clone> StateProviderFactory for ProviderFactoryReopener<DB> {
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
+        self.provider_factory_unchecked().latest()
+    }
+
+    fn state_by_block_number_or_tag(
+        &self,
+        _number_or_tag: BlockNumberOrTag,
+    ) -> ProviderResult<StateProviderBox> {
+        unimplemented!("This method is not supported by ProviderFactoryReopener. Please consider using a BlockchainProvider.");
+    }
+
+    fn history_by_block_number(&self, block: BlockNumber) -> ProviderResult<StateProviderBox> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.history_by_block_number(block)
+    }
+
+    fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
+        let provider = self
+            .check_consistency_and_reopen_if_needed()
+            .map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+        provider.history_by_block_hash(block)
+    }
+
+    fn state_by_block_hash(&self, _block: BlockHash) -> ProviderResult<StateProviderBox> {
+        unimplemented!("This method is not supported by ProviderFactoryReopener. Please consider using a BlockchainProvider.");
+    }
+
+    fn pending(&self) -> ProviderResult<StateProviderBox> {
+        unimplemented!("This method is not supported by ProviderFactoryReopener. Please consider using a BlockchainProvider.");
+    }
+
+    fn pending_state_by_hash(&self, _block_hash: B256) -> ProviderResult<Option<StateProviderBox>> {
+        unimplemented!("This method is not supported by ProviderFactoryReopener. Please consider using a BlockchainProvider.");
+    }
 }


### PR DESCRIPTION
Closes #216 

Replaces all concrete usage of `ProviderFactory` and `ProviderFactoryReopener` with generics bounded by [reth provider traits](https://github.com/paradigmxyz/reth/blob/661b260f6172c047e8530e2331b2c84141e03c2b/crates/storage/provider/src/traits/full.rs#L14-L24). This allows running rbuilder in-process using a node provider and eases swapping to a more modern provider like `BlockchainProvider` in the future. 

Note that not all trait methods can be implemented because `ProviderFactoryReopener` has no access to the blockchain tree (pending state etc.).

## DB Consistency Checks

Consistency checks have been moved out of the rbuilder core into the trait implementation for `ProviderFactoryReopener`. Inside the trait implementation, the current head block number is not known, so the reopener cannot assume that the state of the block given - 256 blocks will be available. 

To not redundantly re-check the consistency of the same block, `ProviderFactoryReopener` tracks the last block verified to have consistent state and will only re-check it when it changes. This adds 1 additional read per provider call to get the head of the chain, however I believe the cost will be insignificant. 