### PR TITLE
Use payload attributes timestamp to calculate op payload deadline

### DIFF
--- a/crates/op-rbuilder/src/integration/integration_test.rs
+++ b/crates/op-rbuilder/src/integration/integration_test.rs
@@ -29,7 +29,7 @@ mod tests {
         framework.start("op-rbuilder", &reth).await.unwrap();
 
         let engine_api = EngineApi::new("http://localhost:1234").unwrap();
-        let mut generator = BlockGenerator::new(&engine_api, None, false);
+        let mut generator = BlockGenerator::new(&engine_api, None, false, 1);
         generator.init().await.unwrap();
 
         for _ in 0..10 {

--- a/crates/op-rbuilder/src/tester/main.rs
+++ b/crates/op-rbuilder/src/tester/main.rs
@@ -24,6 +24,9 @@ enum Commands {
 
         #[clap(long, short, action, default_value = "false")]
         no_tx_pool: bool,
+
+        #[clap(long, short, action, default_value = "1")]
+        block_time_secs: u64,
     },
     /// Deposit funds to the system
     Deposit {
@@ -43,10 +46,11 @@ async fn main() -> eyre::Result<()> {
         Commands::Run {
             validation,
             no_tx_pool,
-        } => run_system(validation, no_tx_pool).await,
+            block_time_secs,
+        } => run_system(validation, no_tx_pool, block_time_secs).await,
         Commands::Deposit { address, amount } => {
             let engine_api = EngineApi::builder().build().unwrap();
-            let mut generator = BlockGenerator::new(&engine_api, None, false);
+            let mut generator = BlockGenerator::new(&engine_api, None, false, 1);
 
             generator.init().await?;
 


### PR DESCRIPTION
## 📝 Summary

This PR removes the hardcoded deadline for the Op payload builder of 2 seconds and uses the payload attributes timestmap to calculate it.

Closes #413 

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
