### PR TITLE
fix beginner setup/instructions for playground config

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -55,7 +55,7 @@ jobs:
           version: nightly
 
       - name: Install native dependencies
-        run: sudo apt-get install -y libsqlite3-dev
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
 
       - name: Lint
         run: make lint

--- a/README.md
+++ b/README.md
@@ -84,15 +84,22 @@ You can use [builder-playground](https://github.com/flashbots/builder-playground
 
 First, start [builder-playground](https://github.com/flashbots/builder-playground):
 
-```
+```bash
 git clone git@github.com:flashbots/builder-playground.git
 cd builder-playground
 go run main.go
 ```
 
-Then, run `rbuilder` using the `config-playground.toml` config file:
+Next, update `config-playground.toml` with fully-qualified paths for entries containing `$HOME`:
 
+```bash
+# replaces '$HOME' with the actual value of "$HOME"
+sed -i "s|\$HOME|$HOME|g" config-playground.toml
 ```
+
+Then run `rbuilder` using the `config-playground.toml` config file:
+
+```bash
 cargo run --bin rbuilder run config-playground.toml
 ```
 

--- a/config-playground.toml
+++ b/config-playground.toml
@@ -13,7 +13,7 @@ coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf
 cl_node_url = ["http://localhost:3500"]
 jsonrpc_server_port = 8645
 jsonrpc_server_ip = "0.0.0.0"
-el_node_ipc_path = "/tmp/reth.ipc"
+el_node_ipc_path = "$HOME/.playground/devnet/reth.ipc"
 extra_data = "⚡🤖"
 
 dry_run = false

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -209,7 +209,7 @@ impl BaseConfig {
             watchdog_timeout: self.watchdog_timeout(),
             error_storage_path: self.error_storage_path.clone(),
             simulation_threads: self.simulation_threads,
-            order_input_config: OrderInputConfig::from_config(self),
+            order_input_config: OrderInputConfig::from_config(self)?,
             blocks_source: slot_source,
             chain_chain_spec: self.chain_spec()?,
             provider,


### PR DESCRIPTION
## 📝 Summary

- changes path of `el_node_ipc_path` in `config-playground.toml` to use `$HOME/.playground/devnet` instead of `/tmp` (aligns with current builder-playground defaults)
- adds a step in the README to replace '$HOME' with your actual home path
  - `$HOME` was not evaluating correctly for me (tested on my ubuntu machine), fully-qualified paths fixed it

## 💡 Motivation and Context

Following the [instructions](https://github.com/flashbots/rbuilder?tab=readme-ov-file#end-to-end-local-testing) without changing anything gave me this error:

```txt
δ cargo run --bin rbuilder run config-playground.toml
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.67s
     Running `target/debug/rbuilder run config-playground.toml`
...(truncated)

Error: No such file or directory (os error 2)

Caused by:
    No such file or directory (os error 2)

Location:
    /home/dev/code/rbuilder/crates/rbuilder/src/live_builder/order_input/clean_orderpool.rs:30:20
```

The [line of code](https://github.com/flashbots/rbuilder/blob/develop/crates/rbuilder/src/live_builder/order_input/clean_orderpool.rs#L30) given by the error connects to the IPC provider, which was being initialized with an invalid path given the current instructions & defaults.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
