### PR TITLE
fix(builder-playground): config-playground.toml tweaks for playground DX

### DIFF
--- a/config-playground.toml
+++ b/config-playground.toml
@@ -3,5 +3,7 @@ chain = "$HOME/.playground/devnet/genesis.json"
 reth_datadir = "$HOME/.playground/devnet/data_reth"
 relay_secret_key = "5eae315483f028b5cdd5d1090ff0c7618b18737ea9bf3c35047189db22835c48"
 el_node_ipc_path = "$HOME/.playground/devnet/reth.ipc"
-live_builders = ["mp-ordering", "mgp-ordering", "parallel"]
+live_builders = ["mgp-ordering"]
 enabled_relays = ["playground"]
+log_level = "info,rbuilder=debug"
+coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"


### PR DESCRIPTION
## 📝 Summary

While getting https://github.com/flashbots/builder-playground/pull/37 working I ran into a couple DX gotchas with the current `config-playground.toml` file.

## 💡 Motivation and Context

- The `parallel` algoirthm was pegging all my CPUs at 100%. Also figured just running `mgp-ordering` is enough.
- Having a random coinbase made it harder to test block building since we only build profitable blocks.  IIRC we now have a setting to build always, but I still think it's cleaner to use the prefunded accounts from the playground.
- Having debug logs helped a ton tracking down pectra issues, so I expect it's useful any time anyone is using the playground for development.

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
