### PR TITLE
Do not run redact sensitive integration test

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -75,7 +75,6 @@ jobs:
           - stable
         features:
           - ""
-          - "redact-sensitive"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
## 📝 Summary

It does not seem necessary for me to run the integration tests in redact-sensitive mode.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
