### PR TITLE
New flag disable_relay_submit

### DIFF
--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -20,6 +20,8 @@ jsonrpc_server_ip = "0.0.0.0"
 el_node_ipc_path = "/tmp/reth.ipc"
 extra_data = "⚡🤖"
 
+disable_relay_submit = false
+
 blocklist_file_path = "./blocklist.json"
 
 dry_run = true

--- a/crates/rbuilder/src/live_builder/block_output/mod.rs
+++ b/crates/rbuilder/src/live_builder/block_output/mod.rs
@@ -2,4 +2,5 @@ pub mod bid_observer;
 pub mod bid_value_source;
 pub mod bidding;
 pub mod block_sealing_bidder_factory;
+pub mod null_builder_sink_factory;
 pub mod relay_submit;

--- a/crates/rbuilder/src/live_builder/block_output/null_builder_sink_factory.rs
+++ b/crates/rbuilder/src/live_builder/block_output/null_builder_sink_factory.rs
@@ -1,0 +1,39 @@
+//! Null implementation for BuilderSinkFactory. It just throws away the bids.
+//! Useful for testing.
+
+use crate::building::builders::Block;
+use reth_primitives::format_ether;
+use tracing::info;
+
+use super::relay_submit::{BlockBuildingSink, BuilderSinkFactory};
+
+#[derive(Debug)]
+pub struct NullBuilderSinkFactory {}
+
+impl BuilderSinkFactory for NullBuilderSinkFactory {
+    fn create_builder_sink(
+        &self,
+        _slot_data: crate::live_builder::payload_events::MevBoostSlotData,
+        _competition_bid_value_source: std::sync::Arc<
+            dyn super::bid_value_source::interfaces::BidValueSource + Send + Sync,
+        >,
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> Box<dyn super::relay_submit::BlockBuildingSink> {
+        Box::new(NullBuilderSink {})
+    }
+}
+
+#[derive(Debug)]
+struct NullBuilderSink {}
+
+impl BlockBuildingSink for NullBuilderSink {
+    fn new_block(&self, block: Block) {
+        info!(
+            true_bid_value = format_ether(block.trace.true_bid_value),
+            buidler_name = block.builder_name,
+            fill_time_ms = block.trace.fill_time.as_millis(),
+            finalize_time_ms = block.trace.finalize_time.as_millis(),
+            "NullBuilderSink received new block"
+        );
+    }
+}


### PR DESCRIPTION
## 📝 Summary

Added a new flag to disable the submit to relay stage completely.

## 💡 Motivation and Context

This flag allows easier safe testing in some contexts since the builder does not submit bids and no validation API is needed.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
