### PR TITLE
Add op-rbuilder metrics

### DIFF
--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -90,6 +90,8 @@ where
         ctx.task_executor()
             .spawn_critical("custom payload builder service", Box::pin(payload_service));
 
+        tracing::info!("Custom payload service started");
+
         Ok(payload_builder)
     }
 }
@@ -114,6 +116,11 @@ fn main() {
                 .with_add_ons(op_node.add_ons())
                 .install_exex("monitoring", move |ctx| {
                     let builder_signer = builder_args.builder_signer;
+                    if let Some(signer) = &builder_signer {
+                        tracing::info!("Builder signer address is set to: {:?}", signer.address);
+                    } else {
+                        tracing::info!("Builder signer is not set");
+                    }
                     async move { Ok(Monitoring::new(ctx, builder_signer).start()) }
                 })
                 .launch_with_fn(|builder| {

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -1,25 +1,61 @@
-use reth_metrics::{metrics::Gauge, Metrics};
+use reth_metrics::{metrics::Counter, metrics::Gauge, metrics::Histogram, Metrics};
 
 /// op-rbuilder metrics
-#[derive(Metrics)]
+#[derive(Metrics, Clone)]
 #[metrics(scope = "op_rbuilder")]
 pub struct OpRBuilderMetrics {
-    /// Number of builder built blocks
-    pub builder_built_blocks: Gauge,
+    /// Number of builder landed blocks
+    pub builder_landed_blocks: Gauge,
     /// Last built block height
-    pub last_built_block_height: Gauge,
+    pub last_landed_block_height: Gauge,
+    /// Number of blocks the builder did not land
+    pub builder_landed_blocks_missed: Gauge,
+    /// Block built success
+    pub block_built_success: Counter,
+    /// Total duration of building a block
+    pub total_block_built_duration: Histogram,
+    /// Duration of fetching transactions from the pool
+    pub transaction_pool_fetch_duration: Histogram,
+    /// Duration of state root calculation
+    pub state_root_calculation_duration: Histogram,
+    /// Duration of sequencer transaction execution
+    pub sequencer_tx_duration: Histogram,
+    /// Duration of state merge transitions
+    pub state_transition_merge_duration: Histogram,
+    /// Duration of payload simulation of all transactions
+    pub payload_tx_simulation_duration: Histogram,
+    /// Number of transaction considered for inclusion in the block
+    pub payload_num_tx_considered: Histogram,
+    /// Payload byte size
+    pub payload_byte_size: Histogram,
+    /// Number of transactions in the payload
+    pub payload_num_tx: Histogram,
+    /// Number of transactions in the payload that were successfully simulated
+    pub payload_num_tx_simulated: Histogram,
+    /// Number of transactions in the payload that were successfully simulated
+    pub payload_num_tx_simulated_success: Histogram,
+    /// Number of transactions in the payload that failed simulation
+    pub payload_num_tx_simulated_fail: Histogram,
+    /// Duration of tx simulation
+    pub tx_simulation_duration: Histogram,
+    /// Byte size of transactions
+    pub tx_byte_size: Histogram,
 }
 
 impl OpRBuilderMetrics {
-    pub fn inc_builder_built_blocks(&self) {
-        self.builder_built_blocks.increment(1);
+    pub fn inc_builder_landed_blocks(&self) {
+        self.builder_landed_blocks.increment(1);
     }
 
-    pub fn dec_builder_built_blocks(&self) {
-        self.builder_built_blocks.decrement(1);
+    pub fn dec_builder_landed_blocks(&self) {
+        self.builder_landed_blocks.decrement(1);
     }
 
-    pub fn set_last_built_block_height(&self, height: u64) {
-        self.last_built_block_height.set(height as f64);
+    pub fn inc_builder_landed_blocks_missed(&self) {
+        self.builder_landed_blocks_missed.increment(1);
+    }
+
+    pub fn set_last_landed_block_height(&self, height: u64) {
+        self.last_landed_block_height.set(height as f64);
     }
 }


### PR DESCRIPTION
## 📝 Summary

Adds variety of metrics to op-rbuilder around the block building process.

## 💡 Motivation and Context

Adding observability and metrics for op-rbuilder.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
