### PR TITLE
fix: fixed variable name mismatch in for loop

### DIFF
--- a/scripts/ci/criterion-get-changes.py
+++ b/scripts/ci/criterion-get-changes.py
@@ -137,5 +137,5 @@ elif output_format == "html":
     print("</tbody>")
 else:
     print("Benchmark \t Mean \t Status \t Significant")
-    for full_id, url, mean_fmt, ms, is_significant in change_data:
+    for full_id, url, mean_fmt, msg, is_significant in change_data:
         print(f"{full_id} \t {mean_fmt}% \t {msg} \t {is_significant}")


### PR DESCRIPTION
## 📝 Summary
Fixed the variable name mismatch between the `for` loop and the `print` statement, where `ms` was used in the loop but `msg` was referenced in the print statement. This led to a `NameError: name 'msg' is not defined`.

## 💡 Motivation and Context
This fix resolves the error caused by the variable name inconsistency, ensuring that the code runs without any issues.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)