### PR TITLE
Validate builder configs in CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -63,6 +63,9 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Validate config files
+        run: make validate-config
+
   integration:
     name: Integration tests
     runs-on: warp-ubuntu-latest-x64-16x

--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,8 @@ bench-prettify: ## Prettifies the latest Criterion report
 	./scripts/ci/criterion-prettify-report.sh target/criterion target/benchmark-html-dev
 	@echo "\nopen target/benchmark-html-dev/report/index.html"
 
+.PHONY: validate-config
+validate-config: ## Validate the correctness of the configuration files
+	@for CONFIG in $(shell ls config-*.toml); do \
+		cargo run --bin validate-config -- --config $$CONFIG; \
+	done

--- a/crates/rbuilder/src/bin/validate-config.rs
+++ b/crates/rbuilder/src/bin/validate-config.rs
@@ -1,0 +1,23 @@
+//! CLI tool to validate a rbuilder config file
+
+use clap::Parser;
+use rbuilder::live_builder::{base_config::load_config_toml_and_env, config::Config};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    #[clap(long, help = "Config file path", env = "RBUILDER_CONFIG")]
+    config: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    let cli = Cli::parse();
+
+    let config_path = &cli.config;
+    let _: Config = load_config_toml_and_env(config_path)?;
+
+    println!("Config file '{}' is valid", config_path.display());
+
+    Ok(())
+}


### PR DESCRIPTION
## 📝 Summary

Add a CLI tool to validate the builder config and run it in CI to validate all configs found in the root of the repo.

## 💡 Motivation and Context

Fix https://github.com/flashbots/rbuilder/issues/278

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
