### PR TITLE
Rename payload generator

### DIFF
--- a/crates/op-rbuilder/src/generator.rs
+++ b/crates/op-rbuilder/src/generator.rs
@@ -53,7 +53,7 @@ pub trait PayloadBuilder<Pool, Client>: Send + Sync + Clone {
 
 /// The generator type that creates new jobs that builds empty blocks.
 #[derive(Debug)]
-pub struct EmptyBlockPayloadJobGenerator<Client, Pool, Tasks, Builder> {
+pub struct BlockPayloadJobGenerator<Client, Pool, Tasks, Builder> {
     /// The client that can interact with the chain.
     client: Client,
     /// txpool
@@ -70,7 +70,7 @@ pub struct EmptyBlockPayloadJobGenerator<Client, Pool, Tasks, Builder> {
 
 // === impl EmptyBlockPayloadJobGenerator ===
 
-impl<Client, Pool, Tasks, Builder> EmptyBlockPayloadJobGenerator<Client, Pool, Tasks, Builder> {
+impl<Client, Pool, Tasks, Builder> BlockPayloadJobGenerator<Client, Pool, Tasks, Builder> {
     /// Creates a new [EmptyBlockPayloadJobGenerator] with the given config and custom
     /// [PayloadBuilder]
     pub fn with_builder(
@@ -91,7 +91,7 @@ impl<Client, Pool, Tasks, Builder> EmptyBlockPayloadJobGenerator<Client, Pool, T
 }
 
 impl<Client, Pool, Tasks, Builder> PayloadJobGenerator
-    for EmptyBlockPayloadJobGenerator<Client, Pool, Tasks, Builder>
+    for BlockPayloadJobGenerator<Client, Pool, Tasks, Builder>
 where
     Client: StateProviderFactory
         + BlockReaderIdExt<Header = alloy_consensus::Header>

--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use generator::EmptyBlockPayloadJobGenerator;
+use generator::BlockPayloadJobGenerator;
 use monitoring::Monitoring;
 use payload_builder::OpPayloadBuilder as FBPayloadBuilder;
 use payload_builder_vanilla::OpPayloadBuilderVanilla;
@@ -75,7 +75,7 @@ where
         );
         let payload_job_config = BasicPayloadJobGeneratorConfig::default();
 
-        let payload_generator = EmptyBlockPayloadJobGenerator::with_builder(
+        let payload_generator = BlockPayloadJobGenerator::with_builder(
             ctx.provider().clone(),
             pool,
             ctx.task_executor().clone(),


### PR DESCRIPTION
## 📝 Summary

This PR renames the `EmptyBlockPayloadJobGenerator` generator.