### PR TITLE
Wait for new commands to appear before starting building loop.

### DIFF
--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -187,7 +187,7 @@ impl DummyBuildingAlgorithm {
             if cancel.is_cancelled() {
                 break None;
             }
-            order_consumer.consume_next_commands().unwrap();
+            order_consumer.blocking_consume_next_commands().unwrap();
             order_consumer.apply_new_commands(&mut orders_sink);
             let orders = orders_sink.get_orders();
             if orders.len() >= self.orders_to_use {

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -84,7 +84,7 @@ where
             break 'building;
         }
 
-        match order_intake_consumer.consume_next_batch() {
+        match order_intake_consumer.blocking_consume_next_batch() {
             Ok(ok) => {
                 if !ok {
                     break 'building;

--- a/crates/rbuilder/src/building/builders/parallel_builder/order_intake_store.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/order_intake_store.rs
@@ -26,7 +26,7 @@ impl OrderIntakeStore {
     }
 
     pub fn consume_next_batch(&mut self) -> eyre::Result<bool> {
-        self.order_consumer.consume_next_commands()?;
+        self.order_consumer.blocking_consume_next_commands()?;
         self.order_consumer.apply_new_commands(&mut self.order_sink);
         Ok(true)
     }


### PR DESCRIPTION

## 📝 Summary

Around 80% of the ordering builder runs were run without new order commands.
This adds blocking until the first command is received, practically we wait around avg = 50ms stddev = 170ms before new order command appear if we average over all ordering builder runs.

This makes builder more efficient, makes it use less CPU and improves E2E latency.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
