### PR TITLE
Add preset builders to the default config

### DIFF
--- a/config-playground.toml
+++ b/config-playground.toml
@@ -25,7 +25,7 @@ dry_run_validation_url = "http://localhost:8545"
 ignore_cancellable_orders = true
 
 sbundle_mergeabe_signers = []
-live_builders = ["mp-ordering", "mgp-ordering"]
+live_builders = ["mp-ordering", "mgp-ordering", "parallel"]
 
 [[relays]]
 name = "custom"

--- a/config-playground.toml
+++ b/config-playground.toml
@@ -25,7 +25,7 @@ dry_run_validation_url = "http://localhost:8545"
 ignore_cancellable_orders = true
 
 sbundle_mergeabe_signers = []
-live_builders = ["mp-ordering"]
+live_builders = ["mp-ordering", "mgp-ordering"]
 
 [[relays]]
 name = "custom"
@@ -33,19 +33,3 @@ url = "http://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e
 priority = 0
 use_ssz_for_submit = false
 use_gzip_for_submit = false
-
-[[builders]]
-name = "mgp-ordering"
-algo = "ordering-builder"
-discard_txs = true
-sorting = "mev-gas-price"
-failed_order_retries = 1
-drop_failed_orders = true
-
-[[builders]]
-name = "mp-ordering"
-algo = "ordering-builder"
-discard_txs = true
-sorting = "max-profit"
-failed_order_retries = 1
-drop_failed_orders = true

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -422,6 +422,47 @@ impl Default for Config {
                         build_duration_deadline_ms: None,
                     }),
                 },
+                BuilderConfig {
+                    name: String::from("mp-ordering-deadline"),
+                    builder: SpecificBuilderConfig::OrderingBuilder(OrderingBuilderConfig {
+                        discard_txs: true,
+                        sorting: Sorting::MaxProfit,
+                        failed_order_retries: 1,
+                        drop_failed_orders: true,
+                        coinbase_payment: false,
+                        build_duration_deadline_ms: Some(30),
+                    }),
+                },
+                BuilderConfig {
+                    name: String::from("mp-ordering-cb"),
+                    builder: SpecificBuilderConfig::OrderingBuilder(OrderingBuilderConfig {
+                        discard_txs: true,
+                        sorting: Sorting::MaxProfit,
+                        failed_order_retries: 1,
+                        drop_failed_orders: true,
+                        coinbase_payment: true,
+                        build_duration_deadline_ms: None,
+                    }),
+                },
+                BuilderConfig {
+                    name: String::from("mgp-ordering-default"),
+                    builder: SpecificBuilderConfig::OrderingBuilder(OrderingBuilderConfig {
+                        discard_txs: true,
+                        sorting: Sorting::MevGasPrice,
+                        failed_order_retries: 1,
+                        drop_failed_orders: false,
+                        coinbase_payment: false,
+                        build_duration_deadline_ms: None,
+                    }),
+                },
+                BuilderConfig {
+                    name: String::from("parallel"),
+                    builder: SpecificBuilderConfig::ParallelBuilder(ParallelBuilderConfig {
+                        discard_txs: true,
+                        num_threads: 25,
+                        coinbase_payment: false,
+                    }),
+                },
             ],
         }
     }


### PR DESCRIPTION
## 📝 Summary

Currently, users need to manually configure block builders by writing out full builder configurations. However, there are only a limited number of meaningful builder configurations that make sense in practice and are allowed on the builder algos. Having users write custom configurations is unnecessary complexity when we can provide all the practical presets out of the box.

This PR provides all the meaningful builder configurations as ready-to-use presets. Users can simply enable the builders they need instead of dealing with detailed configuration. This PR is backwards compatible, the users can still provide their own builder configurations.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
