### PR TITLE
fix: correctly provision # of threads

### DIFF
--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
@@ -1,10 +1,10 @@
 use alloy_primitives::utils::format_ether;
 use crossbeam_queue::SegQueue;
 use eyre::Result;
-use rayon::{ThreadPool, ThreadPoolBuilder};
 use reth_provider::StateProviderFactory;
 use std::{
     sync::{mpsc as std_mpsc, Arc},
+    thread,
     time::Instant,
 };
 use tokio_util::sync::CancellationToken;
@@ -21,12 +21,12 @@ pub type TaskQueue = Arc<SegQueue<ConflictTask>>;
 
 pub struct ConflictResolvingPool<P> {
     task_queue: TaskQueue,
-    thread_pool: ThreadPool,
     group_result_sender: std_mpsc::Sender<ConflictResolutionResultPerGroup>,
     cancellation_token: CancellationToken,
     ctx: BlockBuildingContext,
     provider: P,
     simulation_cache: Arc<SharedSimulationCache>,
+    num_threads: usize,
 }
 
 impl<P> ConflictResolvingPool<P>
@@ -42,31 +42,27 @@ where
         provider: P,
         simulation_cache: Arc<SharedSimulationCache>,
     ) -> Self {
-        let thread_pool = ThreadPoolBuilder::new()
-            .num_threads(num_threads)
-            .build()
-            .expect("Failed to build thread pool");
-
         Self {
             task_queue,
-            thread_pool,
             group_result_sender,
             cancellation_token,
             ctx,
             provider,
             simulation_cache,
+            num_threads,
         }
     }
 
     pub fn start(&self) {
-        for _ in 0..self.thread_pool.current_num_threads() {
+        for _ in 0..self.num_threads {
             let task_queue = self.task_queue.clone();
             let cancellation_token = self.cancellation_token.clone();
             let provider = self.provider.clone();
             let group_result_sender = self.group_result_sender.clone();
             let simulation_cache = self.simulation_cache.clone();
             let ctx = self.ctx.clone();
-            self.thread_pool.spawn(move || {
+
+            thread::spawn(move || {
                 while !cancellation_token.is_cancelled() {
                     if let Some(task) = task_queue.pop() {
                         if cancellation_token.is_cancelled() {

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
@@ -59,49 +59,50 @@ where
     }
 
     pub fn start(&self) {
-        let task_queue = self.task_queue.clone();
-        let cancellation_token = self.cancellation_token.clone();
-        let provider = self.provider.clone();
-        let group_result_sender = self.group_result_sender.clone();
-        let simulation_cache = self.simulation_cache.clone();
-        let ctx = self.ctx.clone();
-
-        self.thread_pool.spawn(move || {
-            while !cancellation_token.is_cancelled() {
-                if let Some(task) = task_queue.pop() {
-                    if cancellation_token.is_cancelled() {
-                        return;
-                    }
-                    let task_start = Instant::now();
-                    if let Ok((task_id, result)) = Self::process_task(
-                        task,
-                        &ctx,
-                        &provider,
-                        cancellation_token.clone(),
-                        Arc::clone(&simulation_cache),
-                    ) {
-                        match group_result_sender.send((task_id, result)) {
-                            Ok(_) => {
-                                trace!(
-                                    task_id = %task_id,
-                                    time_taken_ms = %task_start.elapsed().as_millis(),
-                                    "Conflict resolving: successfully sent group result"
-                                );
-                            }
-                            Err(err) => {
-                                warn!(
-                                    task_id = %task_id,
-                                    error = ?err,
-                                    time_taken_ms = %task_start.elapsed().as_millis(),
-                                    "Conflict resolving: failed to send group result"
-                                );
-                                return;
+        for _ in 0..self.thread_pool.current_num_threads() {
+            let task_queue = self.task_queue.clone();
+            let cancellation_token = self.cancellation_token.clone();
+            let provider = self.provider.clone();
+            let group_result_sender = self.group_result_sender.clone();
+            let simulation_cache = self.simulation_cache.clone();
+            let ctx = self.ctx.clone();
+            self.thread_pool.spawn(move || {
+                while !cancellation_token.is_cancelled() {
+                    if let Some(task) = task_queue.pop() {
+                        if cancellation_token.is_cancelled() {
+                            return;
+                        }
+                        let task_start = Instant::now();
+                        if let Ok((task_id, result)) = Self::process_task(
+                            task,
+                            &ctx,
+                            &provider,
+                            cancellation_token.clone(),
+                            Arc::clone(&simulation_cache),
+                        ) {
+                            match group_result_sender.send((task_id, result)) {
+                                Ok(_) => {
+                                    trace!(
+                                        task_id = %task_id,
+                                        time_taken_ms = %task_start.elapsed().as_millis(),
+                                        "Conflict resolving: successfully sent group result"
+                                    );
+                                }
+                                Err(err) => {
+                                    warn!(
+                                        task_id = %task_id,
+                                        error = ?err,
+                                        time_taken_ms = %task_start.elapsed().as_millis(),
+                                        "Conflict resolving: failed to send group result"
+                                    );
+                                    return;
+                                }
                             }
                         }
                     }
                 }
-            }
-        });
+            });
+        }
     }
 
     fn process_task(


### PR DESCRIPTION
## 📝 Summary

This fixes a bug where we only use 1 thread where the intention was to provision a number of threads.

## 💡 Motivation and Context

This will make resolving conflicts in the parallel builder much more efficient.
---

## ✅ I have completed the following steps:

* [ ✅] Run `make lint`
* [ ✅] Run `make test`
* [ ] Added tests (if applicable)
