### PR TITLE
Removed SimulatedOrder::prev_order since it was not used.

### DIFF
--- a/crates/rbuilder/src/backtest/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_block.rs
@@ -299,15 +299,11 @@ fn print_simulated_orders(
             timestamp_ms_to_slot_time(order_timestamp, timestamp_as_u64(&block_data.onchain_block));
 
         println!(
-            "{:>74} slot_time_ms: {:>8}, gas: {:>8} profit: {}, parent: {}",
+            "{:>74} slot_time_ms: {:>8}, gas: {:>8} profit: {}",
             order.order.id().to_string(),
             slot_time_ms,
             order.sim_value.gas_used,
             format_ether(order.sim_value.coinbase_profit),
-            order
-                .prev_order
-                .map(|prev_order| prev_order.to_string())
-                .unwrap_or_else(String::new)
         );
     }
     println!();

--- a/crates/rbuilder/src/building/block_orders/share_bundle_merger.rs
+++ b/crates/rbuilder/src/building/block_orders/share_bundle_merger.rs
@@ -148,7 +148,6 @@ impl<SinkType: SimulatedOrderSink> MultiBackrunManager<SinkType> {
         Some(SimulatedOrder {
             order: Order::ShareBundle(sbundle),
             sim_value: highest_payback_order.sim_order.sim_value.clone(),
-            prev_order: None,
             used_state_trace: highest_payback_order.sim_order.used_state_trace.clone(),
         })
     }

--- a/crates/rbuilder/src/building/block_orders/test_context.rs
+++ b/crates/rbuilder/src/building/block_orders/test_context.rs
@@ -173,7 +173,6 @@ impl<TestedSinkType: SimulatedOrderSink> TestContext<TestedSinkType> {
         SimulatedOrder {
             order,
             sim_value,
-            prev_order: None,
             used_state_trace: None,
         }
     }

--- a/crates/rbuilder/src/building/block_orders/test_data_generator.rs
+++ b/crates/rbuilder/src/building/block_orders/test_data_generator.rs
@@ -30,7 +30,6 @@ impl TestDataGenerator {
         SimulatedOrder {
             order,
             sim_value,
-            prev_order: None,
             used_state_trace: None,
         }
     }

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
@@ -550,7 +550,6 @@ mod tests {
                 order: Order::Bundle(bundle),
                 used_state_trace: None,
                 sim_value,
-                prev_order: None,
             }
         }
     }

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_task_generator.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_task_generator.rs
@@ -477,7 +477,6 @@ mod tests {
                 }),
                 used_state_trace: Some(trace),
                 sim_value,
-                prev_order: None,
             }
         }
     }

--- a/crates/rbuilder/src/building/builders/parallel_builder/groups.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/groups.rs
@@ -483,7 +483,6 @@ mod tests {
                 }),
                 used_state_trace: Some(trace),
                 sim_value: SimValue::default(),
-                prev_order: None,
             }
         }
     }

--- a/crates/rbuilder/src/building/sim.rs
+++ b/crates/rbuilder/src/building/sim.rs
@@ -429,14 +429,12 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
     fork: &mut PartialBlockFork<'_, '_, Tracer>,
 ) -> Result<OrderSimResult, CriticalCommitOrderError> {
     // simulate parents
-    let mut prev_order = None;
     let mut gas_used = 0;
     let mut blob_gas_used = 0;
     for parent in parent_orders {
         let result = fork.commit_order(&parent, ctx, gas_used, 0, blob_gas_used, true)?;
         match result {
             Ok(res) => {
-                prev_order = Some(parent.id());
                 gas_used += res.gas_used;
                 blob_gas_used += res.blob_gas_used;
             }
@@ -466,7 +464,6 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
                 SimulatedOrder {
                     order,
                     sim_value,
-                    prev_order,
                     used_state_trace: res.used_state_trace,
                 },
                 new_nonces,

--- a/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
@@ -214,7 +214,6 @@ impl TestSetup {
         let sim_order = SimulatedOrder {
             order: self.order_builder.build_order(),
             sim_value: Default::default(),
-            prev_order: Default::default(),
             used_state_trace: Default::default(),
         };
 

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -799,8 +799,6 @@ impl SimValue {
 pub struct SimulatedOrder {
     pub order: Order,
     pub sim_value: SimValue,
-    /// Not used, we should kill this
-    pub prev_order: Option<OrderId>,
     /// Info about read/write slots during the simulation to help figure out what the Order is doing.
     pub used_state_trace: Option<UsedStateTrace>,
 }


### PR DESCRIPTION
## 📝 Summary

Removed SimulatedOrder::prev_order since it was not used.

## 💡 Motivation and Context

Unused members make the rbuilder less aerodynamic.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
