### PR TITLE
fix: bump rust version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #
 # Based on https://depot.dev/blog/rust-dockerfile-best-practices
 #
-FROM rust:1.81 as base
+FROM rust:1.82 as base
 
 ARG FEATURES
 


### PR DESCRIPTION
At the latest builds I’m seeing the following errror:
```
builder 3/8] RUN --mount=type=cache,target=/sccache,sharing=locked     cargo chef cook --release --recipe-path recipe.json:
24.80   reth-trie-common@1.1.1 requires rustc 1.82
24.80   reth-trie-db@1.1.1 requires rustc 1.82
24.80   reth-trie-parallel@1.1.1 requires rustc 1.82
24.80 Either upgrade rustc or select compatible dependency versions with
24.80 `cargo update <name>@<current-ver> --precise <compatible-ver>`
24.80 where `<compatible-ver>` is the latest version supporting rustc 1.81.0
24.80 
24.83 thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-chef-0.1.68/src/recipe.rs:218:27:
24.83 Exited with status code: 101
24.83 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
------
Dockerfile:52
```
