### PR TITLE
New flag require-non-empty-blocklist

### DIFF
--- a/crates/rbuilder/src/backtest/backtest_build_range.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_range.rs
@@ -135,7 +135,7 @@ where
 
     let blocklist = config
         .base_config()
-        .blocklist_provider(false, cancel_token.clone())
+        .blocklist_provider(cancel_token.clone())
         .await?
         .get_blocklist()?;
 

--- a/crates/rbuilder/src/backtest/build_block/landed_block_from_db.rs
+++ b/crates/rbuilder/src/backtest/build_block/landed_block_from_db.rs
@@ -80,7 +80,7 @@ impl<ConfigType: LiveBuilderConfig> LandedBlockFromDBOrdersSource<ConfigType> {
         .await?;
         let blocklist = config
             .base_config()
-            .blocklist_provider(false, CancellationToken::new())
+            .blocklist_provider(CancellationToken::new())
             .await?
             .get_blocklist()?;
 

--- a/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
@@ -59,7 +59,7 @@ where
 
     let blocklist = config
         .base_config()
-        .blocklist_provider(false, CancellationToken::new())
+        .blocklist_provider(CancellationToken::new())
         .await?
         .get_blocklist()?;
 

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -409,7 +409,7 @@ impl LiveBuilderConfig for Config {
 
         let blocklist_provider = self
             .base_config
-            .blocklist_provider(false, cancellation_token.clone())
+            .blocklist_provider(cancellation_token.clone())
             .await?;
         let payload_event = MevBoostSlotDataGenerator::new(
             self.l1_config.beacon_clients()?,


### PR DESCRIPTION
## 📝 Summary

This flag is backwards compatible.
When set true makes use more robust for those looking to enforce a blocklist.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [X] Added tests (if applicable)
