### PR TITLE
Order input traces polish

### DIFF
--- a/crates/rbuilder/src/live_builder/order_input/rpc_server.rs
+++ b/crates/rbuilder/src/live_builder/order_input/rpc_server.rs
@@ -55,7 +55,7 @@ pub async fn start_server_accepting_bundles(
             let bundle: Bundle = match raw_bundle.try_into(TxEncoding::WithBlobData) {
                 Ok(bundle) => bundle,
                 Err(err) => {
-                    warn!(?err, "Failed to parse bundle");
+                    warn!(?err, "Failed to decode raw bundle");
                     // @Metric
                     return;
                 }
@@ -86,7 +86,7 @@ pub async fn start_server_accepting_bundles(
             let raw_tx: Bytes = match params.one() {
                 Ok(raw_tx) => raw_tx,
                 Err(err) => {
-                    warn!(?err, "Failed to parse transaction");
+                    warn!(?err, "Failed to parse raw transaction");
                     // @Metric
                     return Err(err);
                 }
@@ -96,7 +96,7 @@ pub async fn start_server_accepting_bundles(
             let tx: MempoolTx = match raw_tx_order.decode(TxEncoding::WithBlobData) {
                 Ok(tx) => tx,
                 Err(err) => {
-                    warn!(?err, "Failed to verify transaction");
+                    warn!(?err, "Failed to decode raw transaction");
                     // @Metric
                     return Err(ErrorObject::owned(-32602, "failed to verify transaction", None::<()>));
                 }
@@ -146,7 +146,7 @@ async fn handle_mev_send_bundle(
     let decode_res = match raw_bundle.decode(TxEncoding::WithBlobData) {
         Ok(res) => res,
         Err(err) => {
-            warn!(?err, "Failed to verify share bundle");
+            warn!(?err, "Failed to decode raw share bundle");
             // @Metric
             return;
         }
@@ -188,7 +188,7 @@ async fn send_command(
     match channel.send_timeout(command, timeout).await {
         Ok(()) => {}
         Err(SendTimeoutError::Timeout(_)) => {
-            warn!("Failed to sent order, timout");
+            warn!("Failed to sent order, timeout");
         }
         Err(SendTimeoutError::Closed(_)) => {}
     };

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -434,8 +434,13 @@ pub enum RawTxWithBlobsConvertError {
     FailedToDecodeTransaction(Eip2718Error),
     #[error("Invalid transaction signature")]
     InvalidTransactionSignature,
-    #[error("Invalid transaction signature")]
+    #[error("UnexpectedError")]
     UnexpectedError,
+    /// This error is generated when we fail (like FailedToDecodeTransaction) parsing in TxEncoding::WithBlobData mode (Network encoding) but the header looks
+    /// like the beginning of an ethereum mainnet Canonical encoding 4484 tx.
+    /// To avoid consuming resources the generation of this error might not be perfect but helps 99% of the time.
+    #[error("Failed to decode transaction, error: {0}. It probably is a 4484 canonical tx.")]
+    FailedToDecodeTransactionProbablyIs4484Canonical(alloy_rlp::Error),
 }
 
 impl TransactionSignedEcRecoveredWithBlobs {

--- a/crates/rbuilder/src/primitives/serialize.rs
+++ b/crates/rbuilder/src/primitives/serialize.rs
@@ -68,7 +68,7 @@ impl TxEncoding {
                 }
             }
         }
-        return false;
+        false
     }
 }
 

--- a/crates/rbuilder/src/primitives/serialize.rs
+++ b/crates/rbuilder/src/primitives/serialize.rs
@@ -4,7 +4,11 @@ use super::{
     ShareBundleInner, ShareBundleReplacementData, ShareBundleReplacementKey, ShareBundleTx,
     TransactionSignedEcRecoveredWithBlobs, TxRevertBehavior,
 };
+use alloy_consensus::constants::EIP4844_TX_TYPE_ID;
+use alloy_eips::eip2718::Eip2718Error;
 use alloy_primitives::{Address, Bytes, B256, U64};
+use alloy_rlp::{Buf, Header};
+use reth_chainspec::MAINNET;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
@@ -30,9 +34,41 @@ impl TxEncoding {
                 TransactionSignedEcRecoveredWithBlobs::decode_enveloped_with_fake_blobs(raw_tx)
             }
             TxEncoding::WithBlobData => {
-                TransactionSignedEcRecoveredWithBlobs::decode_enveloped_with_real_blobs(raw_tx)
+                let raw_tx_clone = raw_tx.clone(); // This clone is supposed to be cheap
+                let res =
+                    TransactionSignedEcRecoveredWithBlobs::decode_enveloped_with_real_blobs(raw_tx);
+                if let Err(RawTxWithBlobsConvertError::FailedToDecodeTransaction(
+                    Eip2718Error::RlpError(err),
+                )) = res
+                {
+                    if Self::looks_like_canonical_blob_tx(raw_tx_clone) {
+                        return Err(RawTxWithBlobsConvertError::FailedToDecodeTransactionProbablyIs4484Canonical(
+                            err,
+                        ));
+                    }
+                }
+                res
             }
         }
+    }
+
+    fn looks_like_canonical_blob_tx(raw_tx: Bytes) -> bool {
+        // For full check we could call TransactionSigned::decode_enveloped and fully try to decode it is way more expensive.
+        // We expect EIP4844_TX_TYPE_ID + rlp(chainId = 01,.....)
+        let mut tx_slice = raw_tx.as_ref();
+        if let Some(tx_type) = tx_slice.first() {
+            if *tx_type == EIP4844_TX_TYPE_ID {
+                tx_slice.advance(1);
+                if let Ok(outer_header) = Header::decode(&mut tx_slice) {
+                    if outer_header.list {
+                        if let Some(chain_id) = tx_slice.first() {
+                            return (*chain_id as u64) == MAINNET.chain().id();
+                        }
+                    }
+                }
+            }
+        }
+        return false;
     }
 }
 
@@ -555,6 +591,7 @@ mod tests {
     use alloy_consensus::Transaction;
     use alloy_eips::eip2718::Encodable2718;
     use alloy_primitives::{address, fixed_bytes, keccak256, U256};
+    use revm_primitives::bytes;
     use uuid::uuid;
 
     #[test]
@@ -949,5 +986,18 @@ mod tests {
         let raw_order: RawOrder =
             serde_json::from_str(raw_tx_json).expect("failed to decode raw order with tx");
         assert!(matches!(raw_order, RawOrder::Tx(_)));
+    }
+
+    /// We decode a 4484 Tx in canonical format using WithBlobData which is for network format.
+    /// We expect the specific error FailedToDecodeTransactionProbablyIs4484Canonical.
+    #[test]
+    fn test_correct_mixed_blob_mode_decoding() {
+        let raw_tx =  bytes!("03f9021b01829f1084db518e44850efef5c902830249f09406a9ab27c7e2255df1815e6cc0168d7755feb19a80b90184648885fb000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001600000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066cc9a0eb519e9e1de68f6cf0aa1aa1efe3723d50000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001efcf00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0843b9aca00e1a00154404fdaef0e93e6a4df6aa099f66fc4f90267b3ef5bb6ac4d3f77a456ae5180a01367ff3e4598620be9424d5be0deafe5b3d3b7221c5f5c3d9fade0f545b19890a0026cd9941cd2aa4df41d5d36aa2e82a671c3226f2924cb206363a9458f38b8f6");
+        let raw_tx_order = RawTx { tx: raw_tx };
+        let tx_res = raw_tx_order.decode(TxEncoding::WithBlobData);
+        assert!(matches!(
+            tx_res,
+            Err(RawTxWithBlobsConvertError::FailedToDecodeTransactionProbablyIs4484Canonical(_))
+        ));
     }
 }


### PR DESCRIPTION
## 📝 Summary

- log polish
- Distinguish 4484 txs wrongly encoded as canonical format as a specific error.

## 💡 Motivation and Context

Trying to chase order input problems.

---

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
