### PR TITLE
Expand integration test for blocklist

### DIFF
--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -394,12 +394,25 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
 
         let mut db = self.state.new_db_ref();
         let tx = &tx_with_blobs.internal_tx_unsecure();
-        if ctx.blocklist.contains(&tx.signer())
-            || tx
-                .to()
-                .map(|to| ctx.blocklist.contains(&to))
-                .unwrap_or(false)
+        // Check if sender is blocklisted
+        if ctx.blocklist.contains(&tx.signer()) {
+            tracing::debug!(
+                "Transaction rejected - sender {} is blocklisted",
+                tx.signer()
+            );
+            return Ok(Err(TransactionErr::Blocklist));
+        }
+
+        // Check if recipient is blocklisted
+        if tx
+            .to()
+            .map(|to| ctx.blocklist.contains(&to))
+            .unwrap_or(false)
         {
+            tracing::debug!(
+                "Transaction rejected - recipient {} is blocklisted",
+                tx.to().unwrap()
+            );
             return Ok(Err(TransactionErr::Blocklist));
         }
 

--- a/crates/rbuilder/src/integration/playground.rs
+++ b/crates/rbuilder/src/integration/playground.rs
@@ -32,6 +32,7 @@ pub enum PlaygroundError {
 
 pub struct Playground {
     builder: Child,
+    log_path: PathBuf,
 }
 
 fn open_log_file(path: PathBuf) -> io::Result<File> {
@@ -48,8 +49,8 @@ impl Playground {
         bin_path.push("../../target/debug/rbuilder");
 
         // Use the config file from the root directory
-        let config_path =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../config-playground.toml");
+        let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("./src/integration/testdata/config.toml");
 
         let dt: OffsetDateTime = SystemTime::now().into();
 
@@ -99,7 +100,7 @@ impl Playground {
             thread::sleep(std::time::Duration::from_millis(100));
         }
 
-        Ok(Self { builder })
+        Ok(Self { builder, log_path })
     }
 
     pub async fn wait_for_next_slot(
@@ -119,6 +120,19 @@ impl Playground {
 
     pub fn el_url(&self) -> &str {
         "http://localhost:8545"
+    }
+
+    pub fn blocklist_key(&self) -> EthereumWallet {
+        // Address: 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC
+        let signer: PrivateKeySigner =
+            "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+                .parse()
+                .unwrap();
+        EthereumWallet::from(signer)
+    }
+
+    pub fn blocklist_address(&self) -> Address {
+        address!("3C44CdDdB6a900fa2b585dd299e03d12FA4293BC")
     }
 
     pub fn prefunded_key(&self) -> EthereumWallet {
@@ -159,6 +173,15 @@ impl Playground {
         } else {
             Err(PayloadDeliveredError::IncorrectBuilder)
         }
+    }
+
+    pub fn check_logs_contain(&self, pattern: &str) -> Result<bool, PlaygroundError> {
+        let mut file = File::open(&self.log_path).map_err(|_| PlaygroundError::SetupError)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .map_err(|_| PlaygroundError::SetupError)?;
+
+        Ok(contents.contains(pattern))
     }
 }
 

--- a/crates/rbuilder/src/integration/simple.rs
+++ b/crates/rbuilder/src/integration/simple.rs
@@ -10,46 +10,110 @@ mod tests {
     use test_utils::ignore_if_env_not_set;
     use url::Url;
 
-    #[ignore_if_env_not_set("PLAYGROUND")] // TODO: Change with a custom macro (i.e ignore_if_not_playground)
-    #[tokio::test]
-    async fn test_simple_example() {
-        // This test sends a transaction ONLY to the builder and waits for the block to be built with it.
-        let srv = Playground::new().unwrap();
-        srv.wait_for_next_slot().await.unwrap();
+    async fn send_transaction(
+        srv: &Playground,
+        private_key: alloy_network::EthereumWallet,
+        to: Option<alloy_primitives::Address>,
+    ) -> eyre::Result<alloy_primitives::TxHash> {
+        let rbuilder_provider =
+            ProviderBuilder::new().on_http(Url::parse(srv.rbuilder_rpc_url()).unwrap());
 
-        // send a transfer to the builder
         let provider = ProviderBuilder::new()
             .with_recommended_fillers()
-            .wallet(srv.prefunded_key())
+            .wallet(private_key)
             .on_http(Url::parse(srv.el_url()).unwrap());
 
-        let gas_price = provider.get_gas_price().await.unwrap();
+        let gas_price = provider.get_gas_price().await?;
 
         let tx = TransactionRequest::default()
-            .with_to(srv.builder_address())
+            .with_to(to.unwrap_or(srv.builder_address()))
             .with_value(U256::from_str("10000000000000000000").unwrap())
             .with_gas_price(gas_price)
             .with_gas_limit(21000);
 
-        let tx = provider.fill(tx).await.unwrap();
+        let tx = provider.fill(tx).await?;
 
         // send the transaction ONLY to the builder
-        let rbuilder_provider =
-            ProviderBuilder::new().on_http(Url::parse(srv.rbuilder_rpc_url()).unwrap());
         let pending_tx = rbuilder_provider
             .send_tx_envelope(tx.as_envelope().unwrap().clone())
+            .await?;
+
+        Ok(*pending_tx.tx_hash())
+    }
+
+    // #[ignore_if_env_not_set("PLAYGROUND")] // TODO: Change with a custom macro (i.e ignore_if_not_playground)
+    #[tokio::test]
+    async fn test_simple_example() {
+        let srv = Playground::new().unwrap();
+        srv.wait_for_next_slot().await.unwrap();
+
+        // Send transaction using the helper function
+        let tx_hash = send_transaction(&srv, srv.prefunded_key(), None)
             .await
             .unwrap();
 
-        // wait for the transaction in the el node since rbuilder does not implement
-        // the `eth_getTransactionReceipt` method.
+        // Wait for receipt
         let binding = ProviderBuilder::new().on_http(Url::parse(srv.el_url()).unwrap());
-        let pending_tx = PendingTransactionBuilder::new(binding, *pending_tx.tx_hash())
+        let pending_tx = PendingTransactionBuilder::new(binding.clone(), tx_hash)
             .with_timeout(Some(std::time::Duration::from_secs(60)));
 
         let receipt = pending_tx.get_receipt().await.unwrap();
         srv.validate_block_built(receipt.block_number.unwrap())
             .await
             .unwrap();
+
+        // Send a transaction with an account from the blocklist
+        // TODO: This should be a separated test but the integration framework does use fixed port numbers
+        // and we need to change it to use dynamic ports.
+        // Since we only send the transaction to the builder, it should never be included in the block.
+        {
+            srv.wait_for_next_slot().await.unwrap();
+            let tx_hash = send_transaction(&srv, srv.blocklist_key(), None)
+                .await
+                .unwrap();
+
+            // wait for 20 seconds
+            let pending_tx = PendingTransactionBuilder::new(binding.clone(), tx_hash)
+                .with_timeout(Some(std::time::Duration::from_secs(20)));
+
+            assert!(
+                pending_tx.get_receipt().await.is_err(),
+                "Expected transaction to fail since account is blocklisted"
+            );
+
+            assert!(
+                srv.check_logs_contain(
+                    "Transaction rejected - sender 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC is blocklisted"
+                )
+                .unwrap(),
+                "Expected log not found"
+            );
+        }
+
+        // Second blocklist test, send a transaction from a non-blocklisted account to a blocklisted account
+        {
+            srv.wait_for_next_slot().await.unwrap();
+            let tx_hash =
+                send_transaction(&srv, srv.prefunded_key(), Some(srv.blocklist_address()))
+                    .await
+                    .unwrap();
+
+            // wait for 20 seconds
+            let pending_tx = PendingTransactionBuilder::new(binding, tx_hash)
+                .with_timeout(Some(std::time::Duration::from_secs(20)));
+
+            assert!(
+                pending_tx.get_receipt().await.is_err(),
+                "Expected transaction to fail since account is blocklisted"
+            );
+
+            assert!(
+            srv.check_logs_contain(
+                "Transaction rejected - recipient 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC is blocklisted"
+            )
+            .unwrap(),
+            "Expected log not found"
+        );
+        }
     }
 }

--- a/crates/rbuilder/src/integration/simple.rs
+++ b/crates/rbuilder/src/integration/simple.rs
@@ -41,7 +41,7 @@ mod tests {
         Ok(*pending_tx.tx_hash())
     }
 
-    // #[ignore_if_env_not_set("PLAYGROUND")] // TODO: Change with a custom macro (i.e ignore_if_not_playground)
+    #[ignore_if_env_not_set("PLAYGROUND")] // TODO: Change with a custom macro (i.e ignore_if_not_playground)
     #[tokio::test]
     async fn test_simple_example() {
         let srv = Playground::new().unwrap();

--- a/crates/rbuilder/src/integration/testdata/blocklist.json
+++ b/crates/rbuilder/src/integration/testdata/blocklist.json
@@ -1,0 +1,3 @@
+[
+    "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+]

--- a/crates/rbuilder/src/integration/testdata/config.toml
+++ b/crates/rbuilder/src/integration/testdata/config.toml
@@ -1,0 +1,10 @@
+
+chain = "$HOME/.playground/devnet/genesis.json"
+reth_datadir = "$HOME/.playground/devnet/data_reth"
+relay_secret_key = "5eae315483f028b5cdd5d1090ff0c7618b18737ea9bf3c35047189db22835c48"
+el_node_ipc_path = "$HOME/.playground/devnet/reth.ipc"
+live_builders = ["mgp-ordering"]
+enabled_relays = ["playground"]
+log_level = "debug,rbuilder=debug"
+coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+blocklist_file_path = "./src/integration/testdata/blocklist.json"


### PR DESCRIPTION
This PR expands the integration test to cover blocklist functionality end-to-end. The test sends transactions from and to blocklisted accounts to verify the blocklist works as expected. All scenarios are tested within the same test function since the integration framework doesn't currently support concurrent test execution (this should be fixed in the future but requires deeper architectural changes).

Added debug logging when transactions are rejected due to blocklist, allowing the test to verify correct behavior by checking log output.