### PR TITLE
Dynamic load of blocklist from url

### DIFF
--- a/crates/rbuilder/src/backtest/backtest_build_range.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_range.rs
@@ -133,7 +133,11 @@ where
         None
     };
 
-    let blocklist = config.base_config().blocklist()?;
+    let blocklist = config
+        .base_config()
+        .blocklist_provider(false, cancel_token.clone())
+        .await?
+        .get_blocklist()?;
 
     let mut read_blocks = spawn_block_fetcher(
         historical_data_storage,

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -21,6 +21,7 @@ use rbuilder::{
             default_ip, DEFAULT_EL_NODE_IPC_PATH, DEFAULT_INCOMING_BUNDLES_PORT,
             DEFAULT_RETH_DB_PATH,
         },
+        block_list_provider::NullBlockListProvider,
         config::create_provider_factory,
         order_input::{
             OrderInputConfig, DEFAULT_INPUT_CHANNEL_BUFFER_SIZE, DEFAULT_RESULTS_CHANNEL_TIMEOUT,
@@ -62,11 +63,11 @@ async fn main() -> eyre::Result<()> {
     let flashbots_relay_url = "https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net";
     let relay_client = RelayClient::from_url(flashbots_relay_url.parse()?, None, None, None);
     let relay = MevBoostRelaySlotInfoProvider::new(relay_client, "flashbots".to_string(), 0);
-
+    let blocklist_provider = Arc::new(NullBlockListProvider {});
     let payload_event = MevBoostSlotDataGenerator::new(
         vec![Client::default()],
         vec![relay],
-        Default::default(),
+        blocklist_provider.clone(),
         cancel.clone(),
     );
 
@@ -101,7 +102,7 @@ async fn main() -> eyre::Result<()> {
         )?,
         coinbase_signer: Signer::random(),
         extra_data: Vec::new(),
-        blocklist: Default::default(),
+        blocklist_provider,
         global_cancellation: cancel.clone(),
         extra_rpc: RpcModule::new(()),
         sink_factory: Box::new(TraceBlockSinkFactory {}),

--- a/crates/rbuilder/src/live_builder/block_list_provider.rs
+++ b/crates/rbuilder/src/live_builder/block_list_provider.rs
@@ -1,0 +1,193 @@
+use ahash::HashSet;
+use revm_primitives::Address;
+use std::{
+    fs::read_to_string,
+    path::PathBuf,
+    sync::{Arc, Mutex, MutexGuard},
+    time::Duration,
+};
+use time::OffsetDateTime;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+use url::Url;
+
+pub type BlockList = HashSet<Address>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Unable to load initial list")]
+    UnableToLoadInitialList,
+    #[error("Unable to update list")]
+    UnableToUpdateList,
+}
+
+const MIN_ITEMS_ON_BLOCK_LIST: usize = 1;
+
+/// Basic validation on a block list.
+/// Returns if the list looks good.
+fn validate_list(blocklist: &[Address]) -> bool {
+    blocklist.len() >= MIN_ITEMS_ON_BLOCK_LIST
+}
+
+/// Abstraction to get and update the builder's blocklist.
+pub trait BlockListProvider: std::fmt::Debug + Sync + Send {
+    /// Gets the a copy of the last list. Fails if it's too old.
+    fn get_blocklist(&self) -> Result<BlockList, Error>;
+    /// Checks a single address in the current list. Fails if it's too old.
+    fn current_list_contains(&self, address: &Address) -> Result<bool, Error>;
+}
+
+/// BlockListProvider that always returns Ok(empty list)
+#[derive(Debug)]
+pub struct NullBlockListProvider {}
+
+impl BlockListProvider for NullBlockListProvider {
+    fn get_blocklist(&self) -> Result<BlockList, Error> {
+        Ok(BlockList::default())
+    }
+
+    fn current_list_contains(&self, _address: &Address) -> Result<bool, Error> {
+        Ok(false)
+    }
+}
+
+#[derive(Debug)]
+struct BlockListWithTimestamp {
+    pub block_list: BlockList,
+    pub timestamp: OffsetDateTime,
+}
+
+impl BlockListWithTimestamp {
+    fn new(block_list: BlockList) -> Self {
+        Self {
+            block_list,
+            timestamp: OffsetDateTime::now_utc(),
+        }
+    }
+}
+
+const TIMES_TO_UPDATE_PER_MAX_AGE: f32 = 10.0;
+/// BlockListProvider that downloads the list from a url and tries to keep it up to date.
+/// If it fails to update on time it gives an error.
+#[derive(Debug)]
+pub struct HttpBlockListProvider {
+    max_allowed_age: Duration,
+    last_updated_list: Arc<Mutex<BlockListWithTimestamp>>,
+}
+
+impl HttpBlockListProvider {
+    /// Downloads the file and creates a task to update it periodically.
+    pub async fn new(
+        url: Url,
+        max_allowed_age: Duration,
+        validate_list: bool,
+        cancellation: CancellationToken,
+    ) -> Result<Self, Error> {
+        let list = Self::read_list(url.clone(), validate_list)
+            .await
+            .map_err(|_| Error::UnableToLoadInitialList)?;
+
+        let last_updated_list = Arc::new(Mutex::new(BlockListWithTimestamp::new(list)));
+        let last_updated_list_clone = last_updated_list.clone();
+        // Spawn a task that continuously reloads the list
+        tokio::spawn(async move {
+            let period = max_allowed_age.div_f32(TIMES_TO_UPDATE_PER_MAX_AGE);
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(period)=> {
+                        // mini bug, we ignore the cancellation while downloading the file.
+                        if let Ok(list) = Self::read_list(url.clone(),validate_list).await {
+                            let list_len = list.len();
+                            *last_updated_list.lock().unwrap() = BlockListWithTimestamp::new(list);
+                            info!(list_len,"Blocklist updated");
+                        }
+                    },
+                    _ = cancellation.cancelled() =>{
+                        return;
+                    }
+                }
+            }
+        });
+
+        Ok(Self {
+            max_allowed_age,
+            last_updated_list: last_updated_list_clone,
+        })
+    }
+
+    /// lousy error handling since we don't use it much.
+    async fn read_list(
+        url: Url,
+        should_validate_list: bool,
+    ) -> Result<BlockList, Box<dyn std::error::Error>> {
+        let res = {
+            let response = reqwest::get(url.clone()).await?;
+            let blocklist = response.bytes().await?;
+            let blocklist = String::from_utf8_lossy(&blocklist);
+            let blocklist: Vec<Address> = serde_json::from_str(&blocklist)?;
+            if !should_validate_list || validate_list(&blocklist) {
+                Ok(blocklist.into_iter().collect())
+            } else {
+                Err("Invalid list".into())
+            }
+        };
+        if let Err(err) = &res {
+            error!(err=?err,url=?url,"Error reading blocklist");
+        }
+        res
+    }
+
+    fn lock_current_list(&self) -> Result<MutexGuard<'_, BlockListWithTimestamp>, Error> {
+        let last_updated_list = self.last_updated_list.lock().unwrap();
+        if OffsetDateTime::now_utc() - last_updated_list.timestamp > self.max_allowed_age {
+            return Err(Error::UnableToUpdateList);
+        }
+        Ok(last_updated_list)
+    }
+}
+
+impl BlockListProvider for HttpBlockListProvider {
+    /// Just gets the last version and checks the age.
+    fn get_blocklist(&self) -> Result<BlockList, Error> {
+        let last_updated_list = self.lock_current_list()?;
+        Ok(last_updated_list.block_list.clone())
+    }
+
+    fn current_list_contains(&self, address: &Address) -> Result<bool, Error> {
+        let last_updated_list = self.lock_current_list()?;
+        Ok(last_updated_list.block_list.contains(address))
+    }
+}
+
+/// BlockListProvider that opens a file. Useful for backtesting and static scenarios.
+/// Can only fail on creation.
+/// @Pending upgrade the HttpBlockListProvider to allow to plugin the reader and have a generic updatable source for http/file
+#[derive(Debug)]
+pub struct StaticFileBlockListProvider {
+    block_list: Mutex<BlockList>,
+}
+
+impl StaticFileBlockListProvider {
+    pub fn new(path: &PathBuf, should_validate_list: bool) -> Result<Self, Error> {
+        let blocklist_file = read_to_string(path).map_err(|_| Error::UnableToLoadInitialList)?;
+        let blocklist: Vec<Address> =
+            serde_json::from_str(&blocklist_file).map_err(|_| Error::UnableToLoadInitialList)?;
+        if should_validate_list && !validate_list(&blocklist) {
+            return Err(Error::UnableToLoadInitialList);
+        }
+        Ok(Self {
+            block_list: Mutex::new(blocklist.into_iter().collect()),
+        })
+    }
+}
+
+impl BlockListProvider for StaticFileBlockListProvider {
+    /// Just gets the last version and checks the age.
+    fn get_blocklist(&self) -> Result<BlockList, Error> {
+        Ok(self.block_list.lock().unwrap().clone())
+    }
+
+    fn current_list_contains(&self, address: &Address) -> Result<bool, Error> {
+        Ok(self.block_list.lock().unwrap().contains(address))
+    }
+}

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -407,10 +407,14 @@ impl LiveBuilderConfig for Config {
             self.l1_config.max_concurrent_seals as usize,
         ));
 
+        let blocklist_provider = self
+            .base_config
+            .blocklist_provider(false, cancellation_token.clone())
+            .await?;
         let payload_event = MevBoostSlotDataGenerator::new(
             self.l1_config.beacon_clients()?,
             relays,
-            self.base_config.blocklist()?,
+            blocklist_provider.clone(),
             cancellation_token.clone(),
         );
         let live_builder = self
@@ -420,6 +424,7 @@ impl LiveBuilderConfig for Config {
                 sink_factory,
                 payload_event,
                 provider,
+                blocklist_provider,
             )
             .await?;
         let builders = create_builders(self.live_builders()?);

--- a/crates/rbuilder/src/utils/constants.rs
+++ b/crates/rbuilder/src/utils/constants.rs
@@ -4,6 +4,9 @@
 
 pub const BASE_TX_GAS: u64 = 21_000;
 
+pub const SECS_PER_MINUTE: u64 = 60;
+pub const MINS_PER_HOUR: u64 = 60;
+
 //////////////////////////////////////////////////
 // Builder constants
 //////////////////////////////////////////////////


### PR DESCRIPTION
## 📝 Summary

Now we have a new config field `blocklist` which can be:
- a file name and behaves as before (loads from the file) 
- a url and downloads the file from the web. It also updates periodically the list. If it can't update and the blocklist get's too old (configurable via `blocklist_url_max_age_hours` (default 24)) it closes the builder.
We still support the old `blocklist_file_path`.

The change involved replacing several blocklists for a new trait BlockListProvider.

## 💡 Motivation and Context

More robustness.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
