### PR TITLE
Add option pattern for Optimistic Relay mode

### DIFF
--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -106,6 +106,12 @@ pub struct SubmissionConfig {
     pub bid_observer: Box<dyn BidObserver + Send + Sync>,
 }
 
+/// Configuration for optimistic block submission to relays.
+///
+/// For optimistic relays when bid_value < max_bid_value:
+/// - If prevalidate_optimistic_blocks=true: Validate first, then submit with optimistic key
+/// - If prevalidate_optimistic_blocks=false: Submit directly with optimistic key
+/// Otherwise uses normal submission path.
 #[derive(Debug, Clone)]
 pub struct OptimisticConfig {
     pub signer: BLSBlockSigner,

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -102,12 +102,15 @@ pub struct SubmissionConfig {
     pub dry_run: bool,
     pub validation_api: ValidationAPIClient,
 
-    pub optimistic_enabled: bool,
-    pub optimistic_signer: BLSBlockSigner,
-    pub optimistic_max_bid_value: U256,
-    pub optimistic_prevalidate_optimistic_blocks: bool,
-
+    pub optimisitic_config: Option<OptimisticConfig>,
     pub bid_observer: Box<dyn BidObserver + Send + Sync>,
+}
+
+#[derive(Debug, Clone)]
+pub struct OptimisticConfig {
+    pub signer: BLSBlockSigner,
+    pub max_bid_value: U256,
+    pub prevalidate_optimistic_blocks: bool,
 }
 
 /// Values from [`BuiltBlockTrace`]
@@ -186,8 +189,20 @@ async fn run_submit_to_relays_job(
             .iter()
             .filter(|o| !o.order.is_tx())
             .count();
-        let submission_optimistic =
-            config.optimistic_enabled && block.trace.bid_value < config.optimistic_max_bid_value;
+
+        // Only enable the optimistic config for this block if the bid value is below the max bid value
+        let optimistic_config =
+            config
+                .optimisitic_config
+                .clone()
+                .map_or(None, |optimistic_config| {
+                    if block.trace.bid_value < optimistic_config.max_bid_value {
+                        Some(optimistic_config)
+                    } else {
+                        None
+                    }
+                });
+
         let best_bid_value = best_bid_sync_source.best_bid_value().unwrap_or_default();
         let submission_span = info_span!(
             "bid",
@@ -207,7 +222,7 @@ async fn run_submit_to_relays_job(
             parent: &submission_span,
             "Submitting bid",
         );
-        inc_initiated_submissions(submission_optimistic);
+        inc_initiated_submissions(optimistic_config.is_some());
 
         let (normal_signed_submission, optimistic_signed_submission) = {
             let normal_signed_submission = match sign_block_for_relay(
@@ -226,22 +241,30 @@ async fn run_submit_to_relays_job(
                     continue 'submit;
                 }
             };
-            let optimistic_signed_submission = match sign_block_for_relay(
-                &config.optimistic_signer,
-                &block.sealed_block,
-                &block.txs_blobs_sidecars,
-                &block.execution_requests,
-                &config.chain_spec,
-                &slot_data.payload_attributes_event.data,
-                slot_data.slot_data.pubkey,
-                block.trace.bid_value,
-            ) {
-                Ok(res) => res,
-                Err(err) => {
-                    error!(parent: &submission_span, err = ?err, "Error signing block for relay");
-                    continue 'submit;
+
+            let optimistic_signed_submission = if let Some(optimistic_config) =
+                optimistic_config.clone()
+            {
+                match sign_block_for_relay(
+                    &optimistic_config.signer,
+                    &block.sealed_block,
+                    &block.txs_blobs_sidecars,
+                    &block.execution_requests,
+                    &config.chain_spec,
+                    &slot_data.payload_attributes_event.data,
+                    slot_data.slot_data.pubkey,
+                    block.trace.bid_value,
+                ) {
+                    Ok(res) => Some(res),
+                    Err(err) => {
+                        error!(parent: &submission_span, err = ?err, "Error signing block for relay");
+                        continue 'submit;
+                    }
                 }
+            } else {
+                None
             };
+
             (normal_signed_submission, optimistic_signed_submission)
         };
 
@@ -274,8 +297,10 @@ async fn run_submit_to_relays_job(
             );
         }
 
-        if submission_optimistic {
-            let can_submit = if config.optimistic_prevalidate_optimistic_blocks {
+        if let Some(optimistic_signed_submission) = &optimistic_signed_submission {
+            let optimistic_config = optimistic_config.expect("optimistic config is not None");
+
+            let can_submit = if optimistic_config.prevalidate_optimistic_blocks {
                 validate_block(
                     &slot_data,
                     &optimistic_signed_submission,

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -111,7 +111,7 @@ pub struct SubmissionConfig {
 /// For optimistic relays when bid_value < max_bid_value:
 /// - If prevalidate_optimistic_blocks=true: Validate first, then submit with optimistic key
 /// - If prevalidate_optimistic_blocks=false: Submit directly with optimistic key
-/// Otherwise uses normal submission path.
+///   Otherwise uses normal submission path.
 #[derive(Debug, Clone)]
 pub struct OptimisticConfig {
     pub signer: BLSBlockSigner,

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -260,7 +260,7 @@ async fn run_submit_to_relays_job(
                     slot_data.slot_data.pubkey,
                     block.trace.bid_value,
                 ) {
-                    Ok(res) => Some(res),
+                    Ok(res) => Some((res, optimistic_config)),
                     Err(err) => {
                         error!(parent: &submission_span, err = ?err, "Error signing block for relay");
                         continue 'submit;
@@ -302,9 +302,9 @@ async fn run_submit_to_relays_job(
             );
         }
 
-        if let Some(optimistic_signed_submission) = &optimistic_signed_submission {
-            let optimistic_config = optimistic_config.expect("optimistic config is not None");
-
+        if let Some((optimistic_signed_submission, optimistic_config)) =
+            &optimistic_signed_submission
+        {
             let can_submit = if optimistic_config.prevalidate_optimistic_blocks {
                 validate_block(
                     &slot_data,

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -102,7 +102,7 @@ pub struct SubmissionConfig {
     pub dry_run: bool,
     pub validation_api: ValidationAPIClient,
 
-    pub optimisitic_config: Option<OptimisticConfig>,
+    pub optimistic_config: Option<OptimisticConfig>,
     pub bid_observer: Box<dyn BidObserver + Send + Sync>,
 }
 
@@ -198,8 +198,8 @@ async fn run_submit_to_relays_job(
 
         // Only enable the optimistic config for this block if the bid value is below the max bid value
         let optimistic_config = config
-            .optimisitic_config
-            .clone()
+            .optimistic_config
+            .as_ref()
             .and_then(|optimistic_config| {
                 if block.trace.bid_value < optimistic_config.max_bid_value {
                     Some(optimistic_config)
@@ -247,9 +247,7 @@ async fn run_submit_to_relays_job(
                 }
             };
 
-            let optimistic_signed_submission = if let Some(optimistic_config) =
-                optimistic_config.clone()
-            {
+            let optimistic_signed_submission = if let Some(optimistic_config) = optimistic_config {
                 match sign_block_for_relay(
                     &optimistic_config.signer,
                     &block.sealed_block,

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -191,17 +191,16 @@ async fn run_submit_to_relays_job(
             .count();
 
         // Only enable the optimistic config for this block if the bid value is below the max bid value
-        let optimistic_config =
-            config
-                .optimisitic_config
-                .clone()
-                .map_or(None, |optimistic_config| {
-                    if block.trace.bid_value < optimistic_config.max_bid_value {
-                        Some(optimistic_config)
-                    } else {
-                        None
-                    }
-                });
+        let optimistic_config = config
+            .optimisitic_config
+            .clone()
+            .and_then(|optimistic_config| {
+                if block.trace.bid_value < optimistic_config.max_bid_value {
+                    Some(optimistic_config)
+                } else {
+                    None
+                }
+            });
 
         let best_bid_value = best_bid_sync_source.best_bid_value().unwrap_or_default();
         let submission_span = info_span!(
@@ -303,7 +302,7 @@ async fn run_submit_to_relays_job(
             let can_submit = if optimistic_config.prevalidate_optimistic_blocks {
                 validate_block(
                     &slot_data,
-                    &optimistic_signed_submission,
+                    optimistic_signed_submission,
                     block.sealed_block.clone(),
                     &config,
                     cancel.clone(),

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -11,7 +11,7 @@ use super::{
             wallet_balance_watcher::WalletBalanceWatcher,
         },
         block_sealing_bidder_factory::BlockSealingBidderFactory,
-        relay_submit::{RelaySubmitSinkFactory, SubmissionConfig},
+        relay_submit::{OptimisticConfig, RelaySubmitSinkFactory, SubmissionConfig},
     },
 };
 use crate::{
@@ -242,15 +242,22 @@ impl L1Config {
 
         let signer = self.bls_signer(&chain_spec)?;
 
+        let optimistic_config = if self.optimistic_enabled {
+            Some(OptimisticConfig {
+                signer: optimistic_signer,
+                max_bid_value: parse_ether(&self.optimistic_max_bid_value_eth)?,
+                prevalidate_optimistic_blocks: self.optimistic_prevalidate_optimistic_blocks,
+            })
+        } else {
+            None
+        };
+
         Ok(SubmissionConfig {
             chain_spec,
             signer,
             dry_run: self.dry_run,
             validation_api,
-            optimistic_enabled: self.optimistic_enabled,
-            optimistic_signer,
-            optimistic_max_bid_value: parse_ether(&self.optimistic_max_bid_value_eth)?,
-            optimistic_prevalidate_optimistic_blocks: self.optimistic_prevalidate_optimistic_blocks,
+            optimisitic_config: optimistic_config,
             bid_observer,
         })
     }
@@ -266,16 +273,15 @@ impl L1Config {
             "Builder mev boost normal relay pubkey: {:?}",
             submission_config.signer.pub_key()
         );
-        info!(
-            "Builder mev boost optimistic relay pubkey: {:?}",
-            submission_config.optimistic_signer.pub_key()
-        );
-        info!(
-            "Optimistic mode, enabled: {}, prevalidate: {}, max_value: {}",
-            submission_config.optimistic_enabled,
-            submission_config.optimistic_prevalidate_optimistic_blocks,
-            format_ether(submission_config.optimistic_max_bid_value),
-        );
+
+        if let Some(optimitic_config) = submission_config.optimisitic_config.as_ref() {
+            info!(
+                "Optimistic mode enabled, relay pubkey {:?}, prevalidate: {}, max_value: {}",
+                optimitic_config.signer.pub_key(),
+                optimitic_config.prevalidate_optimistic_blocks,
+                format_ether(optimitic_config.max_bid_value),
+            );
+        };
 
         let relays = self.create_relays()?;
         let sink_factory: Box<dyn BuilderSinkFactory> = Box::new(RelaySubmitSinkFactory::new(

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -257,7 +257,7 @@ impl L1Config {
             signer,
             dry_run: self.dry_run,
             validation_api,
-            optimisitic_config: optimistic_config,
+            optimistic_config,
             bid_observer,
         })
     }
@@ -274,7 +274,7 @@ impl L1Config {
             submission_config.signer.pub_key()
         );
 
-        if let Some(optimitic_config) = submission_config.optimisitic_config.as_ref() {
+        if let Some(optimitic_config) = submission_config.optimistic_config.as_ref() {
             info!(
                 "Optimistic mode enabled, relay pubkey {:?}, prevalidate: {}, max_value: {}",
                 optimitic_config.signer.pub_key(),


### PR DESCRIPTION
## 📝 Summary

This PR introduces a new `OptimisitcConfig` for the relayer with an option pattern for its fields. This replaces the current `optimistic_enabled` boolean to signal whether to use the subset of Optimistic configs or not.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
