### PR TITLE
chore(`reth-rbuilder`): remove unnecesary tracing init

### DIFF
--- a/crates/reth-rbuilder/src/main.rs
+++ b/crates/reth-rbuilder/src/main.rs
@@ -96,10 +96,6 @@ where
         let result = async {
             let config: Config = load_config_toml_and_env(config_path)?;
 
-            // TODO: Check removing this is OK. It seems reth already sets up the global tracing
-            // subscriber, so this fails
-            // config.base_config.setup_tracing_subscriber().expect("Failed to set up rbuilder tracing subscriber");
-
             // Spawn redacted server that is safe for tdx builders to expose
             telemetry::servers::redacted::spawn(
                 config.base_config().redacted_telemetry_server_address(),


### PR DESCRIPTION
## 📝 Summary

Removes the tracing initialization when spawning an `rbuilder` handle.

## 💡 Motivation and Context

Reth indeed boots up tracing itself, so this is indeed unnecessary.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
