### PR TITLE
chore(Dockerfile): add --package=${RBUILDER_BIN} to fix reth-rbuilder container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY ./crates/ ./crates/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo build --release --features="$FEATURES" --bin=${RBUILDER_BIN} --package=${RBUILDER_BIN}
+    cargo build --release --features="$FEATURES" --package=${RBUILDER_BIN}
 
 #
 # Runtime container

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY ./crates/ ./crates/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo build --release --features="$FEATURES" --bin=${RBUILDER_BIN}
+    cargo build --release --features="$FEATURES" --bin=${RBUILDER_BIN} --package=${RBUILDER_BIN}
 
 #
 # Runtime container


### PR DESCRIPTION

## 📝 Summary

The addition of `default-members = ["crates/rbuilder"]` in #244 broke the ability to use `docker build --build-arg RBUILDER_BIN=reth-rbuilder` to build a `reth-rbuilder` container, this should re-enable it.

## 💡 Motivation and Context

We're using the `reth-rbuilder` container in kurtosis for Pectra testing.

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
