### PR TITLE
Move bundle merger

### DIFF
--- a/crates/rbuilder/src/backtest/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_block.rs
@@ -124,7 +124,6 @@ where
                 let input = BacktestSimulateBlockInput {
                     ctx: ctx.clone(),
                     builder_name: builder_name.clone(),
-                    sbundle_mergeabe_signers: sbundle_mergeabe_signers.clone(),
                     sim_orders: &sim_orders,
                     provider: provider_factory.clone(),
                     cached_reads: None,

--- a/crates/rbuilder/src/backtest/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_block.rs
@@ -90,7 +90,6 @@ where
 
     let provider_factory = config.base_config().create_provider_factory()?;
     let chain_spec = config.base_config().chain_spec()?;
-    let sbundle_mergeabe_signers = config.base_config().sbundle_mergeabe_signers();
 
     if cli.sim_landed_block {
         let tx_sim_results = sim_historical_block(
@@ -109,6 +108,7 @@ where
         chain_spec.clone(),
         cli.block_building_time_ms,
         config.base_config().blocklist()?,
+        &config.base_config().sbundle_mergeabe_signers(),
         config.base_config().coinbase_signer()?,
     )?;
 

--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -166,7 +166,6 @@ where
         let input = BacktestSimulateBlockInput {
             ctx: ctx.clone(),
             builder_name: building_algorithm_name.clone(),
-            sbundle_mergeabe_signers: sbundle_mergeabe_signers.to_vec(),
             sim_orders: &sim_orders,
             provider: provider.clone(),
             cached_reads,

--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -1,8 +1,9 @@
 use crate::{
     backtest::BlockData,
     building::{
-        builders::BacktestSimulateBlockInput, sim::simulate_all_orders_with_sim_tree,
-        BlockBuildingContext, BundleErr, OrderErr, TransactionErr,
+        builders::BacktestSimulateBlockInput, multi_share_bundle_merger::MultiShareBundleMerger,
+        sim::simulate_all_orders_with_sim_tree, BlockBuildingContext, BundleErr, OrderErr,
+        SimulatedOrderSink, SimulatedOrderStore, TransactionErr,
     },
     live_builder::cli::LiveBuilderConfig,
     primitives::{OrderId, SimulatedOrder},
@@ -15,7 +16,7 @@ use reth_chainspec::ChainSpec;
 use reth_db::Database;
 use reth_provider::{BlockReader, DatabaseProviderFactory, HeaderProvider, StateProviderFactory};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BacktestBuilderOutput {
@@ -61,6 +62,7 @@ pub fn backtest_prepare_ctx_for_block<P>(
     chain_spec: Arc<ChainSpec>,
     build_block_lag_ms: i64,
     blocklist: HashSet<Address>,
+    sbundle_mergeabe_signers: &[Address],
     builder_signer: Signer,
 ) -> eyre::Result<BacktestBlockInput>
 where
@@ -89,6 +91,14 @@ where
     );
     let (sim_orders, sim_errors) =
         simulate_all_orders_with_sim_tree(provider.clone(), &ctx, &orders, false)?;
+
+    // Apply bundle merging as in live building.
+    let order_store = Rc::new(RefCell::new(SimulatedOrderStore::new()));
+    let mut merger = MultiShareBundleMerger::new(sbundle_mergeabe_signers, order_store.clone());
+    for sim_order in sim_orders {
+        merger.insert_order(sim_order);
+    }
+    let sim_orders = order_store.borrow().get_orders();
     Ok(BacktestBlockInput {
         ctx,
         sim_orders,
@@ -126,6 +136,7 @@ where
         chain_spec.clone(),
         build_block_lag_ms,
         blocklist,
+        sbundle_mergeabe_signers,
         config.base_config().coinbase_signer()?,
     )?;
 

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -114,6 +114,7 @@ async fn main() -> eyre::Result<()> {
         run_sparse_trie_prefetcher: false,
         orderpool_sender,
         orderpool_receiver,
+        sbundle_merger_selected_signers: Default::default(),
     };
 
     let ctrlc = tokio::spawn(async move {

--- a/crates/rbuilder/src/building/block_orders/mod.rs
+++ b/crates/rbuilder/src/building/block_orders/mod.rs
@@ -7,17 +7,12 @@ mod order_dumper;
 #[cfg(test)]
 mod test_context;
 mod test_data_generator;
-
-use std::{cell::RefCell, rc::Rc};
-
 use crate::{
     building::Sorting,
     live_builder::simulation::SimulatedOrderCommand,
     primitives::{AccountNonce, OrderId, SimulatedOrder},
 };
 use ahash::HashMap;
-use alloy_primitives::Address;
-use multi_share_bundle_merger::MultiShareBundleMerger;
 use reth_errors::ProviderResult;
 use reth_provider::StateProviderBox;
 
@@ -53,30 +48,11 @@ pub fn simulated_order_command_to_sink<SinkType: SimulatedOrderSink>(
     };
 }
 
-/// Chained composition of [`ShareBundleMerger`] -> [`PrioritizedOrderStore`] allowing merged orders in an prioritized store
+/// Wrapper on [`PrioritizedOrderStore`] soon will die.
 /// IMPORTANT: Read comments for PrioritizedOrderStore to see how to use (add_order here is insert_order) since nonces are a little tricky
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BlockOrders {
-    prioritized_order_store: Rc<RefCell<PrioritizedOrderStore>>,
-    share_bundle_merger: Box<MultiShareBundleMerger<PrioritizedOrderStore>>,
-}
-
-impl Clone for BlockOrders {
-    /// This cloning is tricky since we don't want to clone the Rcs we want to clone the real objects.
-    fn clone(&self) -> Self {
-        let prioritized_order_store =
-            Rc::new(RefCell::new(self.prioritized_order_store.borrow().clone()));
-
-        let share_bundle_merger = Box::new(
-            self.share_bundle_merger
-                .clone_with_sink(prioritized_order_store.clone()),
-        );
-
-        Self {
-            prioritized_order_store,
-            share_bundle_merger,
-        }
-    }
+    prioritized_order_store: PrioritizedOrderStore,
 }
 
 /// SimulatedOrderSink that stores all orders + all the adds from last drain_new_orders ONLY if we didn't see removes.
@@ -131,31 +107,16 @@ impl BlockOrders {
     pub fn new(
         priority: Sorting,
         initial_onchain_nonces: impl IntoIterator<Item = AccountNonce>,
-        sbundle_merger_selected_signers: &[Address],
     ) -> Self {
         let mut onchain_nonces = HashMap::default();
         for onchain_nonce in initial_onchain_nonces {
             onchain_nonces.insert(onchain_nonce.account, onchain_nonce.nonce);
         }
 
-        let prioritized_order_store = Rc::new(RefCell::new(PrioritizedOrderStore::new(
-            priority,
-            onchain_nonces,
-        )));
-
-        let share_bundle_merger = Box::new(MultiShareBundleMerger::new(
-            sbundle_merger_selected_signers,
-            prioritized_order_store.clone(),
-        ));
-
+        let prioritized_order_store = PrioritizedOrderStore::new(priority, onchain_nonces);
         Self {
             prioritized_order_store,
-            share_bundle_merger,
         }
-    }
-
-    fn input_order_store(&mut self) -> &mut MultiShareBundleMerger<PrioritizedOrderStore> {
-        &mut self.share_bundle_merger
     }
 
     pub fn add_order(&mut self, order: SimulatedOrder) {
@@ -166,41 +127,37 @@ impl BlockOrders {
     /// Use ONLY if you are using BlockOrders as an static priority with no new add_order/remove_order etc.
     /// @Pending For this cases it would probably be better to have a PrioritizedOrderStore instead of a BlockOrders
     pub fn readd_order(&mut self, order: SimulatedOrder) {
-        self.prioritized_order_store
-            .borrow_mut()
-            .insert_order(order);
+        self.prioritized_order_store.insert_order(order);
     }
 
     pub fn remove_orders(
         &mut self,
         orders: impl IntoIterator<Item = OrderId>,
     ) -> Vec<SimulatedOrder> {
-        self.prioritized_order_store
-            .borrow_mut()
-            .remove_orders(orders)
+        self.prioritized_order_store.remove_orders(orders)
     }
 
     pub fn pop_order(&mut self) -> Option<SimulatedOrder> {
-        self.prioritized_order_store.borrow_mut().pop_order()
+        self.prioritized_order_store.pop_order()
     }
 
     pub fn update_onchain_nonces(&mut self, new_nonces: &[AccountNonce]) {
         self.prioritized_order_store
-            .borrow_mut()
             .update_onchain_nonces(new_nonces);
     }
 
     pub fn get_all_orders(&self) -> Vec<SimulatedOrder> {
-        self.prioritized_order_store.borrow().get_all_orders()
+        self.prioritized_order_store.get_all_orders()
     }
 }
+
 impl SimulatedOrderSink for BlockOrders {
     fn insert_order(&mut self, order: SimulatedOrder) {
-        self.input_order_store().insert_order(order);
+        self.prioritized_order_store.insert_order(order);
     }
 
     fn remove_order(&mut self, id: OrderId) -> Option<SimulatedOrder> {
-        self.input_order_store().remove_order(id)
+        self.prioritized_order_store.remove_order(id)
     }
 }
 
@@ -209,7 +166,6 @@ pub fn block_orders_from_sim_orders(
     sim_orders: &[SimulatedOrder],
     sorting: Sorting,
     state_provider: &StateProviderBox,
-    sbundle_merger_selected_signers: &[Address],
 ) -> ProviderResult<BlockOrders> {
     let mut onchain_nonces = vec![];
     for order in sim_orders {
@@ -223,8 +179,7 @@ pub fn block_orders_from_sim_orders(
             });
         }
     }
-    let mut block_orders =
-        BlockOrders::new(sorting, onchain_nonces, sbundle_merger_selected_signers);
+    let mut block_orders = BlockOrders::new(sorting, onchain_nonces);
 
     for order in sim_orders.iter().cloned() {
         block_orders.add_order(order);

--- a/crates/rbuilder/src/building/block_orders/mod.rs
+++ b/crates/rbuilder/src/building/block_orders/mod.rs
@@ -12,6 +12,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use crate::{
     building::Sorting,
+    live_builder::simulation::SimulatedOrderCommand,
     primitives::{AccountNonce, OrderId, SimulatedOrder},
 };
 use ahash::HashMap;
@@ -37,6 +38,19 @@ pub trait SimulatedOrderSink {
         }
         result
     }
+}
+
+/// Sends command to sink calling the proper function.
+pub fn simulated_order_command_to_sink<SinkType: SimulatedOrderSink>(
+    command: SimulatedOrderCommand,
+    sink: &mut SinkType,
+) {
+    match command {
+        SimulatedOrderCommand::Simulation(sim_order) => sink.insert_order(sim_order),
+        SimulatedOrderCommand::Cancellation(id) => {
+            let _ = sink.remove_order(id);
+        }
+    };
 }
 
 /// Chained composition of [`ShareBundleMerger`] -> [`PrioritizedOrderStore`] allowing merged orders in an prioritized store

--- a/crates/rbuilder/src/building/block_orders/mod.rs
+++ b/crates/rbuilder/src/building/block_orders/mod.rs
@@ -209,7 +209,7 @@ mod test {
                 nonce.clone(),
                 TestContext {
                     data_gen,
-                    order_pool: BlockOrders::new(Sorting::MaxProfit, vec![nonce], &[]),
+                    order_pool: BlockOrders::new(Sorting::MaxProfit, vec![nonce]),
                 },
             )
         }
@@ -227,7 +227,7 @@ mod test {
                 nonce_2.clone(),
                 TestContext {
                     data_gen,
-                    order_pool: BlockOrders::new(Sorting::MaxProfit, vec![nonce_1, nonce_2], &[]),
+                    order_pool: BlockOrders::new(Sorting::MaxProfit, vec![nonce_1, nonce_2]),
                 },
             )
         }

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -26,6 +26,8 @@ use tokio::sync::{broadcast, broadcast::error::TryRecvError};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use super::simulated_order_command_to_sink;
+
 /// Block we built
 #[derive(Debug, Clone)]
 pub struct Block {
@@ -98,12 +100,7 @@ impl OrderConsumer {
     // Apply insertions and sbundle cancellations on sink
     pub fn apply_new_commands<SinkType: SimulatedOrderSink>(&mut self, sink: &mut SinkType) {
         for order_command in self.new_commands.drain(..) {
-            match order_command {
-                SimulatedOrderCommand::Simulation(sim_order) => sink.insert_order(sim_order),
-                SimulatedOrderCommand::Cancellation(id) => {
-                    let _ = sink.remove_order(id);
-                }
-            };
+            simulated_order_command_to_sink(order_command, sink);
         }
     }
 }

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -49,7 +49,6 @@ pub struct LiveBuilderInput<P, DB> {
     pub sink: Arc<dyn UnfinishedBlockBuildingSink>,
     pub builder_name: String,
     pub cancel: CancellationToken,
-    pub sbundle_mergeabe_signers: Vec<Address>,
     phantom: PhantomData<DB>,
 }
 
@@ -125,13 +124,12 @@ where
         orders: broadcast::Receiver<SimulatedOrderCommand>,
         parent_block: B256,
         sorting: Sorting,
-        sbundle_merger_selected_signers: &[Address],
     ) -> Self {
         let nonce_cache = NonceCache::new(provider, parent_block);
 
         Self {
             nonce_cache,
-            block_orders: BlockOrders::new(sorting, vec![], sbundle_merger_selected_signers),
+            block_orders: BlockOrders::new(sorting, vec![]),
             onchain_nonces_updated: HashSet::default(),
             order_consumer: OrderConsumer::new(orders),
         }
@@ -242,7 +240,6 @@ pub trait UnfinishedBlockBuildingSinkFactory: Debug + Send + Sync {
 pub struct BacktestSimulateBlockInput<'a, P> {
     pub ctx: BlockBuildingContext,
     pub builder_name: String,
-    pub sbundle_mergeabe_signers: Vec<Address>,
     pub sim_orders: &'a Vec<SimulatedOrder>,
     pub provider: P,
     pub cached_reads: Option<CachedReads>,

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -17,7 +17,6 @@ use crate::{
     roothash::RootHashConfig,
 };
 use ahash::{HashMap, HashSet};
-use alloy_primitives::Address;
 use reth::revm::cached::CachedReads;
 use reth_db::database::Database;
 use reth_provider::{BlockReader, DatabaseProviderFactory, StateProviderFactory};
@@ -75,7 +74,6 @@ where
         input.input,
         input.ctx.attributes.parent,
         config.sorting,
-        &input.sbundle_mergeabe_signers,
     );
 
     let mut builder = OrderingBuilderContext::new(
@@ -147,12 +145,8 @@ where
     let state_provider = input
         .provider
         .history_by_block_number(input.ctx.block_env.number.to::<u64>() - 1)?;
-    let block_orders = block_orders_from_sim_orders(
-        input.sim_orders,
-        ordering_config.sorting,
-        &state_provider,
-        &input.sbundle_mergeabe_signers,
-    )?;
+    let block_orders =
+        block_orders_from_sim_orders(input.sim_orders, ordering_config.sorting, &state_provider)?;
     let mut builder = OrderingBuilderContext::new(
         input.provider.clone(),
         input.builder_name,
@@ -346,7 +340,6 @@ where
 #[derive(Debug)]
 pub struct OrderingBuildingAlgorithm {
     root_hash_config: RootHashConfig,
-    sbundle_mergeabe_signers: Vec<Address>,
     config: OrderingBuilderConfig,
     name: String,
 }
@@ -354,13 +347,11 @@ pub struct OrderingBuildingAlgorithm {
 impl OrderingBuildingAlgorithm {
     pub fn new(
         root_hash_config: RootHashConfig,
-        sbundle_mergeabe_signers: Vec<Address>,
         config: OrderingBuilderConfig,
         name: String,
     ) -> Self {
         Self {
             root_hash_config,
-            sbundle_mergeabe_signers,
             config,
             name,
         }
@@ -388,7 +379,6 @@ where
             sink: input.sink,
             builder_name: self.name.clone(),
             cancel: input.cancel,
-            sbundle_mergeabe_signers: self.sbundle_mergeabe_signers.clone(),
             phantom: Default::default(),
         };
         run_ordering_builder(live_input, &self.config);

--- a/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
@@ -35,7 +35,6 @@ use crate::{
     },
     roothash::RootHashConfig,
 };
-use alloy_primitives::Address;
 use reth::revm::cached::CachedReads;
 use reth_db::database::Database;
 use reth_provider::{BlockReader, DatabaseProviderFactory, StateProviderFactory};
@@ -132,8 +131,7 @@ where
             Some(input.sink.clone()),
         );
 
-        let order_intake_consumer =
-            OrderIntakeStore::new(input.input, &input.sbundle_mergeabe_signers);
+        let order_intake_consumer = OrderIntakeStore::new(input.input);
 
         Self {
             order_intake_consumer,
@@ -384,7 +382,6 @@ where
 #[derive(Debug)]
 pub struct ParallelBuildingAlgorithm {
     root_hash_config: RootHashConfig,
-    sbundle_mergeabe_signers: Vec<Address>,
     config: ParallelBuilderConfig,
     name: String,
 }
@@ -392,13 +389,11 @@ pub struct ParallelBuildingAlgorithm {
 impl ParallelBuildingAlgorithm {
     pub fn new(
         root_hash_config: RootHashConfig,
-        sbundle_mergeabe_signers: Vec<Address>,
         config: ParallelBuilderConfig,
         name: String,
     ) -> Self {
         Self {
             root_hash_config,
-            sbundle_mergeabe_signers,
             config,
             name,
         }
@@ -426,7 +421,6 @@ where
             sink: input.sink,
             builder_name: self.name.clone(),
             cancel: input.cancel,
-            sbundle_mergeabe_signers: self.sbundle_mergeabe_signers.clone(),
             phantom: Default::default(),
         };
         run_parallel_builder(live_input, &self.config);

--- a/crates/rbuilder/src/building/builders/parallel_builder/order_intake_store.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/order_intake_store.rs
@@ -1,61 +1,43 @@
-use std::{cell::RefCell, rc::Rc};
-
-use alloy_primitives::Address;
 use tokio::sync::broadcast;
 
 use crate::{
-    building::{
-        builders::OrderConsumer, multi_share_bundle_merger::MultiShareBundleMerger,
-        SimulatedOrderStore,
-    },
+    building::{builders::OrderConsumer, SimulatedOrderStore},
     live_builder::simulation::SimulatedOrderCommand,
     primitives::SimulatedOrder,
 };
 
 /// Struct that allow getting the new orders from the order/cancellation stream in the way the parallel builder likes it.
 /// Contains the current whole set of orders but also can be queried for deltas on the orders ONLY if the deltas are all additions
-/// Chains MultiShareBundleMerger->SimulatedOrderStore
 /// Usage:
 /// call consume_next_batch to poll the source and internally store the new orders
 /// call drain_new_orders/get_orders
 pub struct OrderIntakeStore {
     order_consumer: OrderConsumer,
-    share_bundle_merger: Box<MultiShareBundleMerger<SimulatedOrderStore>>,
-    order_sink: Rc<RefCell<SimulatedOrderStore>>,
+    order_sink: SimulatedOrderStore,
 }
 
 impl OrderIntakeStore {
-    pub fn new(
-        orders_input_stream: broadcast::Receiver<SimulatedOrderCommand>,
-        sbundle_merger_selected_signers: &[Address],
-    ) -> Self {
-        let order_sink = Rc::new(RefCell::new(SimulatedOrderStore::new()));
-        let share_bundle_merger = Box::new(MultiShareBundleMerger::new(
-            sbundle_merger_selected_signers,
-            order_sink.clone(),
-        ));
-
+    pub fn new(orders_input_stream: broadcast::Receiver<SimulatedOrderCommand>) -> Self {
+        let order_sink = SimulatedOrderStore::new();
         Self {
             order_consumer: OrderConsumer::new(orders_input_stream),
-            share_bundle_merger,
             order_sink,
         }
     }
 
     pub fn consume_next_batch(&mut self) -> eyre::Result<bool> {
         self.order_consumer.consume_next_commands()?;
-        let input: &mut MultiShareBundleMerger<SimulatedOrderStore> = &mut self.share_bundle_merger;
-        self.order_consumer.apply_new_commands(input);
+        self.order_consumer.apply_new_commands(&mut self.order_sink);
         Ok(true)
     }
 
     /// returns the new orders since last call if we ONLY had new orders (no cancellations allowed)
     pub fn drain_new_orders(&mut self) -> Option<Vec<SimulatedOrder>> {
-        (*self.order_sink).borrow_mut().drain_new_orders()
+        self.order_sink.drain_new_orders()
     }
 
     /// All the current orders
     pub fn get_orders(&self) -> Vec<SimulatedOrder> {
-        self.order_sink.borrow().get_orders()
+        self.order_sink.get_orders()
     }
 }

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -232,6 +232,9 @@ impl BaseConfig {
 
             orderpool_sender,
             orderpool_receiver,
+            sbundle_merger_selected_signers: Arc::new(
+                self.sbundle_mergeabe_signers.clone().unwrap_or_default(),
+            ),
         })
     }
 

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -1,17 +1,20 @@
-use std::{marker::PhantomData, sync::Arc, time::Duration};
+use std::{cell::RefCell, marker::PhantomData, rc::Rc, sync::Arc, thread, time::Duration};
 
 use crate::{
     building::{
         builders::{
             BlockBuildingAlgorithm, BlockBuildingAlgorithmInput, UnfinishedBlockBuildingSinkFactory,
         },
-        BlockBuildingContext,
+        multi_share_bundle_merger::MultiShareBundleMerger,
+        simulated_order_command_to_sink, BlockBuildingContext, SimulatedOrderSink,
     },
     live_builder::{payload_events::MevBoostSlotData, simulation::SlotOrderSimResults},
+    primitives::{OrderId, SimulatedOrder},
     roothash::run_trie_prefetcher,
 };
 use reth_db::Database;
 use reth_provider::{BlockReader, DatabaseProviderFactory, StateProviderFactory};
+use revm_primitives::Address;
 use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, trace};
@@ -21,7 +24,7 @@ use super::{
         self, order_replacement_manager::OrderReplacementManager, orderpool::OrdersForBlock,
     },
     payload_events,
-    simulation::OrderSimulationPool,
+    simulation::{OrderSimulationPool, SimulatedOrderCommand},
 };
 
 #[derive(Debug)]
@@ -32,6 +35,7 @@ pub struct BlockBuildingPool<P, DB> {
     orderpool_subscriber: order_input::OrderPoolSubscriber,
     order_simulation_pool: OrderSimulationPool<P>,
     run_sparse_trie_prefetcher: bool,
+    sbundle_merger_selected_signers: Arc<Vec<Address>>,
     phantom: PhantomData<DB>,
 }
 
@@ -50,6 +54,7 @@ where
         orderpool_subscriber: order_input::OrderPoolSubscriber,
         order_simulation_pool: OrderSimulationPool<P>,
         run_sparse_trie_prefetcher: bool,
+        sbundle_merger_selected_signers: Arc<Vec<Address>>,
     ) -> Self {
         BlockBuildingPool {
             provider,
@@ -58,6 +63,7 @@ where
             orderpool_subscriber,
             order_simulation_pool,
             run_sparse_trie_prefetcher,
+            sbundle_merger_selected_signers,
             phantom: PhantomData,
         }
     }
@@ -145,17 +151,71 @@ where
             });
         }
 
-        tokio::spawn(multiplex_job(input.orders, broadcast_input));
+        let sbundle_merger_selected_signers = self.sbundle_merger_selected_signers.clone();
+        thread::spawn(move || {
+            merge_and_send(
+                input.orders,
+                broadcast_input,
+                &sbundle_merger_selected_signers,
+            )
+        });
+
+        //        tokio::spawn();
     }
 }
 
-async fn multiplex_job<T>(mut input: mpsc::Receiver<T>, sender: broadcast::Sender<T>) {
+/// Implements SimulatedOrderSink and sends everything to a broadcast::Sender as SimulatedOrderCommand.
+struct SimulatedOrderSinkToChannel {
+    sender: broadcast::Sender<SimulatedOrderCommand>,
+    sender_returned_error: bool,
+}
+
+impl SimulatedOrderSinkToChannel {
+    pub fn new(sender: broadcast::Sender<SimulatedOrderCommand>) -> Self {
+        Self {
+            sender,
+            sender_returned_error: false,
+        }
+    }
+
+    pub fn sender_returned_error(&self) -> bool {
+        self.sender_returned_error
+    }
+}
+
+impl SimulatedOrderSink for SimulatedOrderSinkToChannel {
+    fn insert_order(&mut self, order: SimulatedOrder) {
+        self.sender_returned_error |= self
+            .sender
+            .send(SimulatedOrderCommand::Simulation(order))
+            .is_err()
+    }
+
+    fn remove_order(&mut self, id: OrderId) -> Option<SimulatedOrder> {
+        self.sender_returned_error |= self
+            .sender
+            .send(SimulatedOrderCommand::Cancellation(id))
+            .is_err();
+        None
+    }
+}
+
+/// Merges (see [`MultiShareBundleMerger`]) simulated orders from input and forwards the result to sender.
+fn merge_and_send(
+    mut input: mpsc::Receiver<SimulatedOrderCommand>,
+    sender: broadcast::Sender<SimulatedOrderCommand>,
+    sbundle_merger_selected_signers: &[Address],
+) {
+    let sender = Rc::new(RefCell::new(SimulatedOrderSinkToChannel::new(sender)));
+    let mut merger = MultiShareBundleMerger::new(sbundle_merger_selected_signers, sender.clone());
     // we don't worry about waiting for input forever because it will be closed by producer job
-    while let Some(input) = input.recv().await {
+    while let Some(input) = input.blocking_recv() {
+        simulated_order_command_to_sink(input, &mut merger);
         // we don't create new subscribers to the broadcast so here we can be sure that err means end of receivers
-        if sender.send(input).is_err() {
+        if sender.borrow().sender_returned_error() {
+            trace!("Cancelling merge_and_send job, destination stopped");
             return;
         }
     }
-    trace!("Cancelling multiplex job");
+    trace!("Cancelling merge_and_send job, source stopped");
 }

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -490,14 +490,13 @@ where
 {
     configs
         .into_iter()
-        .map(|cfg| create_builder(cfg, &root_hash_config, &sbundle_mergeabe_signers))
+        .map(|cfg| create_builder(cfg, &root_hash_config))
         .collect()
 }
 
 fn create_builder<P, DB>(
     cfg: BuilderConfig,
     root_hash_config: &RootHashConfig,
-    sbundle_mergeabe_signers: &[Address],
 ) -> Arc<dyn BlockBuildingAlgorithm<P, DB>>
 where
     DB: Database + Clone + 'static,
@@ -507,22 +506,12 @@ where
         + 'static,
 {
     match cfg.builder {
-        SpecificBuilderConfig::OrderingBuilder(order_cfg) => {
-            Arc::new(OrderingBuildingAlgorithm::new(
-                root_hash_config.clone(),
-                sbundle_mergeabe_signers.to_vec(),
-                order_cfg,
-                cfg.name,
-            ))
-        }
-        SpecificBuilderConfig::ParallelBuilder(parallel_cfg) => {
-            Arc::new(ParallelBuildingAlgorithm::new(
-                root_hash_config.clone(),
-                sbundle_mergeabe_signers.to_vec(),
-                parallel_cfg,
-                cfg.name,
-            ))
-        }
+        SpecificBuilderConfig::OrderingBuilder(order_cfg) => Arc::new(
+            OrderingBuildingAlgorithm::new(root_hash_config.clone(), order_cfg, cfg.name),
+        ),
+        SpecificBuilderConfig::ParallelBuilder(parallel_cfg) => Arc::new(
+            ParallelBuildingAlgorithm::new(root_hash_config.clone(), parallel_cfg, cfg.name),
+        ),
     }
 }
 

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -39,7 +39,7 @@ use crate::{
 use alloy_chains::ChainKind;
 use alloy_primitives::{
     utils::{format_ether, parse_ether},
-    Address, FixedBytes, B256,
+    FixedBytes, B256,
 };
 use ethereum_consensus::{
     builder::compute_builder_domain, crypto::SecretKey, primitives::Version,
@@ -340,11 +340,7 @@ impl LiveBuilderConfig for Config {
             )
             .await?;
         let root_hash_config = self.base_config.live_root_hash_config()?;
-        let builders = create_builders(
-            self.live_builders()?,
-            root_hash_config,
-            self.base_config.sbundle_mergeabe_signers(),
-        );
+        let builders = create_builders(self.live_builders()?, root_hash_config);
         Ok(live_builder.with_builders(builders))
     }
 
@@ -479,7 +475,6 @@ pub fn coinbase_signer_from_secret_key(secret_key: &str) -> eyre::Result<Signer>
 pub fn create_builders<P, DB>(
     configs: Vec<BuilderConfig>,
     root_hash_config: RootHashConfig,
-    sbundle_mergeabe_signers: Vec<Address>,
 ) -> Vec<Arc<dyn BlockBuildingAlgorithm<P, DB>>>
 where
     DB: Database + Clone + 'static,

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -110,6 +110,7 @@ where
     /// Notify rbuilder of new [`ReplaceableOrderPoolCommand`] flow via this channel.
     pub orderpool_sender: mpsc::Sender<ReplaceableOrderPoolCommand>,
     pub orderpool_receiver: mpsc::Receiver<ReplaceableOrderPoolCommand>,
+    pub sbundle_merger_selected_signers: Arc<Vec<Address>>,
 }
 
 impl<P, DB, BlocksSourceType: SlotSource> LiveBuilder<P, DB, BlocksSourceType>
@@ -178,6 +179,7 @@ where
             orderpool_subscriber,
             order_simulation_pool,
             self.run_sparse_trie_prefetcher,
+            self.sbundle_merger_selected_signers.clone(),
         );
 
         let watchdog_sender = match self.watchdog_timeout {

--- a/crates/transaction-pool-bundle-ext/bundle_pool_ops/rbuilder/src/lib.rs
+++ b/crates/transaction-pool-bundle-ext/bundle_pool_ops/rbuilder/src/lib.rs
@@ -131,7 +131,6 @@ impl BundlePoolOps {
         let builders = create_builders(
             vec![builder_strategy],
             config.base_config.live_root_hash_config().unwrap(),
-            config.base_config.sbundle_mergeabe_signers(),
         );
 
         // Build and run the process


### PR DESCRIPTION
## 📝 Summary

For historical reasons, bundle merging logic (MultiShareBundleMerger) had to be implemented on each algorithm but that's not needed anymore so I removed MultiShareBundleMerger from both algorithms and added it in a single point between simulation and block building.

## 💡 Motivation and Context

- The way it was before made implementing new algorithms more difficult.
- Removed redundant calculations.

---

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
