### PR TITLE
metric block_sim_errors always output zero

### DIFF
--- a/crates/rbuilder/src/telemetry/metrics.rs
+++ b/crates/rbuilder/src/telemetry/metrics.rs
@@ -109,10 +109,7 @@ register_metrics! {
         &["relay", "kind"]
     )
     .unwrap();
-    pub static BLOCK_SIM_ERRORS: IntCounterVec = IntCounterVec::new(
-        Opts::new("block_sim_errors", "counter of block simulation errors"),
-        &[]
-    )
+    pub static BLOCK_SIM_ERRORS: IntCounter = IntCounter::new("block_sim_errors", "counter of block simulation errors")
     .unwrap();
     pub static SIMULATED_OK_ORDERS: IntCounter =
         IntCounter::new("simulated_ok_orders", "Simulated succeeded orders").unwrap();
@@ -246,7 +243,7 @@ pub fn inc_too_many_req_relay_errors(relay: &MevBoostRelayID) {
 }
 
 pub fn inc_failed_block_simulations() {
-    BLOCK_SIM_ERRORS.with_label_values(&[]).inc()
+    BLOCK_SIM_ERRORS.inc()
 }
 
 pub fn set_current_block(block: u64) {


### PR DESCRIPTION
## 📝 Summary

This change removes useless label from block sim error. This makes metrics always output 0 for this metric (before it was outputting nothing). 
## 💡 Motivation and Context

This metric was not in metrics endpoint output so this lead to the following scenario:
* metric was "null" before error
* error happened once and now metric is showing "1"
* alerts based on grafana functions such as "increase" are not triggered because it there are no increase if it was null before it became 1. This is hard to fix on the level of grafana since all solutions are alerting too much or to little.

So we force the metric to always be 0 in the output and it should make alerting on 0 -> 1 correct.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
