### PR TITLE
remove_order wrongly routed (bug fix)

### DIFF
--- a/crates/rbuilder/src/building/block_orders/mod.rs
+++ b/crates/rbuilder/src/building/block_orders/mod.rs
@@ -161,7 +161,9 @@ impl BlockOrders {
         &mut self,
         orders: impl IntoIterator<Item = OrderId>,
     ) -> Vec<SimulatedOrder> {
-        self.input_order_store().remove_orders(orders)
+        self.prioritized_order_store
+            .borrow_mut()
+            .remove_orders(orders)
     }
 
     pub fn pop_order(&mut self) -> Option<SimulatedOrder> {


### PR DESCRIPTION
## 📝 Summary

BlockOrders remove orders was routed to MultiShareBundleMerger instead of PrioritizedOrderStore making failed orders cancellation fail.

## 💡 Motivation and Context

Do I need a motivation to fix bugs?

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
