### PR TITLE
Allow negative coinbase profit in `Order::Tx` and `Order::Bundle`

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -55,7 +55,7 @@ jobs:
           version: nightly
 
       - name: Install native dependencies
-        run: sudo apt-get install -y libsqlite3-dev
+        run: sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y libsqlite3-dev
 
       - name: Lint
         run: make lint

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -1011,16 +1011,11 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                 )?;
                 match res {
                     Ok(ok) => {
+                        // Builder does not sign txs in this code path, so allow negative coinbase
+                        // profit.
                         let coinbase_balance_after = self.state.balance(ctx.block_env.coinbase)?;
-                        let coinbase_profit = match coinbase_profit(
-                            coinbase_balance_before,
-                            coinbase_balance_after,
-                        ) {
-                            Ok(profit) => profit,
-                            Err(err) => {
-                                return Ok(Err(err));
-                            }
-                        };
+                        let coinbase_profit =
+                            coinbase_balance_after.saturating_sub(coinbase_balance_before);
                         Ok(Ok(OrderOk {
                             coinbase_profit,
                             gas_used: ok.gas_used,
@@ -1049,16 +1044,11 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                 )?;
                 match res {
                     Ok(ok) => {
+                        // Builder does not sign txs in this code path, so allow negative coinbase
+                        // profit.
                         let coinbase_balance_after = self.state.balance(ctx.block_env.coinbase)?;
-                        let coinbase_profit = match coinbase_profit(
-                            coinbase_balance_before,
-                            coinbase_balance_after,
-                        ) {
-                            Ok(profit) => profit,
-                            Err(err) => {
-                                return Ok(Err(err));
-                            }
-                        };
+                        let coinbase_profit =
+                            coinbase_balance_after.saturating_sub(coinbase_balance_before);
                         Ok(Ok(OrderOk {
                             coinbase_profit,
                             gas_used: ok.gas_used,
@@ -1088,6 +1078,8 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                 match res {
                     Ok(ok) => {
                         let coinbase_balance_after = self.state.balance(ctx.block_env.coinbase)?;
+                        // Builder does sign txs in this code path, so do not allow negative coinbase
+                        // profit.
                         let coinbase_profit = match coinbase_profit(
                             coinbase_balance_before,
                             coinbase_balance_after,


### PR DESCRIPTION
When disallowed for all `Order` varients, the coinbase account has no way to spend funds when rbuilder is building all blocks for a chain.

Instead of using saturating_sub, I also tried changing `coinbase_profit` from a `U256` to an `I256`, but ran into issues where a `U256` is required to calculate stuff like `mev_gas_price` in later logic. I'd prefer that approach if anyone knows if it is feasible.