### PR TITLE
OFAC non critical error fix 

### DIFF
--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -278,7 +278,7 @@ pub enum SubmitBlockErr {
     PayloadDelivered,
     #[error("Bid below floor")]
     BidBelowFloor,
-    #[error("Simulation Error")]
+    #[error("Simulation Error: {0}")]
     SimError(String),
     #[error("RPC conversion Error")]
     /// RPC validates the submissions (eg: limit of txs) much more that our model.

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -31,6 +31,16 @@ const GZIP_CONTENT_ENCODING: &str = "gzip";
 const BUILDER_ID_HEADER: &str = "X-Builder-Id";
 const API_TOKEN_HEADER: &str = "X-Api-Token";
 
+/// We don't have nice error codes for relay errors so we have to parse looking for substrings :(
+/// Simulation error base.
+const SIM_FAILED_SUBSTRING: &str = "simulation failed";
+/// Any error containing SIM_FAILED_SUBSTRING and any of SIM_FAILED_NON_CRITICAL_ERRORS is not critical so we should not stop block building.
+const SIM_FAILED_NON_CRITICAL_ERRORS: &[&str] = &[
+    "blacklisted address", // Generated block is good but contains a blacklisted address. This happens if we don't use an OFAC blacklist but the relay does.
+    "unknown ancestor",
+    "missing trie node",
+];
+
 // @Org consolidate with primitives::mev_boost
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -540,8 +550,11 @@ impl RelayClient {
                     }
                     "block already received" => Err(SubmitBlockErr::BlockKnown),
                     _ if msg.contains("read tcp") => Err(RelayError::ConnectionError.into()),
-                    _ if msg.contains("simulation failed") => {
-                        if msg.contains("unknown ancestor") | msg.contains("missing trie node") {
+                    _ if msg.contains(SIM_FAILED_SUBSTRING) => {
+                        if SIM_FAILED_NON_CRITICAL_ERRORS
+                            .iter()
+                            .any(|pat| msg.contains(*pat))
+                        {
                             Err(RelayError::InternalError.into())
                         } else {
                             Err(SubmitBlockErr::SimError(msg.to_string()))

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -278,7 +278,8 @@ pub enum SubmitBlockErr {
     PayloadDelivered,
     #[error("Bid below floor")]
     BidBelowFloor,
-    #[error("Simulation Error: {0}")]
+    #[cfg_attr(not(feature = "redact-sensitive"), error("Simulation Error: {0}"))]
+    #[cfg_attr(feature = "redact-sensitive", error("Simulation Error: [REDACTED]"))]
     SimError(String),
     #[error("RPC conversion Error")]
     /// RPC validates the submissions (eg: limit of txs) much more that our model.


### PR DESCRIPTION
## 📝 Summary

This version considers the error from the relay "block rejected because of OFAC addresses" as non critical.

## 💡 Motivation and Context

Without this change, non OFAC compliant builders would stop building blocks after sending a non-OFAC block to a OFAC complaint relay (flashbot's!).

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
