### PR TITLE
Typo fix README.md

### DIFF
--- a/crates/eth-sparse-mpt/README.md
+++ b/crates/eth-sparse-mpt/README.md
@@ -11,7 +11,7 @@ To use this, for each parent block:
 * machine with 64 cores, Samsung 980Pro SSD
 
 We calculate root hash of some specific blocks in a loop using the same changes.
-This implemenation caches only disk access, all storage and main trie hashes are calculated fully on each iteration.
+This implementation caches only disk access, all storage and main trie hashes are calculated fully on each iteration.
 
 ```
 reth parallel root hash:


### PR DESCRIPTION
# Fix Typo in README.md

## Description
This pull request fixes a typo in the `README.md` file within the `eth-sparse-mpt` crate. It improves the clarity and professionalism of the documentation.

### Details of the Fix
- Corrected **"implemenation"** to **"implementation"** in the description of how the trie hashes are calculated.

## Why This Change?
Accurate and well-written documentation is critical for developers to understand and trust the project. Fixing typos contributes to the overall quality and credibility of the repository.

## Checklist
- [x] Corrected the typo in the `README.md`.
- [x] Verified that no additional context or meaning was altered during the edit.
- [x] Ready for review and merge.

---

Thank you for reviewing this change. Please let me know if there are any other improvements you’d like to see!
