### PR TITLE
Replace BlockOrders for a PrioritizedOrderStore

### DIFF
--- a/crates/rbuilder/src/building/block_orders/mod.rs
+++ b/crates/rbuilder/src/building/block_orders/mod.rs
@@ -16,7 +16,7 @@ use ahash::HashMap;
 use reth_errors::ProviderResult;
 use reth_provider::StateProviderBox;
 
-use prioritized_order_store::PrioritizedOrderStore;
+pub use prioritized_order_store::PrioritizedOrderStore;
 pub use test_data_generator::TestDataGenerator;
 
 /// Generic SimulatedOrder sink to add and remove orders.
@@ -46,13 +46,6 @@ pub fn simulated_order_command_to_sink<SinkType: SimulatedOrderSink>(
             let _ = sink.remove_order(id);
         }
     };
-}
-
-/// Wrapper on [`PrioritizedOrderStore`] soon will die.
-/// IMPORTANT: Read comments for PrioritizedOrderStore to see how to use (add_order here is insert_order) since nonces are a little tricky
-#[derive(Debug, Clone)]
-pub struct BlockOrders {
-    prioritized_order_store: PrioritizedOrderStore,
 }
 
 /// SimulatedOrderSink that stores all orders + all the adds from last drain_new_orders ONLY if we didn't see removes.
@@ -102,71 +95,12 @@ impl SimulatedOrderSink for SimulatedOrderStore {
     }
 }
 
-impl BlockOrders {
-    /// sbundle_merger_selected_signers see [`ShareBundleMerger`]
-    pub fn new(
-        priority: Sorting,
-        initial_onchain_nonces: impl IntoIterator<Item = AccountNonce>,
-    ) -> Self {
-        let mut onchain_nonces = HashMap::default();
-        for onchain_nonce in initial_onchain_nonces {
-            onchain_nonces.insert(onchain_nonce.account, onchain_nonce.nonce);
-        }
-
-        let prioritized_order_store = PrioritizedOrderStore::new(priority, onchain_nonces);
-        Self {
-            prioritized_order_store,
-        }
-    }
-
-    pub fn add_order(&mut self, order: SimulatedOrder) {
-        self.insert_order(order);
-    }
-
-    /// Readds a poped order to the priority queue bypassing other stages
-    /// Use ONLY if you are using BlockOrders as an static priority with no new add_order/remove_order etc.
-    /// @Pending For this cases it would probably be better to have a PrioritizedOrderStore instead of a BlockOrders
-    pub fn readd_order(&mut self, order: SimulatedOrder) {
-        self.prioritized_order_store.insert_order(order);
-    }
-
-    pub fn remove_orders(
-        &mut self,
-        orders: impl IntoIterator<Item = OrderId>,
-    ) -> Vec<SimulatedOrder> {
-        self.prioritized_order_store.remove_orders(orders)
-    }
-
-    pub fn pop_order(&mut self) -> Option<SimulatedOrder> {
-        self.prioritized_order_store.pop_order()
-    }
-
-    pub fn update_onchain_nonces(&mut self, new_nonces: &[AccountNonce]) {
-        self.prioritized_order_store
-            .update_onchain_nonces(new_nonces);
-    }
-
-    pub fn get_all_orders(&self) -> Vec<SimulatedOrder> {
-        self.prioritized_order_store.get_all_orders()
-    }
-}
-
-impl SimulatedOrderSink for BlockOrders {
-    fn insert_order(&mut self, order: SimulatedOrder) {
-        self.prioritized_order_store.insert_order(order);
-    }
-
-    fn remove_order(&mut self, id: OrderId) -> Option<SimulatedOrder> {
-        self.prioritized_order_store.remove_order(id)
-    }
-}
-
 /// Create block orders struct from simulated orders. Used in the backtest, not practical while live.
 pub fn block_orders_from_sim_orders(
     sim_orders: &[SimulatedOrder],
     sorting: Sorting,
     state_provider: &StateProviderBox,
-) -> ProviderResult<BlockOrders> {
+) -> ProviderResult<PrioritizedOrderStore> {
     let mut onchain_nonces = vec![];
     for order in sim_orders {
         for nonce in order.order.nonces() {
@@ -179,10 +113,10 @@ pub fn block_orders_from_sim_orders(
             });
         }
     }
-    let mut block_orders = BlockOrders::new(sorting, onchain_nonces);
+    let mut block_orders = PrioritizedOrderStore::new(sorting, onchain_nonces);
 
     for order in sim_orders.iter().cloned() {
-        block_orders.add_order(order);
+        block_orders.insert_order(order);
     }
 
     Ok(block_orders)
@@ -193,11 +127,11 @@ mod test {
     use crate::primitives::BundledTxInfo;
 
     use super::*;
-    /// Helper struct for common BlockOrders test operations
+    /// Helper struct for common PrioritizedOrderStore test operations
     /// Works hardcoded on Sorting::MaxProfit since it changes nothing on internal logic
     struct TestContext {
         pub data_gen: TestDataGenerator,
-        pub order_pool: BlockOrders,
+        pub order_pool: PrioritizedOrderStore,
     }
 
     impl TestContext {
@@ -209,7 +143,7 @@ mod test {
                 nonce.clone(),
                 TestContext {
                     data_gen,
-                    order_pool: BlockOrders::new(Sorting::MaxProfit, vec![nonce]),
+                    order_pool: PrioritizedOrderStore::new(Sorting::MaxProfit, vec![nonce]),
                 },
             )
         }
@@ -227,7 +161,10 @@ mod test {
                 nonce_2.clone(),
                 TestContext {
                     data_gen,
-                    order_pool: BlockOrders::new(Sorting::MaxProfit, vec![nonce_1, nonce_2]),
+                    order_pool: PrioritizedOrderStore::new(
+                        Sorting::MaxProfit,
+                        vec![nonce_1, nonce_2],
+                    ),
                 },
             )
         }
@@ -240,7 +177,7 @@ mod test {
         ) -> SimulatedOrder {
             let order = self.data_gen.base.create_tx_order(tx_nonce.clone());
             let order = self.data_gen.create_sim_order(order, tx_profit, tx_profit);
-            self.order_pool.add_order(order.clone());
+            self.order_pool.insert_order(order.clone());
             order
         }
 
@@ -251,13 +188,13 @@ mod test {
             bundle_profit: u64,
         ) -> SimulatedOrder {
             let order = self.data_gen.base.create_bundle_multi_tx_order(
-                0, // in the context of BlockOrders we don't care about the block (it's prefiltered)
+                0, // in the context of PrioritizedOrderStore we don't care about the block (it's prefiltered)
                 txs_info, None,
             );
             let order = self
                 .data_gen
                 .create_sim_order(order, bundle_profit, bundle_profit);
-            self.order_pool.add_order(order.clone());
+            self.order_pool.insert_order(order.clone());
             order
         }
 

--- a/crates/rbuilder/src/building/block_orders/prioritized_order_store.rs
+++ b/crates/rbuilder/src/building/block_orders/prioritized_order_store.rs
@@ -65,7 +65,14 @@ pub struct PrioritizedOrderStore {
 }
 
 impl PrioritizedOrderStore {
-    pub fn new(priority: Sorting, onchain_nonces: HashMap<Address, u64>) -> Self {
+    pub fn new(
+        priority: Sorting,
+        initial_onchain_nonces: impl IntoIterator<Item = AccountNonce>,
+    ) -> Self {
+        let mut onchain_nonces = HashMap::default();
+        for onchain_nonce in initial_onchain_nonces {
+            onchain_nonces.insert(onchain_nonce.account, onchain_nonce.nonce);
+        }
         Self {
             main_queue: PriorityQueue::new(),
             main_queue_nonces: HashMap::default(),

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -5,7 +5,7 @@ pub mod ordering_builder;
 pub mod parallel_builder;
 
 use crate::{
-    building::{BlockBuildingContext, BlockOrders, BuiltBlockTrace, SimulatedOrderSink, Sorting},
+    building::{BlockBuildingContext, BuiltBlockTrace, SimulatedOrderSink, Sorting},
     live_builder::{payload_events::MevBoostSlotData, simulation::SimulatedOrderCommand},
     primitives::{AccountNonce, OrderId, SimulatedOrder},
     roothash::RootHashConfig,
@@ -24,7 +24,7 @@ use tokio::sync::{broadcast, broadcast::error::TryRecvError};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use super::simulated_order_command_to_sink;
+use super::{simulated_order_command_to_sink, PrioritizedOrderStore};
 
 /// Block we built
 #[derive(Debug, Clone)]
@@ -106,7 +106,7 @@ impl OrderConsumer {
 pub struct OrderIntakeConsumer<P> {
     nonce_cache: NonceCache<P>,
 
-    block_orders: BlockOrders,
+    block_orders: PrioritizedOrderStore,
     onchain_nonces_updated: HashSet<Address>,
 
     order_consumer: OrderConsumer,
@@ -127,7 +127,7 @@ where
 
         Self {
             nonce_cache,
-            block_orders: BlockOrders::new(sorting, vec![]),
+            block_orders: PrioritizedOrderStore::new(sorting, vec![]),
             onchain_nonces_updated: HashSet::default(),
             order_consumer: OrderConsumer::new(orders),
         }
@@ -180,7 +180,7 @@ where
         Ok(true)
     }
 
-    pub fn current_block_orders(&self) -> BlockOrders {
+    pub fn current_block_orders(&self) -> PrioritizedOrderStore {
         self.block_orders.clone()
     }
 

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -12,7 +12,6 @@ pub mod testing;
 pub mod tracers;
 use alloy_consensus::{Header, EMPTY_OMMER_ROOT_HASH};
 use alloy_primitives::{Address, Bytes, Sealable, U256};
-pub use block_orders::BlockOrders;
 use eth_sparse_mpt::SparseTrieSharedCache;
 use reth_db::Database;
 use reth_primitives::BlockBody;


### PR DESCRIPTION
## 📝 Summary

BlockOrders used to have several members but now it's only a PrioritizedOrderStore so I killed BlockOrders and replaced its uses for PrioritizedOrderStore.

## 💡 Motivation and Context

BlockOrders is just an empty wraper doing nothing more than proxying funcions to PrioritizedOrderStore

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
