### PR TITLE
New relay definition parameters to split submit and get slot info roles.

### DIFF
--- a/crates/rbuilder/benches/benchmarks/mev_boost.rs
+++ b/crates/rbuilder/benches/benchmarks/mev_boost.rs
@@ -3,7 +3,8 @@ use alloy_primitives::{BlockHash, U256};
 use criterion::{criterion_group, Criterion};
 use primitive_types::H384;
 use rbuilder::mev_boost::{
-    rpc::TestDataGenerator, sign_block_for_relay, BLSBlockSigner, DenebSubmitBlockRequest,
+    rpc::TestDataGenerator, sign_block_for_relay, submission::DenebSubmitBlockRequest,
+    BLSBlockSigner,
 };
 use reth::primitives::SealedBlock;
 use reth_chainspec::SEPOLIA;

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -30,10 +30,8 @@ use rbuilder::{
         simulation::SimulatedOrderCommand,
         LiveBuilder,
     },
-    primitives::{
-        mev_boost::{MevBoostRelay, RelayConfig},
-        SimulatedOrder,
-    },
+    mev_boost::RelayClient,
+    primitives::{mev_boost::MevBoostRelaySlotInfoProvider, SimulatedOrder},
     provider::StateProviderFactory,
     utils::{ProviderFactoryReopener, Signer},
 };
@@ -61,11 +59,9 @@ async fn main() -> eyre::Result<()> {
     let chain_spec = MAINNET.clone();
     let cancel = CancellationToken::new();
 
-    let relay_config = RelayConfig::default().
-        with_url("https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net").
-        with_name("flashbots");
-
-    let relay = MevBoostRelay::from_config(&relay_config)?;
+    let flashbots_relay_url = "https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net";
+    let relay_client = RelayClient::from_url(flashbots_relay_url.parse()?, None, None, None);
+    let relay = MevBoostRelaySlotInfoProvider::new(relay_client, "flashbots".to_string(), 0);
 
     let payload_event = MevBoostSlotDataGenerator::new(
         vec![Client::default()],

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -251,6 +251,7 @@ where
         &mut self,
         payout_tx_value: Option<U256>,
     ) -> Result<(), BlockBuildingHelperError> {
+        self.built_block_trace.coinbase_reward = self.partial_block.coinbase_profit;
         let (bid_value, true_value) = if let (Some(payout_tx_gas), Some(payout_tx_value)) =
             (self.payout_tx_gas, payout_tx_value)
         {

--- a/crates/rbuilder/src/building/built_block_trace.rs
+++ b/crates/rbuilder/src/building/built_block_trace.rs
@@ -13,6 +13,8 @@ pub struct BuiltBlockTrace {
     pub included_orders: Vec<ExecutionResult>,
     /// How much we bid (pay to the validator)
     pub bid_value: U256,
+    /// coinbase balance delta before the payout tx.
+    pub coinbase_reward: U256,
     /// True block value (coinbase balance delta) excluding the cost of the payout to validator
     pub true_bid_value: U256,
     /// Some bundle failed with BundleErr::NoSigner, we might want to switch to !use_suggested_fee_recipient_as_coinbase
@@ -49,6 +51,7 @@ impl BuiltBlockTrace {
         Self {
             included_orders: Vec::new(),
             bid_value: U256::from(0),
+            coinbase_reward: U256::from(0),
             true_bid_value: U256::from(0),
             got_no_signer_error: false,
             orders_closed_at: OffsetDateTime::now_utc(),

--- a/crates/rbuilder/src/live_builder/block_output/bid_observer.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bid_observer.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::U256;
 use reth_primitives::SealedBlock;
 
-use crate::{building::BuiltBlockTrace, mev_boost::SubmitBlockRequest};
+use crate::{building::BuiltBlockTrace, mev_boost::submission::SubmitBlockRequest};
 
 /// Trait that receives every bid made by us to the relays.
 pub trait BidObserver: std::fmt::Debug {

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -2,8 +2,11 @@ use crate::{
     building::builders::Block,
     live_builder::payload_events::MevBoostSlotData,
     mev_boost::{
-        sign_block_for_relay, BLSBlockSigner, BidMetadata, BidValueMetadata, RelayError,
-        SubmitBlockErr, SubmitBlockRequest, SubmitBlockRequestWithMetadata,
+        sign_block_for_relay,
+        submission::{
+            BidMetadata, BidValueMetadata, SubmitBlockRequest, SubmitBlockRequestWithMetadata,
+        },
+        BLSBlockSigner, RelayError, SubmitBlockErr,
     },
     primitives::mev_boost::{MevBoostRelayBidSubmitter, MevBoostRelayID},
     telemetry::{

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -4,7 +4,7 @@ use crate::{
     mev_boost::{
         sign_block_for_relay, BLSBlockSigner, RelayError, SubmitBlockErr, SubmitBlockRequest,
     },
-    primitives::mev_boost::{MevBoostRelay, MevBoostRelayID},
+    primitives::mev_boost::{MevBoostRelayBidSubmitter, MevBoostRelayID},
     telemetry::{
         add_relay_submit_time, add_subsidy_value, inc_conn_relay_errors,
         inc_failed_block_simulations, inc_initiated_submissions, inc_other_relay_errors,
@@ -139,7 +139,7 @@ struct BuiltBlockInfo {
 async fn run_submit_to_relays_job(
     best_bid: Arc<BestBlockCell>,
     slot_data: MevBoostSlotData,
-    relays: Vec<MevBoostRelay>,
+    relays: Vec<MevBoostRelayBidSubmitter>,
     config: Arc<SubmissionConfig>,
     cancel: CancellationToken,
     competition_bid_value_source: Arc<dyn BidValueSource + Send + Sync>,
@@ -155,7 +155,7 @@ async fn run_submit_to_relays_job(
         let mut normal_relays = Vec::new();
         let mut optimistic_relays = Vec::new();
         for relay in relays {
-            if relay.optimistic {
+            if relay.optimistic() {
                 optimistic_relays.push(relay);
             } else {
                 normal_relays.push(relay);
@@ -288,7 +288,7 @@ async fn run_submit_to_relays_job(
         measure_block_e2e_latency(&block.trace.included_orders);
 
         for relay in &normal_relays {
-            let span = info_span!(parent: &submission_span, "relay_submit", relay = &relay.id, optimistic = false);
+            let span = info_span!(parent: &submission_span, "relay_submit", relay = &relay.id(), optimistic = false);
             let relay = relay.clone();
             let cancel = cancel.clone();
             let submission = normal_signed_submission.clone();
@@ -320,7 +320,7 @@ async fn run_submit_to_relays_job(
 
             if can_submit {
                 for relay in &optimistic_relays {
-                    let span = info_span!(parent: &submission_span, "relay_submit", relay = &relay.id, optimistic = true);
+                    let span = info_span!(parent: &submission_span, "relay_submit", relay = &relay.id(), optimistic = true);
                     let relay = relay.clone();
                     let cancel = cancel.clone();
                     let submission = optimistic_signed_submission.clone();
@@ -335,7 +335,7 @@ async fn run_submit_to_relays_job(
         } else {
             // non-optimistic submission to optimistic relays
             for relay in &optimistic_relays {
-                let span = info_span!(parent: &submission_span, "relay_submit", relay = &relay.id, optimistic = false);
+                let span = info_span!(parent: &submission_span, "relay_submit", relay = &relay.id(), optimistic = false);
                 let relay = relay.clone();
                 let cancel = cancel.clone();
                 let submission = normal_signed_submission.clone();
@@ -364,7 +364,7 @@ async fn run_submit_to_relays_job(
 pub async fn run_submit_to_relays_job_and_metrics(
     best_bid: Arc<BestBlockCell>,
     slot_data: MevBoostSlotData,
-    relays: Vec<MevBoostRelay>,
+    relays: Vec<MevBoostRelayBidSubmitter>,
     config: Arc<SubmissionConfig>,
     cancel: CancellationToken,
     competition_bid_value_source: Arc<dyn BidValueSource + Send + Sync>,
@@ -446,18 +446,16 @@ async fn validate_block(
 }
 
 async fn submit_bid_to_the_relay(
-    relay: &MevBoostRelay,
+    relay: &MevBoostRelayBidSubmitter,
     cancel: CancellationToken,
     signed_submit_request: SubmitBlockRequest,
     optimistic: bool,
 ) {
     let submit_start = Instant::now();
 
-    if let Some(limiter) = &relay.submission_rate_limiter {
-        if limiter.check().is_err() {
-            trace!("Relay submission is skipped due to rate limit");
-            return;
-        }
+    if !relay.can_submit_bid() {
+        trace!("Relay submission is skipped due to rate limit");
+        return;
     }
 
     let relay_result = tokio::select! {
@@ -470,8 +468,8 @@ async fn submit_bid_to_the_relay(
     match relay_result {
         Ok(()) => {
             trace!("Block submitted to the relay successfully");
-            add_relay_submit_time(&relay.id, submit_time);
-            inc_relay_accepted_submissions(&relay.id, optimistic);
+            add_relay_submit_time(relay.id(), submit_time);
+            inc_relay_accepted_submissions(relay.id(), optimistic);
         }
         Err(SubmitBlockErr::PayloadDelivered | SubmitBlockErr::PastSlot) => {
             trace!("Block already delivered by the relay, cancelling");
@@ -498,19 +496,19 @@ async fn submit_bid_to_the_relay(
         }
         Err(SubmitBlockErr::RelayError(RelayError::TooManyRequests)) => {
             trace!("Too many requests error submitting block to the relay");
-            inc_too_many_req_relay_errors(&relay.id);
+            inc_too_many_req_relay_errors(relay.id());
         }
         Err(SubmitBlockErr::RelayError(RelayError::ConnectionError))
         | Err(SubmitBlockErr::RelayError(RelayError::RequestError(_))) => {
             trace!(err = ?relay_result.unwrap_err(), "Connection error submitting block to the relay");
-            inc_conn_relay_errors(&relay.id);
+            inc_conn_relay_errors(relay.id());
         }
         Err(SubmitBlockErr::BlockKnown) => {
             trace!("Block already known");
         }
         Err(SubmitBlockErr::RelayError(_)) => {
             warn!(err = ?relay_result.unwrap_err(), "Error submitting block to the relay");
-            inc_other_relay_errors(&relay.id);
+            inc_other_relay_errors(relay.id());
         }
         Err(SubmitBlockErr::RPCConversionError(_)) => {
             error!(
@@ -534,14 +532,17 @@ async fn submit_bid_to_the_relay(
 #[derive(Debug)]
 pub struct RelaySubmitSinkFactory {
     submission_config: Arc<SubmissionConfig>,
-    relays: HashMap<MevBoostRelayID, MevBoostRelay>,
+    relays: HashMap<MevBoostRelayID, MevBoostRelayBidSubmitter>,
 }
 
 impl RelaySubmitSinkFactory {
-    pub fn new(submission_config: SubmissionConfig, relays: Vec<MevBoostRelay>) -> Self {
+    pub fn new(
+        submission_config: SubmissionConfig,
+        relays: Vec<MevBoostRelayBidSubmitter>,
+    ) -> Self {
         let relays = relays
             .into_iter()
-            .map(|relay| (relay.id.clone(), relay))
+            .map(|relay| (relay.id().clone(), relay))
             .collect();
         Self {
             submission_config: Arc::new(submission_config),

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -2,7 +2,8 @@ use crate::{
     building::builders::Block,
     live_builder::payload_events::MevBoostSlotData,
     mev_boost::{
-        sign_block_for_relay, BLSBlockSigner, RelayError, SubmitBlockErr, SubmitBlockRequest,
+        sign_block_for_relay, BLSBlockSigner, BidMetadata, BidValueMetadata, RelayError,
+        SubmitBlockErr, SubmitBlockRequest, SubmitBlockRequestWithMetadata,
     },
     primitives::mev_boost::{MevBoostRelayBidSubmitter, MevBoostRelayID},
     telemetry::{
@@ -208,7 +209,14 @@ async fn run_submit_to_relays_job(
                 }
             });
 
-        let best_bid_value = best_bid_sync_source.best_bid_value().unwrap_or_default();
+        let bid_metadata = BidMetadata {
+            value: BidValueMetadata {
+                coinbase_reward: block.trace.coinbase_reward,
+                top_competitor_bid: best_bid_sync_source.best_bid_value(),
+            },
+        };
+
+        let best_bid_value = bid_metadata.value.top_competitor_bid.unwrap_or_default();
         let submission_span = info_span!(
             "bid",
             bid_value = format_ether(block.trace.bid_value),
@@ -240,7 +248,10 @@ async fn run_submit_to_relays_job(
                 slot_data.slot_data.pubkey,
                 block.trace.bid_value,
             ) {
-                Ok(res) => res,
+                Ok(res) => SubmitBlockRequestWithMetadata {
+                    submission: res,
+                    metadata: bid_metadata.clone(),
+                },
                 Err(err) => {
                     error!(parent: &submission_span, err = ?err, "Error signing block for relay");
                     continue 'submit;
@@ -258,7 +269,13 @@ async fn run_submit_to_relays_job(
                     slot_data.slot_data.pubkey,
                     block.trace.bid_value,
                 ) {
-                    Ok(res) => Some((res, optimistic_config)),
+                    Ok(res) => Some((
+                        SubmitBlockRequestWithMetadata {
+                            submission: res,
+                            metadata: bid_metadata.clone(),
+                        },
+                        optimistic_config,
+                    )),
                     Err(err) => {
                         error!(parent: &submission_span, err = ?err, "Error signing block for relay");
                         continue 'submit;
@@ -274,7 +291,7 @@ async fn run_submit_to_relays_job(
         if config.dry_run {
             validate_block(
                 &slot_data,
-                &normal_signed_submission,
+                &normal_signed_submission.submission,
                 block.sealed_block.clone(),
                 &config,
                 cancel.clone(),
@@ -306,7 +323,7 @@ async fn run_submit_to_relays_job(
             let can_submit = if optimistic_config.prevalidate_optimistic_blocks {
                 validate_block(
                     &slot_data,
-                    optimistic_signed_submission,
+                    &optimistic_signed_submission.submission,
                     block.sealed_block.clone(),
                     &config,
                     cancel.clone(),
@@ -352,7 +369,7 @@ async fn run_submit_to_relays_job(
             // NOTE: we only notify normal submission here because they have the same contents but different pubkeys
             config.bid_observer.block_submitted(
                 block.sealed_block,
-                normal_signed_submission,
+                normal_signed_submission.submission,
                 block.trace,
                 builder_name,
                 best_bid_value,
@@ -448,7 +465,7 @@ async fn validate_block(
 async fn submit_bid_to_the_relay(
     relay: &MevBoostRelayBidSubmitter,
     cancel: CancellationToken,
-    signed_submit_request: SubmitBlockRequest,
+    signed_submit_request: SubmitBlockRequestWithMetadata,
     optimistic: bool,
 ) {
     let submit_start = Instant::now();
@@ -486,7 +503,7 @@ async fn submit_bid_to_the_relay(
             store_error_event(
                 SIM_ERROR_CATEGORY,
                 relay_result.as_ref().unwrap_err().to_string().as_str(),
-                &signed_submit_request,
+                &signed_submit_request.submission,
             );
             error!(
                 err = ?relay_result.unwrap_err(),

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -532,7 +532,12 @@ async fn submit_bid_to_the_relay(
 #[derive(Debug)]
 pub struct RelaySubmitSinkFactory {
     submission_config: Arc<SubmissionConfig>,
+    /// Real relays (!MevBoostRelayBidSubmitter::test_relay())
+    /// We submit to these only if the MevBoostRelayID is included on the MevBoostSlotData of the slot.
     relays: HashMap<MevBoostRelayID, MevBoostRelayBidSubmitter>,
+    /// Test relays (MevBoostRelayBidSubmitter::test_relay())
+    /// Always included on submissions.
+    test_relays: Vec<MevBoostRelayBidSubmitter>,
 }
 
 impl RelaySubmitSinkFactory {
@@ -540,13 +545,16 @@ impl RelaySubmitSinkFactory {
         submission_config: SubmissionConfig,
         relays: Vec<MevBoostRelayBidSubmitter>,
     ) -> Self {
+        let test_relays = relays.iter().filter(|r| r.test_relay()).cloned().collect();
         let relays = relays
             .into_iter()
+            .filter(|r| !r.test_relay())
             .map(|relay| (relay.id().clone(), relay))
             .collect();
         Self {
             submission_config: Arc::new(submission_config),
             relays,
+            test_relays,
         }
     }
 }
@@ -564,6 +572,7 @@ impl BuilderSinkFactory for RelaySubmitSinkFactory {
             .relays
             .iter()
             .flat_map(|id| self.relays.get(id))
+            .chain(self.test_relays.iter())
             .cloned()
             .collect();
         tokio::spawn(run_submit_to_relays_job_and_metrics(

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -563,12 +563,8 @@ impl BuilderSinkFactory for RelaySubmitSinkFactory {
         let relays = slot_data
             .relays
             .iter()
-            .map(|id| {
-                self.relays
-                    .get(id)
-                    .expect("Submission job is missing relay")
-                    .clone()
-            })
+            .flat_map(|id| self.relays.get(id))
+            .cloned()
             .collect();
         tokio::spawn(run_submit_to_relays_job_and_metrics(
             best_block_cell.clone(),

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -33,6 +33,7 @@ use crate::{
     mev_boost::{BLSBlockSigner, RelayClient},
     primitives::mev_boost::{
         MevBoostRelayBidSubmitter, MevBoostRelaySlotInfoProvider, RelayConfig, RelayMode,
+        RelaySubmitConfig,
     },
     provider::StateProviderFactory,
     roothash::RootHashConfig,
@@ -666,8 +667,13 @@ lazy_static! {
                 name: "flashbots".to_string(),
                 url: "http://k8s-default-boostrel-9f278153f5-947835446.us-east-2.elb.amazonaws.com"
                     .to_string(),
-                mode: RelayMode::default(),
-                submit_config: None,
+                mode: RelayMode::Full,
+                submit_config: Some(RelaySubmitConfig {
+                    use_ssz_for_submit: true,
+                    use_gzip_for_submit: false,
+                    optimistic: false,
+                    interval_between_submissions_ms: Some(250),
+                }),
                 priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,
@@ -679,8 +685,13 @@ lazy_static! {
             RelayConfig {
                 name: "ultrasound-us".to_string(),
                 url: "https://relay-builders-us.ultrasound.money".to_string(),
-                mode: RelayMode::default(),
-                submit_config: None,
+                mode: RelayMode::Full,
+                submit_config: Some(RelaySubmitConfig {
+                    use_ssz_for_submit: true,
+                    use_gzip_for_submit: true,
+                    optimistic: true,
+                    interval_between_submissions_ms: None,
+                }),
                 priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,
@@ -692,8 +703,13 @@ lazy_static! {
             RelayConfig {
                 name: "ultrasound-eu".to_string(),
                 url: "https://relay-builders-eu.ultrasound.money".to_string(),
-                mode: RelayMode::default(),
-                submit_config: None,
+                mode: RelayMode::Full,
+                submit_config: Some(RelaySubmitConfig {
+                    use_ssz_for_submit: true,
+                    use_gzip_for_submit: true,
+                    optimistic: true,
+                    interval_between_submissions_ms: None,
+                }),
                 priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,
@@ -705,9 +721,13 @@ lazy_static! {
             RelayConfig {
                 name: "agnostic".to_string(),
                 url: "https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net".to_string(),
-                mode: RelayMode::default(),
-                submit_config:None,
-                priority: Some(0),
+                mode: RelayMode::Full,
+                submit_config: Some(RelaySubmitConfig {
+                    use_ssz_for_submit: true,
+                    use_gzip_for_submit: true,
+                    optimistic: true,
+                    interval_between_submissions_ms: None,
+                }),                priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
@@ -718,8 +738,13 @@ lazy_static! {
             RelayConfig {
                 name: "playground".to_string(),
                 url: "http://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@localhost:5555".to_string(),
-                mode: RelayMode::default(),
-                submit_config:None,
+                mode: RelayMode::Full,
+                submit_config: Some(RelaySubmitConfig {
+                    use_ssz_for_submit: false,
+                    use_gzip_for_submit: false,
+                    optimistic: false,
+                    interval_between_submissions_ms: None,
+                }),                
                 priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -717,7 +717,7 @@ lazy_static! {
             RelayConfig {
                 name: "playground".to_string(),
                 url: "http://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@localhost:5555".to_string(),
-                mode: RelayMode::GetSlotInfoOnly,
+                mode: RelayMode::Full,
                 submit_config:None,
                 priority: Some(0),
                 authorization_header: None,

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -666,7 +666,7 @@ lazy_static! {
                 name: "flashbots".to_string(),
                 url: "http://k8s-default-boostrel-9f278153f5-947835446.us-east-2.elb.amazonaws.com"
                     .to_string(),
-                mode: RelayMode::GetSlotInfoOnly,
+                mode: RelayMode::default(),
                 submit_config: None,
                 priority: Some(0),
                 authorization_header: None,
@@ -679,7 +679,7 @@ lazy_static! {
             RelayConfig {
                 name: "ultrasound-us".to_string(),
                 url: "https://relay-builders-us.ultrasound.money".to_string(),
-                mode: RelayMode::GetSlotInfoOnly,
+                mode: RelayMode::default(),
                 submit_config: None,
                 priority: Some(0),
                 authorization_header: None,
@@ -692,7 +692,7 @@ lazy_static! {
             RelayConfig {
                 name: "ultrasound-eu".to_string(),
                 url: "https://relay-builders-eu.ultrasound.money".to_string(),
-                mode: RelayMode::GetSlotInfoOnly,
+                mode: RelayMode::default(),
                 submit_config: None,
                 priority: Some(0),
                 authorization_header: None,
@@ -705,7 +705,7 @@ lazy_static! {
             RelayConfig {
                 name: "agnostic".to_string(),
                 url: "https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net".to_string(),
-                mode: RelayMode::GetSlotInfoOnly,
+                mode: RelayMode::default(),
                 submit_config:None,
                 priority: Some(0),
                 authorization_header: None,
@@ -718,7 +718,7 @@ lazy_static! {
             RelayConfig {
                 name: "playground".to_string(),
                 url: "http://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@localhost:5555".to_string(),
-                mode: RelayMode::Full,
+                mode: RelayMode::default(),
                 submit_config:None,
                 priority: Some(0),
                 authorization_header: None,

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -744,7 +744,7 @@ lazy_static! {
                     use_gzip_for_submit: false,
                     optimistic: false,
                     interval_between_submissions_ms: None,
-                }),                
+                }),
                 priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -186,6 +186,7 @@ impl L1Config {
                     client.clone(),
                     relay_config.name.clone(),
                     submit_config,
+                    relay_config.mode == RelayMode::Test,
                 ));
             } else {
                 eyre::bail!(

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -30,8 +30,10 @@ use crate::{
         base_config::EnvOrValue, block_output::relay_submit::BuilderSinkFactory,
         cli::LiveBuilderConfig, payload_events::MevBoostSlotDataGenerator,
     },
-    mev_boost::BLSBlockSigner,
-    primitives::mev_boost::{MevBoostRelay, RelayConfig},
+    mev_boost::{BLSBlockSigner, RelayClient},
+    primitives::mev_boost::{
+        MevBoostRelayBidSubmitter, MevBoostRelaySlotInfoProvider, RelayConfig, RelayMode,
+    },
     provider::StateProviderFactory,
     roothash::RootHashConfig,
     utils::{build_info::rbuilder_version, ProviderFactoryReopener, Signer},
@@ -171,50 +173,98 @@ impl L1Config {
             .collect()
     }
 
-    pub fn create_relays(&self) -> eyre::Result<Vec<MevBoostRelay>> {
-        let mut relay_configs = DEFAULT_RELAYS.clone();
+    /// Analyzes relay_config and creates MevBoostRelayBidSubmitter/MevBoostRelaySlotInfoProvider as needed.
+    fn create_relay_sub_objects(
+        relay_config: &RelayConfig,
+        client: RelayClient,
+        submitters: &mut Vec<MevBoostRelayBidSubmitter>,
+        slot_info_providers: &mut Vec<MevBoostRelaySlotInfoProvider>,
+    ) -> eyre::Result<()> {
+        if relay_config.mode.submits_bids() {
+            if let Some(submit_config) = &relay_config.submit_config {
+                submitters.push(MevBoostRelayBidSubmitter::new(
+                    client.clone(),
+                    relay_config.name.clone(),
+                    submit_config,
+                ));
+            } else {
+                eyre::bail!(
+                    "Relay {} in mode {:?} has no submit config",
+                    relay_config.name,
+                    relay_config.mode
+                );
+            }
+        }
+        if relay_config.mode.gets_slot_info() {
+            if let Some(priority) = &relay_config.priority {
+                slot_info_providers.push(MevBoostRelaySlotInfoProvider::new(
+                    client.clone(),
+                    relay_config.name.clone(),
+                    *priority,
+                ));
+            } else {
+                eyre::bail!(
+                    "Relay {} in mode {:?} has no priority",
+                    relay_config.name,
+                    relay_config.mode
+                );
+            }
+        }
+        Ok(())
+    }
 
+    pub fn create_relays(
+        &self,
+    ) -> eyre::Result<(
+        Vec<MevBoostRelayBidSubmitter>,
+        Vec<MevBoostRelaySlotInfoProvider>,
+    )> {
+        let mut relay_configs = DEFAULT_RELAYS.clone();
         // Update relay configs from user configuration - replace if found
         for relay in self.relays.clone() {
             relay_configs.insert(relay.name.clone(), relay);
         }
-
         // For backwards compatibility: add all user-configured relays to enabled_relays
         let mut effective_enabled_relays: std::collections::HashSet<String> =
             self.enabled_relays.iter().cloned().collect();
         effective_enabled_relays.extend(self.relays.iter().map(|r| r.name.clone()));
-
         // Create enabled relays
-        let mut results = Vec::new();
+        let mut submitters = Vec::new();
+        let mut slot_info_providers = Vec::new();
         for relay_name in effective_enabled_relays.iter() {
             match relay_configs.get(relay_name) {
-                Some(relay_config) => match MevBoostRelay::from_config(relay_config) {
-                    Ok(relay) => {
-                        info!(
-                            "Created relay: {:?} (priority: {})",
-                            relay_name, relay.priority
-                        );
-                        results.push(relay);
-                    }
-                    Err(e) => {
-                        return Err(eyre::eyre!(
-                            "Failed to create relay {}: {:?}",
-                            relay_name,
-                            e
-                        ));
-                    }
-                },
+                Some(relay_config) => {
+                    let url = match relay_config.url.parse() {
+                        Ok(url) => url,
+                        Err(err) => {
+                            eyre::bail!(
+                                "Failed to parse relay url. Error = {err}. Url = {}",
+                                relay_config.url
+                            );
+                        }
+                    };
+                    let client = RelayClient::from_url(
+                        url,
+                        relay_config.authorization_header.clone(),
+                        relay_config.builder_id_header.clone(),
+                        relay_config.api_token_header.clone(),
+                    );
+                    Self::create_relay_sub_objects(
+                        relay_config,
+                        client,
+                        &mut submitters,
+                        &mut slot_info_providers,
+                    )?;
+                }
                 None => {
                     return Err(eyre::eyre!("Relay {} not found in relays list", relay_name));
                 }
             }
         }
-
-        if results.is_empty() {
-            return Err(eyre::eyre!("No relays enabled"));
+        if slot_info_providers.is_empty() {
+            return Err(eyre::eyre!("No relays enabled for getting slot info"));
         }
-
-        Ok(results)
+        Ok((submitters, slot_info_providers))
     }
 
     fn submission_config(
@@ -285,12 +335,15 @@ impl L1Config {
         })
     }
 
-    /// Creates the RelaySubmitSinkFactory and also returns the associated relays.
+    /// Creates the RelaySubmitSinkFactory and also returns the associated relays (MevBoostRelaySlotInfoProvider).
     pub fn create_relays_sealed_sink_factory(
         &self,
         chain_spec: Arc<ChainSpec>,
         bid_observer: Box<dyn BidObserver + Send + Sync>,
-    ) -> eyre::Result<(Box<dyn BuilderSinkFactory>, Vec<MevBoostRelay>)> {
+    ) -> eyre::Result<(
+        Box<dyn BuilderSinkFactory>,
+        Vec<MevBoostRelaySlotInfoProvider>,
+    )> {
         let submission_config = self.submission_config(chain_spec, bid_observer)?;
         info!(
             "Builder mev boost normal relay pubkey: {:?}",
@@ -306,16 +359,16 @@ impl L1Config {
             );
         };
 
-        let relays = self.create_relays()?;
-        if relays.is_empty() {
-            eyre::bail!("No relays provided");
+        let (submitters, slot_info_providers) = self.create_relays()?;
+        if slot_info_providers.is_empty() {
+            eyre::bail!("No slot info providers provided");
         }
 
         let sink_factory: Box<dyn BuilderSinkFactory> = Box::new(RelaySubmitSinkFactory::new(
             submission_config,
-            relays.clone(),
+            submitters.clone(),
         ));
-        Ok((sink_factory, relays))
+        Ok((sink_factory, slot_info_providers))
     }
 }
 
@@ -612,11 +665,9 @@ lazy_static! {
                 name: "flashbots".to_string(),
                 url: "http://k8s-default-boostrel-9f278153f5-947835446.us-east-2.elb.amazonaws.com"
                     .to_string(),
-                use_ssz_for_submit: true,
-                use_gzip_for_submit: false,
-                priority: 0,
-                optimistic: false,
-                interval_between_submissions_ms: Some(250),
+                mode: RelayMode::GetSlotInfoOnly,
+                submit_config: None,
+                priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
@@ -627,11 +678,9 @@ lazy_static! {
             RelayConfig {
                 name: "ultrasound-us".to_string(),
                 url: "https://relay-builders-us.ultrasound.money".to_string(),
-                use_ssz_for_submit: true,
-                use_gzip_for_submit: true,
-                priority: 0,
-                optimistic: true,
-                interval_between_submissions_ms: None,
+                mode: RelayMode::GetSlotInfoOnly,
+                submit_config: None,
+                priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
@@ -642,11 +691,9 @@ lazy_static! {
             RelayConfig {
                 name: "ultrasound-eu".to_string(),
                 url: "https://relay-builders-eu.ultrasound.money".to_string(),
-                use_ssz_for_submit: true,
-                use_gzip_for_submit: true,
-                priority: 0,
-                optimistic: true,
-                interval_between_submissions_ms: None,
+                mode: RelayMode::GetSlotInfoOnly,
+                submit_config: None,
+                priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
@@ -657,11 +704,9 @@ lazy_static! {
             RelayConfig {
                 name: "agnostic".to_string(),
                 url: "https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net".to_string(),
-                use_ssz_for_submit: true,
-                use_gzip_for_submit: true,
-                priority: 0,
-                optimistic: true,
-                interval_between_submissions_ms: None,
+                mode: RelayMode::GetSlotInfoOnly,
+                submit_config:None,
+                priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
@@ -672,11 +717,9 @@ lazy_static! {
             RelayConfig {
                 name: "playground".to_string(),
                 url: "http://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@localhost:5555".to_string(),
-                priority: 0,
-                use_ssz_for_submit: false,
-                use_gzip_for_submit: false,
-                optimistic: false,
-                interval_between_submissions_ms: None,
+                mode: RelayMode::GetSlotInfoOnly,
+                submit_config:None,
+                priority: Some(0),
                 authorization_header: None,
                 builder_id_header: None,
                 api_token_header: None,
@@ -750,10 +793,10 @@ mod test {
 
         let config: Config = load_config_toml_and_env(p.clone()).expect("Config load");
 
-        let relays = config.l1_config.create_relays().unwrap();
-        assert_eq!(relays.len(), 1);
-        assert_eq!(relays[0].id, "playground");
-        assert_eq!(relays[0].priority, 10);
+        let (_, slot_info_providers) = config.l1_config.create_relays().unwrap();
+        assert_eq!(slot_info_providers.len(), 1);
+        assert_eq!(slot_info_providers[0].id(), "playground");
+        assert_eq!(slot_info_providers[0].priority(), 10);
     }
 
     #[test]

--- a/crates/rbuilder/src/live_builder/payload_events/mod.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         SlotSource,
     },
-    primitives::mev_boost::{MevBoostRelay, MevBoostRelayID},
+    primitives::mev_boost::{MevBoostRelayID, MevBoostRelaySlotInfoProvider},
 };
 use ahash::HashSet;
 use alloy_eips::merge::SLOT_DURATION;
@@ -80,7 +80,7 @@ impl MevBoostSlotData {
 /// - If join with spawned task is needed await on the JoinHandle returned by spawn.
 pub struct MevBoostSlotDataGenerator {
     cls: Vec<Client>,
-    relays: Vec<MevBoostRelay>,
+    relays: Vec<MevBoostRelaySlotInfoProvider>,
     blocklist: HashSet<Address>,
 
     global_cancellation: CancellationToken,
@@ -89,7 +89,7 @@ pub struct MevBoostSlotDataGenerator {
 impl MevBoostSlotDataGenerator {
     pub fn new(
         cls: Vec<Client>,
-        relays: Vec<MevBoostRelay>,
+        relays: Vec<MevBoostRelaySlotInfoProvider>,
         blocklist: HashSet<Address>,
         global_cancellation: CancellationToken,
     ) -> Self {

--- a/crates/rbuilder/src/live_builder/testdata/config_with_relay_override.toml
+++ b/crates/rbuilder/src/live_builder/testdata/config_with_relay_override.toml
@@ -40,3 +40,4 @@ enabled_relays = ["playground"]
 name = "playground"
 url = "http://example.com"
 priority = 10
+mode = "full"

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -24,6 +24,9 @@ use url::Url;
 pub use error::*;
 pub use sign_payload::*;
 
+const TOTAL_PAYMENT_HEADER: &str = "Total-Payment";
+const TOP_BID_HEADER: &str = "Top-Bid";
+
 const JSON_CONTENT_TYPE: &str = "application/json";
 const SSZ_CONTENT_TYPE: &str = "application/octet-stream";
 const GZIP_CONTENT_ENCODING: &str = "gzip";
@@ -450,9 +453,10 @@ impl RelayClient {
     /// Mainly takes care of ssz/json raw/gzip
     async fn call_relay_submit_block(
         &self,
-        data: &SubmitBlockRequest,
+        submission_with_metadata: &SubmitBlockRequestWithMetadata,
         ssz: bool,
         gzip: bool,
+        add_metadata: bool,
     ) -> Result<Response, SubmitBlockErr> {
         let url = {
             let mut url = self.url.clone();
@@ -465,7 +469,7 @@ impl RelayClient {
         // SSZ vs JSON
         let (mut body_data, content_type) = if ssz {
             (
-                match data {
+                match &submission_with_metadata.submission {
                     SubmitBlockRequest::Capella(data) => data.0.as_ssz_bytes(),
                     SubmitBlockRequest::Deneb(data) => data.0.as_ssz_bytes(),
                     SubmitBlockRequest::Electra(data) => data.0.as_ssz_bytes(),
@@ -474,7 +478,7 @@ impl RelayClient {
             )
         } else {
             (
-                serde_json::to_vec(&data)
+                serde_json::to_vec(&submission_with_metadata.submission)
                     .map_err(|e| SubmitBlockErr::RPCSerializationError(e.to_string()))?,
                 JSON_CONTENT_TYPE,
             )
@@ -499,6 +503,21 @@ impl RelayClient {
         }
 
         builder = builder.headers(headers).body(Body::from(body_data));
+        if add_metadata {
+            builder = builder.header(
+                TOTAL_PAYMENT_HEADER,
+                submission_with_metadata
+                    .metadata
+                    .value
+                    .coinbase_reward
+                    .to_string(),
+            );
+            if let Some(top_competitor_bid) =
+                submission_with_metadata.metadata.value.top_competitor_bid
+            {
+                builder = builder.header(TOP_BID_HEADER, top_competitor_bid.to_string());
+            }
+        }
 
         Ok(builder
             .send()
@@ -509,11 +528,14 @@ impl RelayClient {
     /// Submits the block (call_relay_submit_block) and processes some special errors.
     pub async fn submit_block(
         &self,
-        data: &SubmitBlockRequest,
+        data: &SubmitBlockRequestWithMetadata,
         ssz: bool,
         gzip: bool,
+        add_metadata: bool,
     ) -> Result<(), SubmitBlockErr> {
-        let resp = self.call_relay_submit_block(data, ssz, gzip).await?;
+        let resp = self
+            .call_relay_submit_block(data, ssz, gzip, add_metadata)
+            .await?;
         let status = resp.status();
 
         if status == StatusCode::TOO_MANY_REQUESTS {
@@ -630,6 +652,23 @@ impl SubmitBlockRequest {
             SubmitBlockRequest::Electra(req) => req.0.message.clone(),
         }
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct BidMetadata {
+    pub value: BidValueMetadata,
+}
+
+#[derive(Clone, Copy, Default, Debug)]
+pub struct BidValueMetadata {
+    pub coinbase_reward: U256,
+    pub top_competitor_bid: Option<U256>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SubmitBlockRequestWithMetadata {
+    pub submission: SubmitBlockRequest,
+    pub metadata: BidMetadata,
 }
 
 #[cfg(test)]
@@ -781,9 +820,18 @@ mod tests {
 
         let relay_url = Url::from_str(&srv.endpoint()).unwrap();
         let relay = RelayClient::from_url(relay_url, None, None, None);
-        let sub_relay = SubmitBlockRequest::Deneb(generator.create_deneb_submit_block_request());
+        let submission = SubmitBlockRequest::Deneb(generator.create_deneb_submit_block_request());
+        let sub_relay = SubmitBlockRequestWithMetadata {
+            submission,
+            metadata: BidMetadata {
+                value: BidValueMetadata {
+                    coinbase_reward: Default::default(),
+                    top_competitor_bid: None,
+                },
+            },
+        };
         relay
-            .submit_block(&sub_relay, true, true)
+            .submit_block(&sub_relay, true, true, false)
             .await
             .expect("OPS!");
     }

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -2,13 +2,11 @@ mod error;
 pub mod fake_mev_boost_relay;
 pub mod rpc;
 pub mod sign_payload;
+pub mod submission;
 
 use super::utils::u256decimal_serde_helper;
 
 use alloy_primitives::{Address, BlockHash, Bytes, U256};
-use alloy_rpc_types_beacon::relay::{
-    BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4,
-};
 use flate2::{write::GzEncoder, Compression};
 use primitive_types::H384;
 use reqwest::{
@@ -19,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use ssz::Encode;
 use std::{io::Write, str::FromStr};
+use submission::{SubmitBlockRequest, SubmitBlockRequestNoBlobs, SubmitBlockRequestWithMetadata};
 use url::Url;
 
 pub use error::*;
@@ -456,7 +455,7 @@ impl RelayClient {
         submission_with_metadata: &SubmitBlockRequestWithMetadata,
         ssz: bool,
         gzip: bool,
-        add_metadata: bool,
+        fake_relay: bool,
     ) -> Result<Response, SubmitBlockErr> {
         let url = {
             let mut url = self.url.clone();
@@ -477,9 +476,17 @@ impl RelayClient {
                 SSZ_CONTENT_TYPE,
             )
         } else {
-            (
+            let json_result = if fake_relay {
+                // For the fake relay we remove the blobs
+                serde_json::to_vec(&SubmitBlockRequestNoBlobs(
+                    &submission_with_metadata.submission,
+                ))
+            } else {
                 serde_json::to_vec(&submission_with_metadata.submission)
-                    .map_err(|e| SubmitBlockErr::RPCSerializationError(e.to_string()))?,
+            };
+
+            (
+                json_result.map_err(|e| SubmitBlockErr::RPCSerializationError(e.to_string()))?,
                 JSON_CONTENT_TYPE,
             )
         };
@@ -503,7 +510,7 @@ impl RelayClient {
         }
 
         builder = builder.headers(headers).body(Body::from(body_data));
-        if add_metadata {
+        if fake_relay {
             builder = builder.header(
                 TOTAL_PAYMENT_HEADER,
                 submission_with_metadata
@@ -531,10 +538,10 @@ impl RelayClient {
         data: &SubmitBlockRequestWithMetadata,
         ssz: bool,
         gzip: bool,
-        add_metadata: bool,
+        fake_relay: bool,
     ) -> Result<(), SubmitBlockErr> {
         let resp = self
-            .call_relay_submit_block(data, ssz, gzip, add_metadata)
+            .call_relay_submit_block(data, ssz, gzip, fake_relay)
             .await?;
         let status = resp.status();
 
@@ -621,58 +628,10 @@ impl RelayClient {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ElectraSubmitBlockRequest(SignedBidSubmissionV4);
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct DenebSubmitBlockRequest(SignedBidSubmissionV3);
-
-impl DenebSubmitBlockRequest {
-    pub fn as_ssz_bytes(&self) -> Vec<u8> {
-        self.0.as_ssz_bytes()
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct CapellaSubmitBlockRequest(SignedBidSubmissionV2);
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(untagged)]
-pub enum SubmitBlockRequest {
-    Capella(CapellaSubmitBlockRequest),
-    Deneb(DenebSubmitBlockRequest),
-    Electra(ElectraSubmitBlockRequest),
-}
-
-impl SubmitBlockRequest {
-    pub fn bid_trace(&self) -> BidTrace {
-        match self {
-            SubmitBlockRequest::Capella(req) => req.0.message.clone(),
-            SubmitBlockRequest::Deneb(req) => req.0.message.clone(),
-            SubmitBlockRequest::Electra(req) => req.0.message.clone(),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct BidMetadata {
-    pub value: BidValueMetadata,
-}
-
-#[derive(Clone, Copy, Default, Debug)]
-pub struct BidValueMetadata {
-    pub coinbase_reward: U256,
-    pub top_competitor_bid: Option<U256>,
-}
-
-#[derive(Clone, Debug)]
-pub struct SubmitBlockRequestWithMetadata {
-    pub submission: SubmitBlockRequest,
-    pub metadata: BidMetadata,
-}
-
 #[cfg(test)]
 mod tests {
+    use submission::{BidMetadata, BidValueMetadata};
+
     use super::{rpc::TestDataGenerator, *};
     use crate::mev_boost::fake_mev_boost_relay::FakeMevBoostRelay;
 

--- a/crates/rbuilder/src/mev_boost/rpc.rs
+++ b/crates/rbuilder/src/mev_boost/rpc.rs
@@ -1,4 +1,4 @@
-use super::DenebSubmitBlockRequest;
+use super::submission::DenebSubmitBlockRequest;
 use alloy_consensus::{Blob, Bytes48};
 use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
 use alloy_rpc_types_beacon::{

--- a/crates/rbuilder/src/mev_boost/sign_payload.rs
+++ b/crates/rbuilder/src/mev_boost/sign_payload.rs
@@ -1,4 +1,4 @@
-use super::{
+use super::submission::{
     CapellaSubmitBlockRequest, DenebSubmitBlockRequest, ElectraSubmitBlockRequest,
     SubmitBlockRequest,
 };

--- a/crates/rbuilder/src/mev_boost/submission.rs
+++ b/crates/rbuilder/src/mev_boost/submission.rs
@@ -1,0 +1,112 @@
+use alloy_primitives::U256;
+use alloy_rpc_types_beacon::{
+    relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
+    requests::ExecutionRequestsV4,
+    BlsSignature,
+};
+use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
+use serde::{Deserialize, Serialize};
+use ssz::Encode;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ElectraSubmitBlockRequest(pub SignedBidSubmissionV4);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DenebSubmitBlockRequest(pub SignedBidSubmissionV3);
+
+impl DenebSubmitBlockRequest {
+    pub fn as_ssz_bytes(&self) -> Vec<u8> {
+        self.0.as_ssz_bytes()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CapellaSubmitBlockRequest(pub SignedBidSubmissionV2);
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum SubmitBlockRequest {
+    Capella(CapellaSubmitBlockRequest),
+    Deneb(DenebSubmitBlockRequest),
+    Electra(ElectraSubmitBlockRequest),
+}
+
+impl SubmitBlockRequest {
+    pub fn bid_trace(&self) -> BidTrace {
+        match self {
+            SubmitBlockRequest::Capella(req) => req.0.message.clone(),
+            SubmitBlockRequest::Deneb(req) => req.0.message.clone(),
+            SubmitBlockRequest::Electra(req) => req.0.message.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BidMetadata {
+    pub value: BidValueMetadata,
+}
+
+#[derive(Clone, Copy, Default, Debug)]
+pub struct BidValueMetadata {
+    pub coinbase_reward: U256,
+    pub top_competitor_bid: Option<U256>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SubmitBlockRequestWithMetadata {
+    pub submission: SubmitBlockRequest,
+    pub metadata: BidMetadata,
+}
+
+/// Signed bid submission that is serialized without blobs bundle.
+#[derive(Debug)]
+pub struct SubmitBlockRequestNoBlobs<'a>(pub &'a SubmitBlockRequest);
+
+impl serde::Serialize for SubmitBlockRequestNoBlobs<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0 {
+            SubmitBlockRequest::Capella(v2) => v2.serialize(serializer),
+            SubmitBlockRequest::Deneb(v3) => {
+                #[derive(serde::Serialize)]
+                struct SignedBidSubmissionV3Ref<'a> {
+                    message: &'a BidTrace,
+                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
+                    execution_payload: &'a ExecutionPayloadV3,
+                    blobs_bundle: &'a BlobsBundleV1,
+                    signature: &'a BlsSignature,
+                }
+
+                SignedBidSubmissionV3Ref {
+                    message: &v3.0.message,
+                    execution_payload: &v3.0.execution_payload,
+                    blobs_bundle: &BlobsBundleV1::new([]), // override blobs bundle with empty one
+                    signature: &v3.0.signature,
+                }
+                .serialize(serializer)
+            }
+            SubmitBlockRequest::Electra(v4) => {
+                #[derive(serde::Serialize)]
+                struct SignedBidSubmissionV4Ref<'a> {
+                    message: &'a BidTrace,
+                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
+                    execution_payload: &'a ExecutionPayloadV3,
+                    blobs_bundle: &'a BlobsBundleV1,
+                    execution_requests: &'a ExecutionRequestsV4,
+                    signature: &'a BlsSignature,
+                }
+
+                SignedBidSubmissionV4Ref {
+                    message: &v4.0.message,
+                    execution_payload: &v4.0.execution_payload,
+                    blobs_bundle: &BlobsBundleV1::new([]), // override blobs bundle with empty one
+                    signature: &v4.0.signature,
+                    execution_requests: &v4.0.execution_requests,
+                }
+                .serialize(serializer)
+            }
+        }
+    }
+}

--- a/crates/rbuilder/src/primitives/mev_boost.rs
+++ b/crates/rbuilder/src/primitives/mev_boost.rs
@@ -1,5 +1,5 @@
 use crate::mev_boost::{
-    RelayClient, RelayError, SubmitBlockErr, SubmitBlockRequest, ValidatorSlotData,
+    RelayClient, RelayError, SubmitBlockErr, SubmitBlockRequestWithMetadata, ValidatorSlotData,
 };
 use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
 use serde::{Deserialize, Deserializer};
@@ -155,9 +155,17 @@ impl MevBoostRelayBidSubmitter {
         }
     }
 
-    pub async fn submit_block(&self, data: &SubmitBlockRequest) -> Result<(), SubmitBlockErr> {
+    pub async fn submit_block(
+        &self,
+        data: &SubmitBlockRequestWithMetadata,
+    ) -> Result<(), SubmitBlockErr> {
         self.client
-            .submit_block(data, self.use_ssz_for_submit, self.use_gzip_for_submit)
+            .submit_block(
+                data,
+                self.use_ssz_for_submit,
+                self.use_gzip_for_submit,
+                self.test_relay,
+            )
             .await
     }
 }

--- a/crates/rbuilder/src/primitives/mev_boost.rs
+++ b/crates/rbuilder/src/primitives/mev_boost.rs
@@ -1,5 +1,6 @@
 use crate::mev_boost::{
-    RelayClient, RelayError, SubmitBlockErr, SubmitBlockRequestWithMetadata, ValidatorSlotData,
+    submission::SubmitBlockRequestWithMetadata, RelayClient, RelayError, SubmitBlockErr,
+    ValidatorSlotData,
 };
 use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
 use serde::{Deserialize, Deserializer};

--- a/crates/rbuilder/src/primitives/mev_boost.rs
+++ b/crates/rbuilder/src/primitives/mev_boost.rs
@@ -1,31 +1,77 @@
-use crate::mev_boost::{RelayClient, SubmitBlockErr, SubmitBlockRequest};
+use crate::mev_boost::{
+    RelayClient, RelayError, SubmitBlockErr, SubmitBlockRequest, ValidatorSlotData,
+};
 use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
 use serde::{Deserialize, Deserializer};
 use std::{env, sync::Arc, time::Duration};
-use url::Url;
 
 /// Usually human readable id for relays. Not used on anything on any protocol just to identify the relays.
 pub type MevBoostRelayID = String;
+
+/// Modes for a relay since we may use them for different purposes.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq, Default)]
+pub enum RelayMode {
+    /// Submits bids, gets slot info. No extra headers on bidding.
+    #[serde(rename = "full")]
+    Full,
+    /// Only gets slot info.
+    #[serde(rename = "slot_info")]
+    #[default]
+    GetSlotInfoOnly,
+    /// Submits bids with extra headers. Does not used to get slot info.
+    #[serde(rename = "fake")]
+    Fake,
+}
+
+impl RelayMode {
+    pub fn submits_bids(&self) -> bool {
+        match self {
+            RelayMode::Full => true,
+            RelayMode::GetSlotInfoOnly => false,
+            RelayMode::Fake => true,
+        }
+    }
+    pub fn gets_slot_info(&self) -> bool {
+        match self {
+            RelayMode::Full => true,
+            RelayMode::GetSlotInfoOnly => true,
+            RelayMode::Fake => false,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RelayConfig {
     pub name: String,
     pub url: String,
-    pub priority: usize,
-    // true->ssz false->json
-    #[serde(default)]
-    pub use_ssz_for_submit: bool,
-    #[serde(default)]
-    pub use_gzip_for_submit: bool,
-    #[serde(default)]
-    pub optimistic: bool,
     #[serde(default, deserialize_with = "deserialize_env_var")]
     pub authorization_header: Option<String>,
     #[serde(default, deserialize_with = "deserialize_env_var")]
     pub builder_id_header: Option<String>,
     #[serde(default, deserialize_with = "deserialize_env_var")]
     pub api_token_header: Option<String>,
+    /// mode defines the need of submit_config/priority
+    pub mode: RelayMode,
+    #[serde(flatten)]
+    /// Submit specific info.
+    /// Used only for Full and Fake mode.
+    pub submit_config: Option<RelaySubmitConfig>,
+    /// priority when getting slot data so solve unconsistencies. Lower number ->  higher priority.
+    /// Used only for Full and GetSlotInfoOnly mode.
+    pub priority: Option<usize>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct RelaySubmitConfig {
+    /// true->ssz false->json
+    #[serde(default)]
+    pub use_ssz_for_submit: bool,
+    #[serde(default)]
+    pub use_gzip_for_submit: bool,
+    #[serde(default)]
+    pub optimistic: bool,
     #[serde(default)]
     pub interval_between_submissions_ms: Option<u64>,
 }
@@ -46,57 +92,95 @@ impl RelayConfig {
     }
 }
 
-/// Wrapper over RelayClient that allows to submit blocks and
-/// hides the particular configuration (eg: ssz, gip, optimistic).
-/// Sometimes the client is used externally.
+/// Wrapper in RelayClient to submit blocks.
+/// Hides the particular configuration (eg: ssz, gip, optimistic).
 #[derive(Debug, Clone)]
-pub struct MevBoostRelay {
+pub struct MevBoostRelayBidSubmitter {
     /// Id for UI
-    pub id: MevBoostRelayID,
-    pub client: RelayClient,
-    /// Lower priority -> more important.
-    pub priority: usize,
+    id: MevBoostRelayID,
+
+    client: RelayClient,
     /// true -> ssz; false -> json.
-    pub use_ssz_for_submit: bool,
-    pub use_gzip_for_submit: bool,
+    use_ssz_for_submit: bool,
+    use_gzip_for_submit: bool,
     /// Relay accepts optimistic submissions.
-    pub optimistic: bool,
-    pub submission_rate_limiter: Option<Arc<DefaultDirectRateLimiter>>,
+    optimistic: bool,
+    submission_rate_limiter: Option<Arc<DefaultDirectRateLimiter>>,
 }
 
-impl MevBoostRelay {
-    pub fn from_config(config: &RelayConfig) -> eyre::Result<Self> {
-        let client = {
-            let url: Url = config.url.parse()?;
-            RelayClient::from_url(
-                url,
-                config.authorization_header.clone(),
-                config.builder_id_header.clone(),
-                config.api_token_header.clone(),
-            )
-        };
-
+impl MevBoostRelayBidSubmitter {
+    pub fn new(client: RelayClient, id: String, config: &RelaySubmitConfig) -> Self {
         let submission_rate_limiter = config.interval_between_submissions_ms.map(|d| {
             Arc::new(RateLimiter::direct(
                 Quota::with_period(Duration::from_millis(d)).expect("Rate limiter time period"),
             ))
         });
-
-        Ok(MevBoostRelay {
-            id: config.name.to_string(),
+        Self {
+            id,
             client,
-            priority: config.priority,
             use_ssz_for_submit: config.use_ssz_for_submit,
             use_gzip_for_submit: config.use_gzip_for_submit,
             optimistic: config.optimistic,
             submission_rate_limiter,
-        })
+        }
+    }
+
+    pub fn id(&self) -> &MevBoostRelayID {
+        &self.id
+    }
+
+    pub fn optimistic(&self) -> bool {
+        self.optimistic
+    }
+
+    /// false -> rate limiter don't allow
+    pub fn can_submit_bid(&self) -> bool {
+        if let Some(limiter) = &self.submission_rate_limiter {
+            limiter.check().is_ok()
+        } else {
+            true
+        }
     }
 
     pub async fn submit_block(&self, data: &SubmitBlockRequest) -> Result<(), SubmitBlockErr> {
         self.client
             .submit_block(data, self.use_ssz_for_submit, self.use_gzip_for_submit)
             .await
+    }
+}
+
+/// Wrapper over RelayClient that allows to ask for slot validators info.
+#[derive(Debug, Clone)]
+pub struct MevBoostRelaySlotInfoProvider {
+    /// Id for UI
+    id: MevBoostRelayID,
+    client: RelayClient,
+    /// Lower priority -> more important.
+    priority: usize,
+}
+
+impl MevBoostRelaySlotInfoProvider {
+    pub fn new(client: RelayClient, id: String, priority: usize) -> Self {
+        Self {
+            client,
+            id,
+            priority,
+        }
+    }
+    pub fn id(&self) -> &MevBoostRelayID {
+        &self.id
+    }
+    pub fn priority(&self) -> usize {
+        self.priority
+    }
+
+    /// A little ugly, needed for backtest payload fetcher.
+    pub fn client(&self) -> RelayClient {
+        self.client.clone()
+    }
+
+    pub async fn get_current_epoch_validators(&self) -> Result<Vec<ValidatorSlotData>, RelayError> {
+        self.client.get_current_epoch_validators().await
     }
 }
 
@@ -127,6 +211,7 @@ mod test {
         authorization_header = 'env:XXX'
         builder_id_header = 'env:YYY'
         api_token_header = 'env:ZZZ'
+        mode = 'slot_info'
         ";
 
         std::env::set_var("XXX", "AAA");
@@ -136,9 +221,28 @@ mod test {
         let config: RelayConfig = toml::from_str(example).unwrap();
         assert_eq!(config.name, "relay1");
         assert_eq!(config.url, "url");
-        assert_eq!(config.priority, 0);
+        assert_eq!(config.priority, Some(0));
         assert_eq!(config.authorization_header.unwrap(), "AAA");
         assert_eq!(config.builder_id_header.unwrap(), "BBB");
         assert_eq!(config.api_token_header.unwrap(), "CCC");
+        assert_eq!(config.mode, RelayMode::GetSlotInfoOnly);
+    }
+
+    #[test]
+    fn test_deserialize_relay_config_modes() {
+        let example_base = "
+        name = 'relay1'
+        url = 'url'
+        mode = "
+            .to_string();
+
+        let config: RelayConfig = toml::from_str(&(example_base.clone() + "'full'")).unwrap();
+        assert_eq!(config.mode, RelayMode::Full);
+
+        let config: RelayConfig = toml::from_str(&(example_base.clone() + "'slot_info'")).unwrap();
+        assert_eq!(config.mode, RelayMode::GetSlotInfoOnly);
+
+        let config: RelayConfig = toml::from_str(&(example_base.clone() + "'fake'")).unwrap();
+        assert_eq!(config.mode, RelayMode::Fake);
     }
 }

--- a/crates/rbuilder/src/primitives/mev_boost.rs
+++ b/crates/rbuilder/src/primitives/mev_boost.rs
@@ -13,10 +13,10 @@ pub type MevBoostRelayID = String;
 pub enum RelayMode {
     /// Submits bids, gets slot info. No extra headers on bidding.
     #[serde(rename = "full")]
+    #[default]
     Full,
     /// Only gets slot info.
     #[serde(rename = "slot_info")]
-    #[default]
     GetSlotInfoOnly,
     /// Submits bids with extra headers. Does not used to get slot info.
     #[serde(rename = "test")]
@@ -52,6 +52,7 @@ pub struct RelayConfig {
     #[serde(default, deserialize_with = "deserialize_env_var")]
     pub api_token_header: Option<String>,
     /// mode defines the need of submit_config/priority
+    #[serde(default)]
     pub mode: RelayMode,
     #[serde(flatten)]
     /// Submit specific info.
@@ -244,5 +245,15 @@ mod test {
 
         let config: RelayConfig = toml::from_str(&(example_base.clone() + "'test'")).unwrap();
         assert_eq!(config.mode, RelayMode::Test);
+    }
+
+    #[test]
+    fn test_deserialize_relay_config_no_mode() {
+        let config = "
+        name = 'relay1'
+        url = 'url'";
+
+        let config: RelayConfig = toml::from_str(config).unwrap();
+        assert_eq!(config.mode, RelayMode::Full);
     }
 }

--- a/crates/rbuilder/src/primitives/mev_boost.rs
+++ b/crates/rbuilder/src/primitives/mev_boost.rs
@@ -107,10 +107,17 @@ pub struct MevBoostRelayBidSubmitter {
     /// Relay accepts optimistic submissions.
     optimistic: bool,
     submission_rate_limiter: Option<Arc<DefaultDirectRateLimiter>>,
+    /// This is not a real relay so we can send blocks to it even if it does not have any validator registered.
+    test_relay: bool,
 }
 
 impl MevBoostRelayBidSubmitter {
-    pub fn new(client: RelayClient, id: String, config: &RelaySubmitConfig) -> Self {
+    pub fn new(
+        client: RelayClient,
+        id: String,
+        config: &RelaySubmitConfig,
+        test_relay: bool,
+    ) -> Self {
         let submission_rate_limiter = config.interval_between_submissions_ms.map(|d| {
             Arc::new(RateLimiter::direct(
                 Quota::with_period(Duration::from_millis(d)).expect("Rate limiter time period"),
@@ -123,7 +130,12 @@ impl MevBoostRelayBidSubmitter {
             use_gzip_for_submit: config.use_gzip_for_submit,
             optimistic: config.optimistic,
             submission_rate_limiter,
+            test_relay,
         }
+    }
+
+    pub fn test_relay(&self) -> bool {
+        self.test_relay
     }
 
     pub fn id(&self) -> &MevBoostRelayID {

--- a/crates/rbuilder/src/primitives/mev_boost.rs
+++ b/crates/rbuilder/src/primitives/mev_boost.rs
@@ -18,7 +18,7 @@ pub enum RelayMode {
     /// Only gets slot info.
     #[serde(rename = "slot_info")]
     GetSlotInfoOnly,
-    /// Submits bids with extra headers. Does not used to get slot info.
+    /// Submits bids with extra headers. Is not used to get slot info.
     #[serde(rename = "test")]
     Test,
 }

--- a/crates/rbuilder/src/primitives/mev_boost.rs
+++ b/crates/rbuilder/src/primitives/mev_boost.rs
@@ -19,8 +19,8 @@ pub enum RelayMode {
     #[default]
     GetSlotInfoOnly,
     /// Submits bids with extra headers. Does not used to get slot info.
-    #[serde(rename = "fake")]
-    Fake,
+    #[serde(rename = "test")]
+    Test,
 }
 
 impl RelayMode {
@@ -28,14 +28,14 @@ impl RelayMode {
         match self {
             RelayMode::Full => true,
             RelayMode::GetSlotInfoOnly => false,
-            RelayMode::Fake => true,
+            RelayMode::Test => true,
         }
     }
     pub fn gets_slot_info(&self) -> bool {
         match self {
             RelayMode::Full => true,
             RelayMode::GetSlotInfoOnly => true,
-            RelayMode::Fake => false,
+            RelayMode::Test => false,
         }
     }
 }
@@ -242,7 +242,7 @@ mod test {
         let config: RelayConfig = toml::from_str(&(example_base.clone() + "'slot_info'")).unwrap();
         assert_eq!(config.mode, RelayMode::GetSlotInfoOnly);
 
-        let config: RelayConfig = toml::from_str(&(example_base.clone() + "'fake'")).unwrap();
-        assert_eq!(config.mode, RelayMode::Fake);
+        let config: RelayConfig = toml::from_str(&(example_base.clone() + "'test'")).unwrap();
+        assert_eq!(config.mode, RelayMode::Test);
     }
 }

--- a/crates/rbuilder/src/validation_api_client.rs
+++ b/crates/rbuilder/src/validation_api_client.rs
@@ -2,7 +2,7 @@ use alloy_json_rpc::{ErrorPayload, RpcError};
 use std::{fmt::Debug, sync::Arc};
 
 use crate::{
-    mev_boost::SubmitBlockRequest,
+    mev_boost::submission::SubmitBlockRequest,
     telemetry::add_block_validation_time,
     utils::{http_provider, BoxedProvider},
 };


### PR DESCRIPTION
## 📝 Summary

The role of MevBoostRelay is now fulfilled by MevBoostRelayBidSubmitter or MevBoostRelaySlotInfoProvider.
This allows the use of some relays only to get slot info and others to bid.

## 💡 Motivation and Context

This will allow some new testing mode using a new relay mode "fake".
The fake relay will receive bids but does not implement any validation registration info.

---

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
