### PR TITLE
Stop spawn_clean_orderpool_job on shutdown

### DIFF
--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -334,33 +334,41 @@ where
     let handle = tokio::spawn(async move {
         info!("Clean orderpool job: started");
 
-        while let Some(header) = header_receiver.recv().await {
-            let block_number = header.number;
-            set_current_block(block_number);
-            let state = match provider_factory.latest() {
-                Ok(state) => state,
-                Err(err) => {
-                    error!("Failed to get latest state: {}", err);
-                    // @Metric error count
-                    continue;
+        loop {
+            tokio::select! {
+                Some(header) = header_receiver.recv() => {
+                    let block_number = header.number;
+                    set_current_block(block_number);
+                    let state = match provider_factory.latest() {
+                        Ok(state) => state,
+                        Err(err) => {
+                            error!("Failed to get latest state: {}", err);
+                            // @Metric error count
+                            continue;
+                        }
+                    };
+
+                    let mut orderpool = orderpool.lock();
+                    let start = Instant::now();
+
+                    orderpool.head_updated(block_number, &state);
+
+                    let update_time = start.elapsed();
+                    let (tx_count, bundle_count) = orderpool.content_count();
+                    set_ordepool_count(tx_count, bundle_count);
+                    debug!(
+                        block_number,
+                        tx_count,
+                        bundle_count,
+                        update_time_ms = update_time.as_millis(),
+                        "Cleaned orderpool",
+                    );
+                },
+                _ = global_cancellation.cancelled() => {
+                    info!("Clean orderpool job: received cancellation signal");
+                    break;
                 }
-            };
-
-            let mut orderpool = orderpool.lock();
-            let start = Instant::now();
-
-            orderpool.head_updated(block_number, &state);
-
-            let update_time = start.elapsed();
-            let (tx_count, bundle_count) = orderpool.content_count();
-            set_ordepool_count(tx_count, bundle_count);
-            debug!(
-                block_number,
-                tx_count,
-                bundle_count,
-                update_time_ms = update_time.as_millis(),
-                "Cleaned orderpool",
-            );
+            }
         }
 
         global_cancellation.cancel();

--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -336,33 +336,41 @@ where
 
         loop {
             tokio::select! {
-                Some(header) = header_receiver.recv() => {
-                    let block_number = header.number;
-                    set_current_block(block_number);
-                    let state = match provider_factory.latest() {
-                        Ok(state) => state,
-                        Err(err) => {
-                            error!("Failed to get latest state: {}", err);
-                            // @Metric error count
-                            continue;
+                header = header_receiver.recv() => {
+                    if let Some(header) = header {
+                        let block_number = header.number;
+                        set_current_block(block_number);
+                        let state = match provider_factory.latest() {
+                            Ok(state) => state,
+                            Err(err) => {
+                                error!("Failed to get latest state: {}", err);
+                                // @Metric error count
+                                continue;
+                            }
+                        };
+
+                        let mut orderpool = orderpool.lock();
+                        let start = Instant::now();
+
+                        orderpool.head_updated(block_number, &state);
+
+                        let update_time = start.elapsed();
+                        let (tx_count, bundle_count) = orderpool.content_count();
+                        set_ordepool_count(tx_count, bundle_count);
+                        debug!(
+                            block_number,
+                            tx_count,
+                            bundle_count,
+                            update_time_ms = update_time.as_millis(),
+                            "Cleaned orderpool",
+                        );
+                    } else {
+                        info!("Clean orderpool job: channel ended");
+                        if !global_cancellation.is_cancelled(){
+                            error!("Clean orderpool job: channel ended with no cancellation");
                         }
-                    };
-
-                    let mut orderpool = orderpool.lock();
-                    let start = Instant::now();
-
-                    orderpool.head_updated(block_number, &state);
-
-                    let update_time = start.elapsed();
-                    let (tx_count, bundle_count) = orderpool.content_count();
-                    set_ordepool_count(tx_count, bundle_count);
-                    debug!(
-                        block_number,
-                        tx_count,
-                        bundle_count,
-                        update_time_ms = update_time.as_millis(),
-                        "Cleaned orderpool",
-                    );
+                        break;
+                    }
                 },
                 _ = global_cancellation.cancelled() => {
                     info!("Clean orderpool job: received cancellation signal");

--- a/scripts/ci/benchmark-in-ci.sh
+++ b/scripts/ci/benchmark-in-ci.sh
@@ -62,6 +62,8 @@ function run_benchmark() {
 
         # Switch back to current commit and run benchmarks again
         echo "Switching back to $HEAD_SHA_SHORT and running benchmarks ..."
+        # Reset to ensure any changes (e.g. to Cargo.lock) are discarded before attempting to checkout.
+        git reset --hard
         git checkout $HEAD_SHA
         cargo bench --workspace
     fi


### PR DESCRIPTION
## 📝 Summary

Bug introduced in #327. Rbuilder would not stop with `Ctrl-C` because it would be waiting for `spawn_clean_orderpool_job` to finish. But, `spawn_clean_orderpool_job` would not handle the cancellation token.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
