### PR TITLE
fix: bench ci

### DIFF
--- a/scripts/ci/benchmark-in-ci.sh
+++ b/scripts/ci/benchmark-in-ci.sh
@@ -62,6 +62,8 @@ function run_benchmark() {
 
         # Switch back to current commit and run benchmarks again
         echo "Switching back to $HEAD_SHA_SHORT and running benchmarks ..."
+        # Reset to ensure any changes (e.g. to Cargo.lock) are discarded before attempting to checkout.
+        git reset --hard
         git checkout $HEAD_SHA
         cargo bench --workspace
     fi


### PR DESCRIPTION
Sometimes, the Cargo.lock will differ between `BASE_SHA` and `HEAD_SHA`. 

This can cause the final checkout to `HEAD_SHA` to fail.

This PR resolves that, by resetting any changes prior to the final checkout. 