### PR TITLE
chore(backtest): Track filtered orders for easier debugging

### DIFF
--- a/crates/rbuilder/src/backtest/fetch/mod.rs
+++ b/crates/rbuilder/src/backtest/fetch/mod.rs
@@ -15,6 +15,10 @@ use crate::{
 use alloy_provider::Provider;
 use alloy_rpc_types::{Block, BlockId, BlockNumberOrTag, BlockTransactionsKind};
 
+use crate::{
+    backtest::{fetch::mev_boost::PayloadDeliveredFetcher, OrdersWithTimestamp},
+    utils::BoxedProvider,
+};
 use eyre::WrapErr;
 use flashbots_db::RelayDB;
 use futures::TryStreamExt;
@@ -25,11 +29,6 @@ use std::{
 };
 use tokio::sync::Mutex;
 use tracing::{info, trace};
-
-use crate::{
-    backtest::{fetch::mev_boost::PayloadDeliveredFetcher, OrdersWithTimestamp},
-    utils::BoxedProvider,
-};
 
 /// Struct that brings block information ([BlockData]) from several [DataSource]s
 /// Filters txs already landed (onchain nonce > tx nonce)
@@ -255,6 +254,7 @@ impl HistoricalDataFetcher {
             onchain_block,
             available_orders,
             built_block_data,
+            filtered_orders: Default::default(),
         })
     }
 }

--- a/crates/rbuilder/src/backtest/mod.rs
+++ b/crates/rbuilder/src/backtest/mod.rs
@@ -29,6 +29,7 @@ pub use results_store::{BacktestResultsStorage, StoredBacktestResult};
 use serde::{Deserialize, Serialize};
 pub use store::HistoricalDataStorage;
 use time::OffsetDateTime;
+use tracing::trace;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RawOrdersWithTimestamp {
@@ -81,6 +82,7 @@ pub struct BlockData {
     /// Orders we had at the moment of building the block.
     /// This might be an approximation depending on DataSources used.
     pub available_orders: Vec<OrdersWithTimestamp>,
+    pub filtered_orders: HashSet<OrderId>,
     pub built_block_data: Option<BuiltBlockData>,
 }
 
@@ -97,8 +99,15 @@ impl BlockData {
     }
 
     fn filter_orders_by_end_timestamp_ms(&mut self, final_timestamp_ms: u64) {
-        self.available_orders
-            .retain(|orders| orders.timestamp_ms <= final_timestamp_ms);
+        self.available_orders.retain(|orders| {
+            if orders.timestamp_ms <= final_timestamp_ms {
+                true
+            } else {
+                trace!(order = ?orders.order.id(), "order filtered by end timestamp");
+                self.filtered_orders.insert(orders.order.id());
+                false
+            }
+        });
 
         // make sure that we have only one copy of the cancellable orders
         // we use timestamp and not replacement sequence number because of the limitation of the backtest
@@ -111,6 +120,8 @@ impl BlockData {
         self.available_orders.retain(|orders| {
             if let Some(key) = orders.order.replacement_key() {
                 if replacement_keys_seen.contains(&key) {
+                    trace!(order = ?orders.order.id(), "order filtered by end timestamp");
+                    self.filtered_orders.insert(orders.order.id());
                     return false;
                 }
                 replacement_keys_seen.insert(key);
@@ -135,13 +146,26 @@ impl BlockData {
                 return true;
             };
             let txs = orders.order.list_txs();
-            txs.iter().any(|(tx, _)| !mempool_txs.contains(&tx.hash()))
+            if txs.iter().any(|(tx, _)| !mempool_txs.contains(&tx.hash())) {
+                true
+            } else {
+                trace!(order = ?orders.order.id(), "order filtered from public mempool");
+                self.filtered_orders.insert(orders.order.id());
+                false
+            }
         });
     }
 
     pub fn filter_orders_by_ids(&mut self, order_ids: &[String]) {
-        self.available_orders
-            .retain(|order| order_ids.contains(&order.order.id().to_string()));
+        self.available_orders.retain(|order| {
+            if order_ids.contains(&order.order.id().to_string()) {
+                true
+            } else {
+                trace!(order = ?order.order.id(), "order filtered by id");
+                self.filtered_orders.insert(order.order.id());
+                false
+            }
+        });
     }
 
     pub fn filter_out_ignored_signers(&mut self, ignored_signers: &[Address]) {
@@ -152,7 +176,13 @@ impl BlockData {
             } else {
                 return true;
             };
-            !ignored_signers.contains(&signer)
+            if !ignored_signers.contains(&signer) {
+                true
+            } else {
+                trace!(order = ?order.id(), "order filtered by ignored signers");
+                self.filtered_orders.insert(order.id());
+                false
+            }
         });
     }
 

--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -256,7 +256,11 @@ fn get_available_orders(
                 included_orders_available.insert(order.order.id(), order.clone());
             }
             None => {
-                warn!(order = ?id, "Included order not found in available orders");
+                if block_data.filtered_orders.contains(id) {
+                    info!(order = ?id, "Included order was filtered from available orders");
+                } else {
+                    warn!(order = ?id, "Included order not found in available orders");
+                }
             }
         }
     }

--- a/crates/rbuilder/src/backtest/store.rs
+++ b/crates/rbuilder/src/backtest/store.rs
@@ -21,6 +21,7 @@ use sqlx::{
     ConnectOptions, Connection, Executor, Row, SqliteConnection,
 };
 use std::{
+    default::Default,
     ffi::OsString,
     path::{Path, PathBuf},
     str::FromStr,
@@ -529,6 +530,7 @@ fn group_rows_into_block_data(
                     onchain_block,
                     available_orders: Vec::new(),
                     built_block_data: None,
+                    filtered_orders: Default::default(),
                 },
             ))
         })
@@ -687,6 +689,7 @@ mod test {
             onchain_block,
             available_orders: orders,
             built_block_data: Some(built_block_data),
+            filtered_orders: Default::default(),
         };
 
         let mut storage = HistoricalDataStorage::new_from_memory().await.unwrap();


### PR DESCRIPTION
## 📝 Summary

Adds `BlockData.filtered_orders` to track which order ids were removed by filtering, and then changes `warn` to `info` if those orders don't show up in available orders.

## 💡 Motivation and Context

Removes some warnings on backtesting when for example an order containing only public mempool txs is removed.

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
