### PR TITLE
correctly parse eth_sendBundle payload when sent as object

### DIFF
--- a/crates/rbuilder/src/live_builder/order_input/rpc_server.rs
+++ b/crates/rbuilder/src/live_builder/order_input/rpc_server.rs
@@ -46,10 +46,15 @@ pub async fn start_server_accepting_bundles(
     module.register_async_method("eth_sendBundle", move |params, _| {
         let results = results_clone.clone();
         async move {
-	    let received_at = OffsetDateTime::now_utc();
-
+    	    let received_at = OffsetDateTime::now_utc();
             let start = Instant::now();
-            let raw_bundle: RawBundle = match params.one() {
+
+            let params = if params.is_object() {
+                params.parse()
+            } else {
+                params.one()
+            };
+            let raw_bundle: RawBundle = match params {
                 Ok(raw_bundle) => raw_bundle,
                 Err(err) => {
                     warn!(?err, "Failed to parse raw bundle");


### PR DESCRIPTION
## 📝 Summary

parse `eth_sendBundle` params as object if sent as object, otherwise parse as single-element array (prev behavior).

## 💡 Motivation and Context

if params are sent as an object (as is done by [alloy](https://github.com/alloy-rs)), `eth_sendBundle` fails with an "invalid payload" error.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
~~* [ ] Added tests (if applicable)~~
