### PR TITLE
chore: add `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.83.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

Add `rust-toolchain.toml` to avoid picking up default system toolchain. 

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
