### PR TITLE
Fixed the typo. For now it backwards compatible.

### DIFF
--- a/config-backtest-example.toml
+++ b/config-backtest-example.toml
@@ -8,7 +8,7 @@ backtest_fetch_eth_rpc_parallel = 400
 backtest_fetch_output_file = "~/.rbuilder/backtest/main.sqlite"
 backtest_fetch_mempool_data_dir = "~/.rbuilder/mempool-data"
 
-sbundle_mergeabe_signers = []
+sbundle_mergeable_signers = []
 
 backtest_builders = ["mp-ordering", "mgp-ordering"]
 

--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -31,7 +31,7 @@ max_concurrent_seals = 4
 
 # genesis_fork_version = "0x00112233"
 
-sbundle_mergeabe_signers = []
+sbundle_mergeable_signers = []
 live_builders = ["mp-ordering", "mgp-ordering", "merging"]
 
 [[relays]]

--- a/config-optimism-local.toml
+++ b/config-optimism-local.toml
@@ -21,7 +21,7 @@ dry_run_validation_url = "http://localhost:8545"
 
 ignore_cancellable_orders = true
 
-sbundle_mergeabe_signers = []
+sbundle_mergeable_signers = []
 live_builders = ["mp-ordering"]
 
 [[relays]]

--- a/config-playground.toml
+++ b/config-playground.toml
@@ -24,7 +24,7 @@ dry_run_validation_url = "http://localhost:8545"
 
 ignore_cancellable_orders = true
 
-sbundle_mergeabe_signers = []
+sbundle_mergeable_signers = []
 live_builders = ["mp-ordering", "mgp-ordering", "parallel"]
 
 [[relays]]

--- a/crates/rbuilder/src/backtest/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_block.rs
@@ -108,7 +108,7 @@ where
         chain_spec.clone(),
         cli.block_building_time_ms,
         config.base_config().blocklist()?,
-        &config.base_config().sbundle_mergeabe_signers(),
+        &config.base_config().sbundle_mergeable_signers(),
         config.base_config().coinbase_signer()?,
     )?;
 

--- a/crates/rbuilder/src/backtest/backtest_build_range.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_range.rs
@@ -178,7 +178,7 @@ where
                         builders_names,
                         &config,
                         blocklist,
-                        &config.base_config().sbundle_mergeabe_signers(),
+                        &config.base_config().sbundle_mergeable_signers(),
                     ) {
                         Ok(ok) => Some(ok),
                         Err(err) => {

--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -1010,7 +1010,7 @@ where
         base_config.backtest_builders.clone(),
         config,
         base_config.blocklist()?,
-        &base_config.sbundle_mergeabe_signers(),
+        &base_config.sbundle_mergeable_signers(),
     )?
     .builder_outputs
     .into_iter()


### PR DESCRIPTION
## 📝 Summary

It was supposed to be sbundle_mergeable_signers but was sbundle_mergeabe_signers.

## 💡 Motivation and Context

- My eyes start to bleed everytime I see that typo.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
