### PR TITLE
Show error in config in reth-rbuilder

### DIFF
--- a/crates/reth-rbuilder/src/main.rs
+++ b/crates/reth-rbuilder/src/main.rs
@@ -156,7 +156,7 @@ where
         .await;
 
         if let Err(e) = result {
-            error!("Fatal rbuilder error: {}", e);
+            error!("Fatal rbuilder error: {:#}", e);
             process::exit(1);
         }
 


### PR DESCRIPTION
## 📝 Summary

Before, if there was an error in the config file, it would only show the context error "Config file parsing" but it would not show the specific error. This PR changes that and shows the full error.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
