### PR TITLE
New type BiddableUnfinishedBlock to avoid checking TBV of blocks built

### DIFF
--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -10,7 +10,9 @@ use rbuilder::{
     beacon_api_client::Client,
     building::{
         builders::{
-            block_building_helper::{BlockBuildingHelper, BlockBuildingHelperFromProvider},
+            block_building_helper::{
+                BiddableUnfinishedBlock, BlockBuildingHelper, BlockBuildingHelperFromProvider,
+            },
             BlockBuildingAlgorithm, BlockBuildingAlgorithmInput, OrderConsumer,
             UnfinishedBlockBuildingSink, UnfinishedBlockBuildingSinkFactory,
         },
@@ -142,9 +144,9 @@ impl UnfinishedBlockBuildingSinkFactory for TraceBlockSinkFactory {
 struct TracingBlockSink {}
 
 impl UnfinishedBlockBuildingSink for TracingBlockSink {
-    fn new_block(&self, block: Box<dyn BlockBuildingHelper>) {
+    fn new_block(&self, block: BiddableUnfinishedBlock) {
         info!(
-            order_count =? block.built_block_trace().included_orders.len(),
+            order_count =? block.block().built_block_trace().included_orders.len(),
             "Block generated. Throwing it away!"
         );
     }
@@ -234,7 +236,9 @@ where
             let block = self
                 .build_block(orders, input.provider, &input.ctx)
                 .unwrap();
-            input.sink.new_block(block);
+            if let Ok(block) = BiddableUnfinishedBlock::new(block) {
+                input.sink.new_block(block);
+            }
         }
     }
 }

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -79,6 +79,39 @@ pub trait BlockBuildingHelper: Send + Sync {
     fn builder_name(&self) -> &str;
 }
 
+/// Wraps a BlockBuildingHelper with a valid true_block_value which makes it ready to bid.
+pub struct BiddableUnfinishedBlock {
+    block: Box<dyn BlockBuildingHelper>,
+    true_block_value: U256,
+}
+
+impl BiddableUnfinishedBlock {
+    pub fn new(block: Box<dyn BlockBuildingHelper>) -> Result<Self, BlockBuildingHelperError> {
+        let true_block_value = block.true_block_value()?;
+        Ok(Self {
+            block,
+            true_block_value,
+        })
+    }
+
+    pub fn true_block_value(&self) -> U256 {
+        self.true_block_value
+    }
+
+    /// returns not mutable ref to ensure true_block_value does not change.
+    pub fn block(&self) -> &dyn BlockBuildingHelper {
+        self.block.as_ref()
+    }
+
+    pub fn can_add_payout_tx(&self) -> bool {
+        self.block.can_add_payout_tx()
+    }
+
+    pub fn into_building_helper(self) -> Box<dyn BlockBuildingHelper> {
+        self.block
+    }
+}
+
 /// Implementation of BlockBuildingHelper based on a generic Provider
 #[derive(Clone)]
 pub struct BlockBuildingHelperFromProvider<P>

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 use ahash::HashSet;
 use alloy_eips::eip4844::BlobTransactionSidecar;
 use alloy_primitives::{Address, Bytes, B256};
-use block_building_helper::BlockBuildingHelper;
+use block_building_helper::BiddableUnfinishedBlock;
 use reth::{primitives::SealedBlock, revm::cached::CachedReads};
 use reth_errors::ProviderError;
 use std::{fmt::Debug, sync::Arc};
@@ -190,7 +190,7 @@ where
 
 /// Output of the BlockBuildingAlgorithm.
 pub trait UnfinishedBlockBuildingSink: std::fmt::Debug + Send + Sync {
-    fn new_block(&self, block: Box<dyn BlockBuildingHelper>);
+    fn new_block(&self, block: BiddableUnfinishedBlock);
 
     /// The sink may not like blocks where coinbase is the final fee_recipient (eg: this does not allows us to take profit!).
     /// Not sure this is the right place for this func. Might move somewhere else.

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -24,8 +24,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info_span, trace};
 
 use super::{
-    block_building_helper::BlockBuildingHelperFromProvider, handle_building_error,
-    BacktestSimulateBlockInput, Block, BlockBuildingAlgorithm, BlockBuildingAlgorithmInput,
+    block_building_helper::{BiddableUnfinishedBlock, BlockBuildingHelperFromProvider},
+    handle_building_error, BacktestSimulateBlockInput, Block, BlockBuildingAlgorithm,
+    BlockBuildingAlgorithmInput,
 };
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -105,7 +106,9 @@ where
                 if block.built_block_trace().got_no_signer_error {
                     use_suggested_fee_recipient_as_coinbase = false;
                 }
-                input.sink.new_block(block);
+                if let Ok(block) = BiddableUnfinishedBlock::new(block) {
+                    input.sink.new_block(block);
+                }
             }
             Err(err) => {
                 if !handle_building_error(err) {

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -13,7 +13,9 @@ use tracing::{info_span, trace};
 use crate::{
     building::{
         builders::{
-            block_building_helper::{BlockBuildingHelper, BlockBuildingHelperFromProvider},
+            block_building_helper::{
+                BiddableUnfinishedBlock, BlockBuildingHelper, BlockBuildingHelperFromProvider,
+            },
             handle_building_error, UnfinishedBlockBuildingSink,
         },
         BlockBuildingContext,
@@ -150,7 +152,9 @@ where
                     }
 
                     if let Some(sink) = &self.sink {
-                        sink.new_block(new_block);
+                        if let Ok(new_block) = BiddableUnfinishedBlock::new(new_block) {
+                            sink.new_block(new_block);
+                        }
                     }
                 }
             }

--- a/crates/rbuilder/src/live_builder/block_output/bidding/interfaces.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding/interfaces.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
 use crate::{
-    building::builders::{block_building_helper::BlockBuildingHelper, UnfinishedBlockBuildingSink},
+    building::builders::{
+        block_building_helper::{BiddableUnfinishedBlock, BlockBuildingHelper},
+        UnfinishedBlockBuildingSink,
+    },
     live_builder::block_output::bid_value_source::interfaces::BidValueObs,
 };
 use alloy_primitives::{BlockNumber, U256};
@@ -19,7 +22,7 @@ pub trait SlotBidder: UnfinishedBlockBuildingSink + BidValueObs {}
 /// Bid we want to make.
 pub struct Bid {
     /// Block we should seal with payout tx of payout_tx_value.
-    block: Box<dyn BlockBuildingHelper>,
+    block: BiddableUnfinishedBlock,
     /// payout_tx_value should be Some <=> block.can_add_payout_tx()
     payout_tx_value: Option<U256>,
 }
@@ -34,7 +37,7 @@ impl std::fmt::Debug for Bid {
 
 impl Bid {
     /// Creates a new Bid instance.
-    pub fn new(block: Box<dyn BlockBuildingHelper>, payout_tx_value: Option<U256>) -> Self {
+    pub fn new(block: BiddableUnfinishedBlock, payout_tx_value: Option<U256>) -> Self {
         Self {
             block,
             payout_tx_value,
@@ -42,7 +45,7 @@ impl Bid {
     }
 
     pub fn block(self) -> Box<dyn BlockBuildingHelper> {
-        self.block
+        self.block.into_building_helper()
     }
 
     /// Returns the payout transaction value.

--- a/crates/rbuilder/src/live_builder/block_output/bidding/true_block_value_bidder.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding/true_block_value_bidder.rs
@@ -2,7 +2,9 @@ use super::interfaces::{
     Bid, BidMaker, BiddingService, BiddingServiceWinControl, LandedBlockInfo, SlotBidder,
 };
 use crate::{
-    building::builders::{block_building_helper::BlockBuildingHelper, UnfinishedBlockBuildingSink},
+    building::builders::{
+        block_building_helper::BiddableUnfinishedBlock, UnfinishedBlockBuildingSink,
+    },
     live_builder::block_output::bid_value_source::interfaces::BidValueObs,
 };
 use alloy_primitives::U256;
@@ -56,12 +58,9 @@ struct TrueBlockValueBidder {
 impl SlotBidder for TrueBlockValueBidder {}
 
 impl UnfinishedBlockBuildingSink for TrueBlockValueBidder {
-    fn new_block(&self, block: Box<dyn BlockBuildingHelper>) {
+    fn new_block(&self, block: BiddableUnfinishedBlock) {
         let payout_tx_value = if block.can_add_payout_tx() {
-            match block.true_block_value() {
-                Ok(tbv) => Some(tbv),
-                Err(_) => return,
-            }
+            Some(block.true_block_value())
         } else {
             None
         };

--- a/crates/rbuilder/src/live_builder/block_output/block_sealing_bidder_factory.rs
+++ b/crates/rbuilder/src/live_builder/block_output/block_sealing_bidder_factory.rs
@@ -1,5 +1,8 @@
 use crate::{
-    building::builders::{UnfinishedBlockBuildingSink, UnfinishedBlockBuildingSinkFactory},
+    building::builders::{
+        block_building_helper::BiddableUnfinishedBlock, UnfinishedBlockBuildingSink,
+        UnfinishedBlockBuildingSinkFactory,
+    },
     live_builder::payload_events::MevBoostSlotData,
     provider::StateProviderFactory,
 };
@@ -175,10 +178,7 @@ impl BlockSealingBidder {
 }
 
 impl UnfinishedBlockBuildingSink for BlockSealingBidder {
-    fn new_block(
-        &self,
-        block: Box<dyn crate::building::builders::block_building_helper::BlockBuildingHelper>,
-    ) {
+    fn new_block(&self, block: BiddableUnfinishedBlock) {
         self.bidder.new_block(block);
     }
 


### PR DESCRIPTION
## 📝 Summary

In some replaced I replaced Box<dyn BlockBuildingHelper> for BiddableUnfinishedBlock since BlockBuildingHelper is in the process of being built and might not have a good TBV.
By using BiddableUnfinishedBlock we model that the block is ready so it always has a true_block_value.

## 💡 Motivation and Context

Removes annoying tests for Some(true_block_value) where we know it should be always Some.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
