### PR TITLE
Validate rbuilder with op-reth

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -165,6 +165,9 @@ jobs:
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
+      - name: Download op-reth
+        run: ./scripts/ci/download-op-reth.sh
+
       - name: Build the rbuilder
         run: cargo build -p op-rbuilder --bin op-rbuilder --features optimism
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -166,7 +166,9 @@ jobs:
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
 
       - name: Download op-reth
-        run: ./scripts/ci/download-op-reth.sh
+        run: |
+          ./scripts/download-op-reth.sh
+          echo "$(pwd)" >> $GITHUB_PATH
 
       - name: Build the rbuilder
         run: cargo build -p op-rbuilder --bin op-rbuilder --features optimism

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Download op-reth
         run: |
-          ./scripts/download-op-reth.sh
+          ./scripts/ci/download-op-reth.sh
           echo "$(pwd)" >> $GITHUB_PATH
 
       - name: Build the rbuilder

--- a/crates/op-rbuilder/src/integration/integration_test.rs
+++ b/crates/op-rbuilder/src/integration/integration_test.rs
@@ -1,6 +1,8 @@
 #[cfg(all(test, feature = "integration"))]
 mod tests {
-    use crate::integration::{op_rbuilder::OpRbuilderConfig, IntegrationFramework};
+    use crate::integration::{
+        op_rbuilder::OpRbuilderConfig, op_reth::OpRethConfig, IntegrationFramework,
+    };
     use crate::tester::{BlockGenerator, EngineApi};
     use std::path::PathBuf;
     use uuid::Uuid;
@@ -16,20 +18,30 @@ mod tests {
         genesis_path.push("../../genesis.json");
         assert!(genesis_path.exists());
 
-        // generate a random dir for the data dir
-        let data_dir = std::env::temp_dir().join(Uuid::new_v4().to_string());
-
-        // generate a rra
-        let reth = OpRbuilderConfig::new()
-            .chain_config_path(genesis_path)
-            .data_dir(data_dir)
+        // create the builder
+        let builder_data_dir = std::env::temp_dir().join(Uuid::new_v4().to_string());
+        let builder = OpRbuilderConfig::new()
+            .chain_config_path(genesis_path.clone())
+            .data_dir(builder_data_dir)
             .auth_rpc_port(1234)
             .network_port(1235);
 
-        framework.start("op-rbuilder", &reth).await.unwrap();
+        framework.start("op-rbuilder", &builder).await.unwrap();
+
+        // create the validation reth node
+        let reth_data_dir = std::env::temp_dir().join(Uuid::new_v4().to_string());
+        let reth = OpRethConfig::new()
+            .chain_config_path(genesis_path)
+            .data_dir(reth_data_dir)
+            .auth_rpc_port(1236)
+            .network_port(1237);
+
+        framework.start("op-reth", &reth).await.unwrap();
 
         let engine_api = EngineApi::new("http://localhost:1234").unwrap();
-        let mut generator = BlockGenerator::new(&engine_api, None, false);
+        let validation_api = EngineApi::new("http://localhost:1236").unwrap();
+
+        let mut generator = BlockGenerator::new(&engine_api, Some(&validation_api), false);
         generator.init().await.unwrap();
 
         for _ in 0..10 {

--- a/crates/op-rbuilder/src/integration/mod.rs
+++ b/crates/op-rbuilder/src/integration/mod.rs
@@ -17,6 +17,7 @@ pub const DEFAULT_JWT_TOKEN: &str =
 
 mod integration_test;
 pub mod op_rbuilder;
+pub mod op_reth;
 
 #[derive(Debug)]
 pub enum IntegrationError {

--- a/crates/op-rbuilder/src/integration/op_reth.rs
+++ b/crates/op-rbuilder/src/integration/op_reth.rs
@@ -1,0 +1,107 @@
+use crate::integration::{poll_logs, IntegrationError, Service, DEFAULT_JWT_TOKEN};
+use futures_util::Future;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
+
+fn get_or_create_jwt_path(jwt_path: Option<&PathBuf>) -> PathBuf {
+    jwt_path.cloned().unwrap_or_else(|| {
+        let tmp_dir = std::env::temp_dir();
+        let jwt_path = tmp_dir.join("jwt.hex");
+        std::fs::write(&jwt_path, DEFAULT_JWT_TOKEN).expect("Failed to write JWT secret file");
+        jwt_path
+    })
+}
+
+#[derive(Default)]
+pub struct OpRethConfig {
+    auth_rpc_port: Option<u16>,
+    jwt_secret_path: Option<PathBuf>,
+    chain_config_path: Option<PathBuf>,
+    data_dir: Option<PathBuf>,
+    http_port: Option<u16>,
+    network_port: Option<u16>,
+}
+
+impl OpRethConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn auth_rpc_port(mut self, port: u16) -> Self {
+        self.auth_rpc_port = Some(port);
+        self
+    }
+
+    pub fn chain_config_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.chain_config_path = Some(path.into());
+        self
+    }
+
+    pub fn data_dir<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.data_dir = Some(path.into());
+        self
+    }
+
+    pub fn network_port(mut self, port: u16) -> Self {
+        self.network_port = Some(port);
+        self
+    }
+}
+
+impl Service for OpRethConfig {
+    fn command(&self) -> Command {
+        let bin_path = PathBuf::from("op-reth");
+
+        let mut cmd = Command::new(bin_path);
+        let jwt_path = get_or_create_jwt_path(self.jwt_secret_path.as_ref());
+
+        cmd.arg("node")
+            .arg("--authrpc.port")
+            .arg(
+                self.auth_rpc_port
+                    .expect("auth_rpc_port not set")
+                    .to_string(),
+            )
+            .arg("--authrpc.jwtsecret")
+            .arg(
+                jwt_path
+                    .to_str()
+                    .expect("Failed to convert jwt_path to string"),
+            )
+            .arg("--chain")
+            .arg(
+                self.chain_config_path
+                    .as_ref()
+                    .expect("chain_config_path not set"),
+            )
+            .arg("--datadir")
+            .arg(self.data_dir.as_ref().expect("data_dir not set"))
+            .arg("--disable-discovery")
+            .arg("--port")
+            .arg(self.network_port.expect("network_port not set").to_string());
+
+        if let Some(http_port) = self.http_port {
+            cmd.arg("--http")
+                .arg("--http.port")
+                .arg(http_port.to_string());
+        }
+
+        cmd
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    fn ready(&self, log_path: &Path) -> impl Future<Output = Result<(), IntegrationError>> + Send {
+        async move {
+            poll_logs(
+                log_path,
+                "Starting consensus engine",
+                Duration::from_millis(100),
+                Duration::from_secs(60),
+            )
+            .await
+        }
+    }
+}

--- a/scripts/ci/download-op-reth.sh
+++ b/scripts/ci/download-op-reth.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Download the op-reth release
+wget https://github.com/paradigmxyz/reth/releases/download/v1.1.5/op-reth-v1.1.5-x86_64-unknown-linux-gnu.tar.gz
+
+# Extract the tar.gz file
+tar -xzf op-reth-v1.1.5-x86_64-unknown-linux-gnu.tar.gz
+
+# Make the binary executable
+chmod +x op-reth
+
+# Clean up the tar.gz file (optional)
+rm op-reth-v1.1.5-x86_64-unknown-linux-gnu.tar.gz


### PR DESCRIPTION
## 📝 Summary

This PR extends the `op-rbuilder` integration test to use an off-the-shelf op-node to validate the blocks built. It was already possible to do as part of the engineAPI mocker command. This PR enables that behaviour on the integration test too.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
