### PR TITLE
feat: Add nix flake and building `op-rbuilder` and `reth-rbuilder` via flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733581040,
+        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733625333,
+        "narHash": "sha256-tIML2axjm4AnlKP29upVJxzBpj4Cy4ak+PKonqQtXmc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "430c8b054e45ea44fd2c9521a378306ada507a6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "rbuilder";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+
+        # Get both nightly and stable Rust, but nightly is primary
+        rustNightly = pkgs.rust-bin.nightly.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" "cargo" ];
+        };
+        
+        rustStable = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" "cargo" ];
+        };
+
+        # System-specific packages
+        systemSpecific = with pkgs;
+          if stdenv.isDarwin then [
+            darwin.apple_sdk.frameworks.Security
+            darwin.apple_sdk.frameworks.SystemConfiguration
+            darwin.cctools
+            libiconv
+          ] else [
+            glibc
+            gdb
+          ];
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Rust toolchains (nightly first)
+            rustNightly
+            rustStable
+
+            # C/C++ toolchains
+            clang
+            lldb
+            gnumake
+
+            # Development tools
+            pkg-config
+            openssl
+            git
+
+          ] ++ systemSpecific;
+
+          shellHook = ''
+            export RUST_BACKTRACE=1
+            export RUST_SRC_PATH=${rustNightly}/lib/rustlib/src/rust/library
+            
+            # Set CC and CXX environment variables
+            export CC=${pkgs.clang}/bin/clang
+            export CXX=${pkgs.clang}/bin/clang++
+            
+            # Add cargo bins to PATH
+            export PATH=$PATH:$HOME/.cargo/bin
+            
+            # Set nightly as default
+            rustup default nightly 2>/dev/null || true
+            
+            # Platform-specific environment setup
+            ${if pkgs.stdenv.isDarwin then ''
+              export DYLD_LIBRARY_PATH=${pkgs.openssl}/lib:$DYLD_LIBRARY_PATH
+              export LIBRARY_PATH=${pkgs.openssl}/lib:$LIBRARY_PATH
+              export CPPFLAGS="-I${pkgs.openssl}/include"
+              export LDFLAGS="-L${pkgs.openssl}/lib"
+            '' else ''
+              export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
+            ''}
+
+            echo "Nightly Rust toolchain is set as default."
+            echo "Use 'rustup override set stable' to switch to stable if needed."
+          '';
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,5 @@
 {
   description = "rbuilder";
-
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay = {
@@ -9,7 +8,6 @@
     };
     flake-utils.url = "github:numtide/flake-utils";
   };
-
   outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
@@ -17,8 +15,7 @@
         pkgs = import nixpkgs {
           inherit system overlays;
         };
-
-        # Get both nightly and stable Rust, but nightly is primary
+        
         rustNightly = pkgs.rust-bin.nightly.latest.default.override {
           extensions = [ "rust-src" "rust-analyzer" "cargo" ];
         };
@@ -27,7 +24,31 @@
           extensions = [ "rust-src" "rust-analyzer" "cargo" ];
         };
 
-        # System-specific packages
+        readCargoToml = path: 
+          let 
+            toml = builtins.readFile path;
+            match = builtins.match ''.*version = ["']([^"']*)["'].*'' toml;
+          in
+            if match == null then "0.1.0" else builtins.head match;
+
+        filterSource = name: 
+          pkgs.lib.cleanSourceWith {
+            src = ./.;
+            filter = path: type: let 
+              baseName = baseNameOf (toString path);
+              path' = toString path;
+              cratePath = "crates/${name}";
+            in (
+              baseName == "Cargo.toml" ||
+              baseName == "Cargo.lock" ||
+              (pkgs.lib.hasPrefix cratePath path' && (
+                baseName == "Cargo.toml" ||
+                pkgs.lib.hasPrefix "src" baseName ||
+                pkgs.lib.hasSuffix ".rs" baseName
+              ))
+            );
+          };
+
         systemSpecific = with pkgs;
           if stdenv.isDarwin then [
             darwin.apple_sdk.frameworks.Security
@@ -38,41 +59,77 @@
             glibc
             gdb
           ];
+
+        commonBuildInputs = with pkgs; [
+          openssl
+          pkg-config
+        ] ++ systemSpecific;
+
+        commonNativeBuildInputs = with pkgs; [
+          rustNightly
+          pkg-config
+        ];
+
       in
       {
+        packages = {
+          op-rbuilder = pkgs.rustPlatform.buildRustPackage {
+            pname = "op-rbuilder";
+            version = readCargoToml ./crates/op-rbuilder/Cargo.toml;
+            src = filterSource "op-rbuilder";
+            
+            buildInputs = commonBuildInputs;
+            nativeBuildInputs = commonNativeBuildInputs;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              allowBuiltinFetchGit = true;
+            };
+          };
+
+          reth-rbuilder = pkgs.rustPlatform.buildRustPackage {
+            pname = "reth-rbuilder";
+            version = readCargoToml ./crates/reth-rbuilder/Cargo.toml;
+            src = filterSource "reth-rbuilder";
+            
+            buildInputs = commonBuildInputs;
+            nativeBuildInputs = commonNativeBuildInputs;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              allowBuiltinFetchGit = true;
+            };
+          };
+
+          default = self.packages.${system}.op-rbuilder;
+        };
+
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            # Rust toolchains (nightly first)
             rustNightly
             rustStable
-
-            # C/C++ toolchains
             clang
             lldb
             gnumake
-
-            # Development tools
             pkg-config
             openssl
             git
-
           ] ++ systemSpecific;
 
           shellHook = ''
+            export OLD_PS1="$PS1" # Preserve the original PS1
+            export PS1="nix-shell:rbuilder $PS1"
+
             export RUST_BACKTRACE=1
             export RUST_SRC_PATH=${rustNightly}/lib/rustlib/src/rust/library
             
-            # Set CC and CXX environment variables
             export CC=${pkgs.clang}/bin/clang
             export CXX=${pkgs.clang}/bin/clang++
             
-            # Add cargo bins to PATH
             export PATH=$PATH:$HOME/.cargo/bin
             
-            # Set nightly as default
             rustup default nightly 2>/dev/null || true
             
-            # Platform-specific environment setup
             ${if pkgs.stdenv.isDarwin then ''
               export DYLD_LIBRARY_PATH=${pkgs.openssl}/lib:$DYLD_LIBRARY_PATH
               export LIBRARY_PATH=${pkgs.openssl}/lib:$LIBRARY_PATH
@@ -81,9 +138,13 @@
             '' else ''
               export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
             ''}
-
             echo "Nightly Rust toolchain is set as default."
             echo "Use 'rustup override set stable' to switch to stable if needed."
+          '';
+          
+          # reset ps1
+          shellExitHook = ''
+            export PS1="$OLD_PS1"
           '';
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -58,16 +58,20 @@
           ] else [
             glibc
             gdb
+            gcc.cc.lib
           ];
 
         commonBuildInputs = with pkgs; [
           openssl
           pkg-config
+          clang
         ] ++ systemSpecific;
 
         commonNativeBuildInputs = with pkgs; [
           rustNightly
           pkg-config
+          gcc
+          clang
         ];
 
       in
@@ -80,6 +84,8 @@
             
             buildInputs = commonBuildInputs;
             nativeBuildInputs = commonNativeBuildInputs;
+
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
 
             cargoLock = {
               lockFile = ./Cargo.lock;
@@ -95,6 +101,8 @@
             buildInputs = commonBuildInputs;
             nativeBuildInputs = commonNativeBuildInputs;
 
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+
             cargoLock = {
               lockFile = ./Cargo.lock;
               allowBuiltinFetchGit = true;
@@ -108,6 +116,7 @@
           buildInputs = with pkgs; [
             rustNightly
             rustStable
+            gcc
             clang
             lldb
             gnumake
@@ -119,12 +128,13 @@
           shellHook = ''
             export OLD_PS1="$PS1" # Preserve the original PS1
             export PS1="nix-shell:rbuilder $PS1"
-
+            
             export RUST_BACKTRACE=1
             export RUST_SRC_PATH=${rustNightly}/lib/rustlib/src/rust/library
             
-            export CC=${pkgs.clang}/bin/clang
-            export CXX=${pkgs.clang}/bin/clang++
+            export CC=${pkgs.gcc}/bin/gcc
+            export CXX=${pkgs.gcc}/bin/g++
+            export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
             
             export PATH=$PATH:$HOME/.cargo/bin
             
@@ -141,7 +151,7 @@
             echo "Nightly Rust toolchain is set as default."
             echo "Use 'rustup override set stable' to switch to stable if needed."
           '';
-          
+
           # reset ps1
           shellExitHook = ''
             export PS1="$OLD_PS1"


### PR DESCRIPTION
## 📝 Summary

Adds a Nix flake that packages `op-rbuilder` and `reth-rbuilder`. Provides nightly Rust, C/C++ toolchains, and cross-platform support for development and deployment.

## 💡 Motivation and Context

A Nix flake ensures deterministic environments for both development and deployment. This is especially valuable for TEE deployments where reproducible builds are essential. The environment "just works" for developers while guaranteeing consistent deployments.