### PR TITLE
refactor(op-rbuilder): simplify OpRbuilderPayloadBuilder implementation

### DIFF
--- a/crates/op-rbuilder/node/src/node.rs
+++ b/crates/op-rbuilder/node/src/node.rs
@@ -281,9 +281,10 @@ impl OpRbuilderPayloadServiceBuilder {
 
         Evm: ConfigureEvm<Header = Header>,
     {
-        let payload_builder =
-            op_rbuilder_payload_builder::OpRbuilderPayloadBuilder::new(evm_config)
-                .set_compute_pending_block(self.compute_pending_block);
+        let payload_builder = op_rbuilder_payload_builder::OpRbuilderPayloadBuilder::new(
+            evm_config,
+            self.compute_pending_block,
+        );
         let conf = ctx.payload_builder_config();
 
         let payload_job_config = BasicPayloadJobGeneratorConfig::default()

--- a/crates/op-rbuilder/payload_builder/src/builder.rs
+++ b/crates/op-rbuilder/payload_builder/src/builder.rs
@@ -43,27 +43,11 @@ pub struct OpRbuilderPayloadBuilder<EvmConfig> {
 }
 
 impl<EvmConfig> OpRbuilderPayloadBuilder<EvmConfig> {
-    pub const fn new(evm_config: EvmConfig) -> Self {
+    pub const fn new(evm_config: EvmConfig, compute_pending_block: bool) -> Self {
         Self {
-            compute_pending_block: true,
             evm_config,
+            compute_pending_block,
         }
-    }
-
-    /// Sets the rollup's compute pending block configuration option.
-    pub const fn set_compute_pending_block(mut self, compute_pending_block: bool) -> Self {
-        self.compute_pending_block = compute_pending_block;
-        self
-    }
-
-    /// Enables the rollup's compute pending block configuration option.
-    pub const fn compute_pending_block(self) -> Self {
-        self.set_compute_pending_block(true)
-    }
-
-    /// Returns the rollup's compute pending block configuration option.
-    pub const fn is_compute_pending_block(&self) -> bool {
-        self.compute_pending_block
     }
 }
 


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

`OpRbuilderPayloadBuilder` includes two parameters `compute_pending_block` and `evm_config`. The construction pattern should either use builder-mode for both or follow new-mode for both. I make it to new-mode.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
 