### PR TITLE
Revert unintentional changes

### DIFF
--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -135,8 +135,6 @@ where
     }
 
     pub async fn run(self) -> eyre::Result<()> {
-        // We keep the last block to avoid going back in time since we are now very robust about reorgs or this kind of behavior.
-        let mut last_processed_block: Option<u64> = None;
         info!("Builder block list size: {}", self.blocklist.len(),);
         info!(
             "Builder coinbase address: {:?}",
@@ -205,12 +203,6 @@ where
                 );
                 continue;
             }
-            // Allow only increasing blocks
-            if last_processed_block
-                .is_some_and(|last_processed_block| payload.block() <= last_processed_block)
-            {
-                continue;
-            }
             let current_time = OffsetDateTime::now_utc();
             // see if we can get parent header in a reasonable time
             let time_to_slot = payload.timestamp() - current_time;
@@ -257,7 +249,6 @@ where
             );
 
             inc_active_slots();
-            last_processed_block = Some(payload.block());
 
             if let Some(block_ctx) = BlockBuildingContext::from_attributes(
                 payload.payload_attributes_event.clone(),


### PR DESCRIPTION
## 📝 Summary

https://github.com/flashbots/rbuilder/pull/286 included some changes by mistake.
These changes are still under consideration in https://github.com/flashbots/rbuilder/pull/284.
We will wait until we have more info.

## 💡 Motivation and Context

"Active slots" metric was lower than usual.

---

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
