### PR TITLE
Add deposit command for op-rbuilder tester

### DIFF
--- a/crates/op-rbuilder/src/lib.rs
+++ b/crates/op-rbuilder/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod integration;
 pub mod tester;
+pub mod tx_signer;

--- a/crates/op-rbuilder/src/tester/main.rs
+++ b/crates/op-rbuilder/src/tester/main.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::Address;
 use clap::Parser;
 use op_rbuilder::tester::*;
 
@@ -24,6 +25,13 @@ enum Commands {
         #[clap(long, short, action, default_value = "false")]
         no_tx_pool: bool,
     },
+    /// Deposit funds to the system
+    Deposit {
+        #[clap(long, help = "Address to deposit funds to")]
+        address: Address,
+        #[clap(long, help = "Amount to deposit")]
+        amount: u128,
+    },
 }
 
 #[tokio::main]
@@ -36,5 +44,15 @@ async fn main() -> eyre::Result<()> {
             validation,
             no_tx_pool,
         } => run_system(validation, no_tx_pool).await,
+        Commands::Deposit { address, amount } => {
+            let engine_api = EngineApi::builder().build().unwrap();
+            let mut generator = BlockGenerator::new(&engine_api, None, false);
+
+            generator.init().await?;
+
+            let block_hash = generator.deposit(address, amount).await?;
+            println!("Deposit transaction included in block: {}", block_hash);
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new `deposit` command to the op-rbuilder `tester` CLI tool that allows seeding accounts with ETH using deposit transactions.

## Changes
- Added new `Deposit` command to the CLI that takes an address and amount
- Reused existing `BlockGenerator` infrastructure to submit deposit transactions
- Uses default engine API configuration for simplicity

## Usage
To deposit 1 ETH to an account (once the op-rbuilder is running):
```
$ cargo run -- deposit --address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92200 --amount 1000000000000000000
```
