### PR TITLE
fix: comments errors in the code

### DIFF
--- a/crates/eth-sparse-mpt/src/sparse_mpt/diff_trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/sparse_mpt/diff_trie/mod.rs
@@ -192,7 +192,7 @@ impl DiffTrie {
                     new_nodes.reserve(3);
                     new_nodes.push((leaf_ptr, DiffTrieNode::new_leaf(key1, value)));
 
-                    // banch will point to the current extension child directly or to new extension node
+                    // branch will point to the current extension child directly or to new extension node
                     // that will point to child
 
                     let branch_other_child = if !key2.is_empty() {
@@ -410,7 +410,7 @@ impl DiffTrie {
                     let child_below = self
                         .nodes
                         .remove(child_ptr)
-                        .expect("orphaned child existance is checked when walking down");
+                        .expect("orphaned child existence is checked when walking down");
                     let node_above =
                         try_get_node_mut(&mut self.nodes, current_node, &Nibbles::new())
                             .expect("nodes must exist when walking back");
@@ -540,7 +540,7 @@ impl DiffTrie {
         match deletion_result {
             NodeDeletionResult::NodeDeleted => {
                 let ptr = get_new_ptr(&mut self.ptrs);
-                // trie is emptry, insert the null node on top
+                // trie is empty, insert the null node on top
                 self.nodes.insert(ptr, DiffTrieNode::new_null());
                 self.head = ptr;
             }

--- a/crates/op-rbuilder/payload_builder/src/builder.rs
+++ b/crates/op-rbuilder/payload_builder/src/builder.rs
@@ -275,7 +275,7 @@ where
         }
 
         // Convert the transaction to a [TransactionSignedEcRecovered]. This is
-        // purely for the purposes of utilizing the `evm_config.tx_env`` function.
+        // purely for the purposes of utilizing the `evm_config.tx_env` function.
         // Deposit transactions do not have signatures, so if the tx is a deposit, this
         // will just pull in its `from` address.
         let sequencer_tx = sequencer_tx
@@ -417,7 +417,7 @@ where
                     }
                     err => {
                         // this is an error that we should treat as fatal for this attempt
-                        error!("rbuilder provided where an error occured!");
+                        error!("rbuilder provided where an error occurred!");
                         return Err(PayloadBuilderError::EvmExecutionError(err));
                     }
                 }

--- a/crates/op-rbuilder/payload_builder/src/builder.rs
+++ b/crates/op-rbuilder/payload_builder/src/builder.rs
@@ -275,7 +275,7 @@ where
         }
 
         // Convert the transaction to a [TransactionSignedEcRecovered]. This is
-        // purely for the purposes of utilizing the `evm_config.tx_env` function.
+        // purely for the purposes of utilizing the `evm_config.tx_env`` function.
         // Deposit transactions do not have signatures, so if the tx is a deposit, this
         // will just pull in its `from` address.
         let sequencer_tx = sequencer_tx
@@ -417,7 +417,7 @@ where
                     }
                     err => {
                         // this is an error that we should treat as fatal for this attempt
-                        error!("rbuilder provided where an error occurred!");
+                        error!("rbuilder provided where an error occured!");
                         return Err(PayloadBuilderError::EvmExecutionError(err));
                     }
                 }


### PR DESCRIPTION
## 📝 Summary

Fixed serious comments errors and typos around docs files.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
