### PR TITLE
Use only required fields in playground config

### DIFF
--- a/config-playground.toml
+++ b/config-playground.toml
@@ -1,6 +1,6 @@
 
 chain = "$HOME/.playground/devnet/genesis.json"
 reth_datadir = "$HOME/.playground/devnet/data_reth"
-el_node_ipc_path = "$HOME/.playground/devnet/reth.ipc"
-coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+relay_secret_key = "5eae315483f028b5cdd5d1090ff0c7618b18737ea9bf3c35047189db22835c48"
+live_builders = ["mp-ordering", "mgp-ordering", "parallel"]
 enabled_relays = ["playground"]

--- a/config-playground.toml
+++ b/config-playground.toml
@@ -1,30 +1,5 @@
-log_json = false
-log_level = "info,rbuilder=debug"
-redacted_telemetry_server_port = 6061
-redacted_telemetry_server_ip = "0.0.0.0"
-full_telemetry_server_port = 6060
-full_telemetry_server_ip = "0.0.0.0"
 
 chain = "$HOME/.playground/devnet/genesis.json"
 reth_datadir = "$HOME/.playground/devnet/data_reth"
-relay_secret_key = "5eae315483f028b5cdd5d1090ff0c7618b18737ea9bf3c35047189db22835c48"
 coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-
-cl_node_url = ["http://localhost:3500"]
-jsonrpc_server_port = 8645
-jsonrpc_server_ip = "0.0.0.0"
-el_node_ipc_path = "$HOME/.playground/devnet/reth.ipc"
-extra_data = "⚡🤖"
-
-dry_run = false
-dry_run_validation_url = "http://localhost:8545"
-
-# blocks_processor_url can be an API service to record bids and transactions. It is not required.
-# blocks_processor_url = "http://block_processor.internal"
-
-ignore_cancellable_orders = true
-
-sbundle_mergeable_signers = []
-live_builders = ["mp-ordering", "mgp-ordering", "parallel"]
-
 enabled_relays = ["playground"]

--- a/config-playground.toml
+++ b/config-playground.toml
@@ -2,5 +2,6 @@
 chain = "$HOME/.playground/devnet/genesis.json"
 reth_datadir = "$HOME/.playground/devnet/data_reth"
 relay_secret_key = "5eae315483f028b5cdd5d1090ff0c7618b18737ea9bf3c35047189db22835c48"
+el_node_ipc_path = "$HOME/.playground/devnet/reth.ipc"
 live_builders = ["mp-ordering", "mgp-ordering", "parallel"]
 enabled_relays = ["playground"]

--- a/config-playground.toml
+++ b/config-playground.toml
@@ -1,5 +1,6 @@
 
 chain = "$HOME/.playground/devnet/genesis.json"
 reth_datadir = "$HOME/.playground/devnet/data_reth"
+el_node_ipc_path = "$HOME/.playground/devnet/reth.ipc"
 coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 enabled_relays = ["playground"]


### PR DESCRIPTION
## 📝 Summary

Simplify the playground config to include only the required fields.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
