### PR TITLE
Improve reliability of the database provider health check

### DIFF
--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -22,6 +22,7 @@ use crate::{
     primitives::SimulatedOrder,
     roothash::RootHashConfig,
     telemetry,
+    utils::{check_block_hash_reader_health, HistoricalBlockError},
 };
 
 use super::Block;
@@ -125,6 +126,8 @@ pub enum BlockBuildingHelperError {
     FinalizeError(#[from] FinalizeError),
     #[error("Payout tx not allowed for block")]
     PayoutTxNotAllowed,
+    #[error("Provider historical block hashes error: {0}")]
+    HistoricalBlockError(#[from] HistoricalBlockError),
 }
 
 impl BlockBuildingHelperError {
@@ -174,6 +177,10 @@ where
     ) -> Result<Self, BlockBuildingHelperError> {
         // @Maybe an issue - we have 2 db txs here (one for hash and one for finalize)
         let state_provider = provider.history_by_block_hash(building_ctx.attributes.parent)?;
+
+        let last_committed_block = building_ctx.block() - 1;
+        check_block_hash_reader_health(last_committed_block, &state_provider)?;
+
         let fee_recipient_balance_start = state_provider
             .account_balance(building_ctx.attributes.suggested_fee_recipient)?
             .unwrap_or_default();
@@ -196,6 +203,7 @@ where
             partial_block.reserve_gas(payout_tx_gas);
             Some(payout_tx_gas)
         };
+
         Ok(Self {
             _fee_recipient_balance_start: fee_recipient_balance_start,
             block_state,

--- a/crates/rbuilder/src/utils/mod.rs
+++ b/crates/rbuilder/src/utils/mod.rs
@@ -26,7 +26,8 @@ use alloy_consensus::TxEnvelope;
 use alloy_eips::eip2718::Encodable2718;
 pub use noncer::{NonceCache, NonceCacheRef};
 pub use provider_factory_reopen::{
-    check_provider_factory_health, is_provider_factory_health_error, ProviderFactoryReopener,
+    check_block_hash_reader_health, is_provider_factory_health_error, HistoricalBlockError,
+    ProviderFactoryReopener,
 };
 use reth_chainspec::ChainSpec;
 use reth_evm_ethereum::revm_spec_by_timestamp_after_merge;

--- a/crates/rbuilder/src/utils/provider_factory_reopen.rs
+++ b/crates/rbuilder/src/utils/provider_factory_reopen.rs
@@ -14,6 +14,7 @@ use reth_provider::{
     HeaderProvider, StateProviderBox, StateProviderFactory, StaticFileProviderFactory,
 };
 use revm_primitives::{B256, U256};
+use std::ops::DerefMut;
 use std::{ops::RangeBounds, path::PathBuf, sync::Arc};
 use tracing::debug;
 
@@ -87,7 +88,7 @@ impl<N: NodeTypesWithDB + ProviderNodeTypes + Clone> ProviderFactoryReopener<N> 
         // Don't need to check consistency for the block that was just checked.
         let last_consistent_block = *self.last_consistent_block.read();
         if !self.testing_mode && last_consistent_block != Some(best_block_number) {
-            match check_provider_factory_health(best_block_number, &provider_factory) {
+            match check_block_hash_reader_health(best_block_number, provider_factory.deref_mut()) {
                 Ok(()) => {}
                 Err(err) => {
                     debug!(?err, "Provider factory is inconsistent, reopening");
@@ -102,7 +103,7 @@ impl<N: NodeTypesWithDB + ProviderNodeTypes + Clone> ProviderFactoryReopener<N> 
                 }
             }
 
-            match check_provider_factory_health(best_block_number, &provider_factory) {
+            match check_block_hash_reader_health(best_block_number, provider_factory.deref_mut()) {
                 Ok(()) => {}
                 Err(err) => {
                     inc_provider_bad_reopen_counter();
@@ -127,23 +128,34 @@ pub fn is_provider_factory_health_error(report: &eyre::Error) -> bool {
         .contains("Missing historical block hash for block")
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum HistoricalBlockError {
+    #[error("ProviderError while checking block hashes: {0}")]
+    ProviderError(#[from] ProviderError),
+    #[error("Missing historical block hash for block {missing_hash_block}, latest block: {latest_block}")]
+    MissingHash {
+        missing_hash_block: u64,
+        latest_block: u64,
+    },
+}
+
 /// Here we check if we have all the necessary historical block hashes in the database
 /// This was added as a debugging method because static_files storage was not working correctly
-pub fn check_provider_factory_health<N: NodeTypesWithDB + ProviderNodeTypes>(
-    current_block_number: u64,
-    provider_factory: &ProviderFactory<N>,
-) -> eyre::Result<()> {
+/// last_block_number is the number of the latest committed block (i.e. if we build block 1001 it should be 1000)
+pub fn check_block_hash_reader_health<R: BlockHashReader>(
+    last_block_number: u64,
+    reader: &R,
+) -> Result<(), HistoricalBlockError> {
     // evm must have access to block hashes of 256 of the previous blocks
-    let blocks_to_check = current_block_number.min(256);
-    for i in 1..=blocks_to_check {
-        let num = current_block_number - i;
-        let hash = provider_factory.block_hash(num)?;
+    let blocks_to_check = last_block_number.min(256);
+    for i in 0..blocks_to_check {
+        let num = last_block_number - i;
+        let hash = reader.block_hash(num)?;
         if hash.is_none() {
-            eyre::bail!(
-                "Missing historical block hash for block {}, current block: {}",
-                num,
-                current_block_number
-            );
+            return Err(HistoricalBlockError::MissingHash {
+                missing_hash_block: num,
+                latest_block: last_block_number,
+            });
         }
     }
 


### PR DESCRIPTION
## 📝 Summary

1. It fixes +1 error in the `check_provider_factory_health` method. We need to check last 256 blocks for the block that we are building right now and that mean we need to include latest committed block to the checking range but we were excluding that.
2. It adds additional last check to eliminate possibility of having broken database transaction. 
The way we do this check is that we look at the database provider factory which is not the db transaction but something that creates them. So there is a possibility that we can check provider factory just before it breaks. Checking it in the block builder helper makes this check on the database transaction level so there is a guarantee that the state will not be changed during the lifetime of the block builder helper.

## 💡 Motivation and Context

Database provider factory is likely to be responsible for the incorrect block that we built.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
