### PR TITLE
Relay submit improvements

### DIFF
--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -32,8 +32,6 @@ max_concurrent_seals = 4
 # genesis_fork_version = "0x00112233"
 
 sbundle_mergeabe_signers = []
-# slot_delta_to_start_submits_ms is usually negative since we start bidding BEFORE the slot start
-# slot_delta_to_start_submits_ms = -5000
 live_builders = ["mp-ordering", "mgp-ordering", "merging"]
 
 [[relays]]

--- a/config-playground.toml
+++ b/config-playground.toml
@@ -25,8 +25,6 @@ dry_run_validation_url = "http://localhost:8545"
 ignore_cancellable_orders = true
 
 sbundle_mergeabe_signers = []
-# slot_delta_to_start_submits_ms is usually negative since we start bidding BEFORE the slot start
-# slot_delta_to_start_submits_ms = -5000
 live_builders = ["mp-ordering"]
 
 [[relays]]

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -105,8 +105,6 @@ pub struct SubmissionConfig {
     pub optimistic_prevalidate_optimistic_blocks: bool,
 
     pub bid_observer: Box<dyn BidObserver + Send + Sync>,
-    /// Delta relative to slot_time at which we start to submit blocks. Usually negative since we need to start submitting BEFORE the slot time.
-    pub slot_delta_to_start_submits: time::Duration,
 }
 
 /// run_submit_to_relays_job waits at least MIN_TIME_BETWEEN_BLOCK_CHECK between new block polls to avoid 100% CPU
@@ -143,14 +141,6 @@ async fn run_submit_to_relays_job(
         slot_data.slot(),
     );
     let mut res = None;
-    // first, sleep to slot time - slot_delta_to_start_submits
-    {
-        let submit_start_time = slot_data.timestamp() + config.slot_delta_to_start_submits;
-        let sleep_duration = submit_start_time - time::OffsetDateTime::now_utc();
-        if sleep_duration.is_positive() {
-            sleep(sleep_duration.try_into().unwrap()).await;
-        }
-    }
 
     let (normal_relays, optimistic_relays) = {
         let mut normal_relays = Vec::new();

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -63,8 +63,6 @@ use std::{
 use tracing::info;
 use url::Url;
 
-/// From experience (Vitaly's) all generated blocks before slot_time-8sec end loosing (due to last moment orders?)
-const DEFAULT_SLOT_DELTA_TO_START_SUBMITS: time::Duration = time::Duration::milliseconds(-8000);
 /// We initialize the wallet with the last full day. This should be enough for any bidder.
 /// On debug I measured this to be < 300ms so it's not big deal.
 pub const WALLET_INIT_HISTORY_SIZE: Duration = Duration::from_secs(60 * 60 * 24);
@@ -204,12 +202,6 @@ impl L1Config {
         BLSBlockSigner::new(secret_key, signing_domain)
     }
 
-    pub fn slot_delta_to_start_submits(&self) -> time::Duration {
-        self.slot_delta_to_start_submits_ms
-            .map(time::Duration::milliseconds)
-            .unwrap_or(DEFAULT_SLOT_DELTA_TO_START_SUBMITS)
-    }
-
     fn submission_config(
         &self,
         chain_spec: Arc<ChainSpec>,
@@ -258,7 +250,6 @@ impl L1Config {
             optimistic_signer,
             optimistic_max_bid_value: parse_ether(&self.optimistic_max_bid_value_eth)?,
             optimistic_prevalidate_optimistic_blocks: self.optimistic_prevalidate_optimistic_blocks,
-            slot_delta_to_start_submits: self.slot_delta_to_start_submits(),
             bid_observer,
         })
     }

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -118,9 +118,6 @@ pub struct L1Config {
     /// If true all optimistic submissions will be validated on nodes specified in `dry_run_validation_url`
     pub optimistic_prevalidate_optimistic_blocks: bool,
 
-    /// See [`SubmissionConfig`]
-    slot_delta_to_start_submits_ms: Option<i64>,
-
     /// How many seals we are going to be doing in parallel.
     /// Optimal value may change depending on the roothash computation caching strategies.
     pub max_concurrent_seals: u64,
@@ -144,7 +141,6 @@ impl Default for L1Config {
             optimistic_enabled: false,
             optimistic_max_bid_value_eth: "0.0".to_string(),
             optimistic_prevalidate_optimistic_blocks: false,
-            slot_delta_to_start_submits_ms: None,
             cl_node_url: vec![EnvOrValue::from("http://127.0.0.1:3500")],
             max_concurrent_seals: DEFAULT_MAX_CONCURRENT_SEALS,
             genesis_fork_version: None,

--- a/crates/rbuilder/src/primitives/serialize.rs
+++ b/crates/rbuilder/src/primitives/serialize.rs
@@ -262,6 +262,7 @@ pub struct CancelShareBundle {
     pub key: ShareBundleReplacementKey,
 }
 /// Since we use the same API (mev_sendBundle) to get new bundles and also to cancel them we need this struct
+#[allow(clippy::large_enum_variant)]
 pub enum RawShareBundleDecodeResult {
     NewShareBundle(ShareBundle),
     CancelShareBundle(CancelShareBundle),


### PR DESCRIPTION
## 📝 Summary

Removed the sleep at the beginning of the relay submit loop since this is the responsibility of the bidding module.
Replaced a 5ms polling for an await to improve bidding latency.
 
## 💡 Motivation and Context

New root hash speed makes this 5ms latency important.

---

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
