### PR TITLE
Replace dry run mode with a test relay

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+/cargo
+/data
+/mev-test-contract/cache
+/mev-test-contract/out
+/target
+/scripts/benchmark-results.*
+/test/
+/integration_logs
+
+# editors
+.code
+.idea
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4347,7 +4347,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rustls 0.23.16",
@@ -4380,7 +4380,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4399,7 +4399,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -5070,7 +5070,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "jsonrpsee-core 0.24.7",
@@ -5145,7 +5145,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "jsonrpsee-core 0.24.7",
  "jsonrpsee-types 0.24.7",
@@ -7879,7 +7879,6 @@ dependencies = [
  "futures",
  "governor",
  "humantime",
- "hyper 1.5.0",
  "integer-encoding",
  "itertools 0.11.0",
  "jsonrpsee 0.20.4",
@@ -8099,7 +8098,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.3",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -10346,7 +10345,7 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "jsonrpsee 0.24.7",
  "jsonwebtoken",
  "parking_lot",
@@ -12774,6 +12773,37 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "test-relay"
+version = "0.1.0"
+dependencies = [
+ "ahash",
+ "alloy-consensus",
+ "alloy-json-rpc",
+ "alloy-primitives 0.8.15",
+ "alloy-provider",
+ "clap 4.5.21",
+ "clap_builder",
+ "ctor",
+ "ethereum_ssz",
+ "eyre",
+ "flate2",
+ "lazy_static",
+ "metrics_macros",
+ "prometheus",
+ "rbuilder",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "warp",
+]
 
 [[package]]
 name = "test_utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ incremental = false
 [workspace.dependencies]
 reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-beacon-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
@@ -50,6 +51,7 @@ reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5", features = [
     "test-utils",
 ] }
@@ -62,17 +64,31 @@ reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-auto-seal-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-rpc-types-compat = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-rpc-api-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-node = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
@@ -113,8 +129,12 @@ alloy-rpc-types-engine = { version = "0.9.2", features = ["ssz"] }
 alloy-rpc-types-eth = { version = "0.9.2" }
 alloy-signer-local = { version = "0.9.2" }
 alloy-rpc-client = { version = "0.9.2" }
+alloy-genesis = { version = "0.9.2" }
 alloy-trie = { version = "0.7" }
+op-alloy-rpc-types = { version = "0.9.0", default-features = false }
 op-alloy-rpc-types-engine = { version =  "0.9.0", default-features = false }
+op-alloy-rpc-jsonrpsee = { version =  "0.9.0", default-features = false }
+op-alloy-network = { version =  "0.9.0", default-features = false }
 op-alloy-consensus = { version =  "0.9.0", default-features = false }
 
 async-trait = { version = "0.1.83" }
@@ -123,7 +143,10 @@ clap_builder = { version = "4.5.19" }
 thiserror = { version = "1.0.64" }
 eyre = { version = "0.6.12" }
 jsonrpsee = { version = "0.24.4" }
+jsonrpsee-types = { version = "0.24.4" }
+parking_lot = { version = "0.12.3" }
 tokio = { version = "1.40.0" }
+auto_impl = { version = "1.2.0" }
 reqwest = { version = "0.12.8" }
 serde = { version = "1.0.210" }
 serde_json = { version = "1.0.128" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,10 @@ members = [
     "crates/rbuilder/src/test_utils",
     "crates/rbuilder/src/telemetry/metrics_macros",
     "crates/eth-sparse-mpt",
-    "crates/sysperf"
+    "crates/sysperf",
+    "crates/test-relay",
 ]
-default-members = ["crates/rbuilder", "crates/reth-rbuilder"]
+default-members = ["crates/rbuilder", "crates/reth-rbuilder", "crates/test-relay"]
 resolver = "2"
 
 # Like release, but with full debug symbols. Useful for e.g. `perf`.
@@ -34,7 +35,6 @@ incremental = false
 [workspace.dependencies]
 reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-beacon-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
@@ -50,7 +50,6 @@ reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5", features = [
     "test-utils",
 ] }
@@ -63,31 +62,17 @@ reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-auto-seal-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-rpc-types-compat = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-rpc-api-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-discv4 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-node = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
 reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.5" }
@@ -128,41 +113,40 @@ alloy-rpc-types-engine = { version = "0.9.2", features = ["ssz"] }
 alloy-rpc-types-eth = { version = "0.9.2" }
 alloy-signer-local = { version = "0.9.2" }
 alloy-rpc-client = { version = "0.9.2" }
-alloy-genesis = { version = "0.9.2" }
 alloy-trie = { version = "0.7" }
-
-# op
-op-alloy-rpc-types = { version = "0.9.0", default-features = false }
 op-alloy-rpc-types-engine = { version =  "0.9.0", default-features = false }
-op-alloy-rpc-jsonrpsee = { version =  "0.9.0", default-features = false }
-op-alloy-network = { version =  "0.9.0", default-features = false }
 op-alloy-consensus = { version =  "0.9.0", default-features = false }
 
 async-trait = { version = "0.1.83" }
-clap = { version = "4.4.3" }
+clap = { version = "4.4.3", features = ["derive", "env"] }
+clap_builder = { version = "4.5.19" }
 thiserror = { version = "1.0.64" }
 eyre = { version = "0.6.12" }
 jsonrpsee = { version = "0.24.4" }
-jsonrpsee-types = { version = "0.24.4" }
-parking_lot = { version = "0.12.3" }
 tokio = { version = "1.40.0" }
-auto_impl = { version = "1.2.0" }
 reqwest = { version = "0.12.8" }
 serde = { version = "1.0.210" }
 serde_json = { version = "1.0.128" }
 serde_with = { version = "3.8.1" }
 secp256k1 = { version = "0.29" }
-clap_builder = { version = "4.5.19" }
 derive_more = { version = "1" }
 tokio-stream = "0.1.16"
 tokio-util = "0.7.12"
 url = "2.5.2"
+warp = "0.3.7"
+flate2 = "1.0.35"
+prometheus = "0.13.4"
+ctor = "0.2"
 
 libc = { version = "0.2.161" }
 lazy_static = "1.4.0"
 tikv-jemallocator = { version = "0.6" }
 tracing = "0.1.37"
 metrics = { version = "0.24.1" }
+ahash = "0.8.6"
+time = { version = "0.3.36", features = ["macros", "formatting", "parsing"] }
 
 eth-sparse-mpt = { path = "crates/eth-sparse-mpt" }
+rbuilder = { path = "crates/rbuilder" }
 sysperf = { path = "crates/sysperf" }
+metrics_macros = { path = "crates/rbuilder/src/telemetry/metrics_macros"}

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,13 @@ clean: ## Clean up
 build: ## Build (debug version)
 	cargo build --features "$(FEATURES)"
 
-.PHONY: docker-image
-docker-image: ## Build a rbuilder Docker image
-	docker build --platform linux/amd64 --build-arg FEATURES="$(FEATURES)" . -t rbuilder
+.PHONY: docker-image-rubilder
+docker-image-rubilder: ## Build a rbuilder Docker image
+	docker build --platform linux/amd64 --target rbuilder-runtime --build-arg FEATURES="$(FEATURES)"  . -t rbuilder
+
+.PHONY: docker-image-test-relay
+docker-image-test-relay: ## Build a test relay Docker image
+	docker build --platform linux/amd64 --target test-relay-runtime --build-arg FEATURES="$(FEATURES)" . -t test-relay
 
 ##@ Dev
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ rbuilder has a solid initial benchmarking setup (based on [Criterion.rs](https:/
 - Benchmarks are located in [`crates/rbuilder/benches`](./crates/rbuilder/benches/). We'd love to add more meaningful benchmarks there!
 - Let us know about further improvement ideas and additional relevant benchmarks.
 
+### Testing on real orderflow 
+
+For testing full live builders using real orderflow without submitting blocks, we provide the `test-relay` tool. This standalone binary implements the MEV-Boost relay API required for builder to function. The test-relay only performs block validation and compares profits between builders who submit blocks to it, without actually sending blocks to the network.
+
 ### End-to-end local testing
 
 You can use [builder-playground](https://github.com/flashbots/builder-playground) to deploy a fully functional local setup for the builder ([Lighthouse](https://github.com/sigp/lighthouse) consensus client (proposer + validator) + [Reth](https://github.com/paradigmxyz/reth/) execution client + [MEV-Boost-Relay](https://github.com/flashbots/mev-boost-relay))) to test rbuilder.
@@ -199,7 +203,7 @@ Big shoutout to the [Reth](https://github.com/paradigmxyz/reth) team for buildin
 
 
 | Binary                      | Description                                                                                           |
-| --------------------------- | ----------------------------------------------------------------------------------------------------- |
+|-----------------------------|-------------------------------------------------------------------------------------------------------|
 | `rbuilder`                  | Live block builder                                                                                    |
 | `backtest-build-block`      | Run backtests for a single block                                                                      |
 | `backtest-build-range`      | Run backtests for a range of block                                                                    |
@@ -210,3 +214,4 @@ Big shoutout to the [Reth](https://github.com/paradigmxyz/reth) team for buildin
 | `debug-order-input`         | Observe input of the bundles and transactions                                                         |
 | `debug-order-sim`           | Observe simulation of the bundles and transactions                                                    |
 | `debug-slot-data-generator` | Shows new payload jobs coming from CL with attached data from relays.                                 |
+| `test-relay`                | Test MEV-boost relay that accepts blocks and validates them.                                          |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ To run rbuilder you need:
 * Source of bundles that sends `eth_sendBundle`, `mev_sendBundle`, `eth_sendRawTransaction` as JSON rpc calls. (`jsonrpc_server_port`)
   (by default rbuilder will take raw txs from the reth node mempool)
 * Relays so submit to (`relays`)
-* Alternatively it can submit to the block validation API if run in the dry run mode (`dry_run`, `dry_run_validation_url`)
 
 A sample configuration for running Lighthouse and triggering payload events would be:
 ```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ rbuilder has a solid initial benchmarking setup (based on [Criterion.rs](https:/
 - Benchmarks are located in [`crates/rbuilder/benches`](./crates/rbuilder/benches/). We'd love to add more meaningful benchmarks there!
 - Let us know about further improvement ideas and additional relevant benchmarks.
 
-### Testing on real orderflow 
+### Testing with a fake relay
 
 This repo includes a `test-relay` tool for testing live builders without submitting blocks to live production relays. This standalone binary implements the MEV-Boost Relay API required for builder to function. The test-relay only performs block validation and compares profits between builders who submit blocks to it, without actually sending blocks to the network.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ rbuilder has a solid initial benchmarking setup (based on [Criterion.rs](https:/
 
 ### Testing on real orderflow 
 
-For testing full live builders using real orderflow without submitting blocks, we provide the `test-relay` tool. This standalone binary implements the MEV-Boost relay API required for builder to function. The test-relay only performs block validation and compares profits between builders who submit blocks to it, without actually sending blocks to the network.
+This repo includes a `test-relay` tool for testing live builders without submitting blocks to live production relays. This standalone binary implements the MEV-Boost Relay API required for builder to function. The test-relay only performs block validation and compares profits between builders who submit blocks to it, without actually sending blocks to the network.
+
+The test relay exposes several Prometheus metrics about the blocks it received.
 
 ### End-to-end local testing
 

--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -22,9 +22,6 @@ extra_data = "⚡🤖"
 
 blocklist_file_path = "./blocklist.json"
 
-dry_run = true
-dry_run_validation_url = "http://localhost:8545"
-
 ignore_cancellable_orders = true
 
 # genesis_fork_version = "0x00112233"

--- a/config-optimism-local.toml
+++ b/config-optimism-local.toml
@@ -16,9 +16,6 @@ jsonrpc_server_ip = "0.0.0.0"
 el_node_ipc_path = "/tmp/reth.ipc"
 extra_data = "⚡🤖"
 
-dry_run = false
-dry_run_validation_url = "http://localhost:8545"
-
 ignore_cancellable_orders = true
 
 sbundle_mergeable_signers = []

--- a/crates/eth-sparse-mpt/Cargo.toml
+++ b/crates/eth-sparse-mpt/Cargo.toml
@@ -38,7 +38,7 @@ alloy-trie.workspace = true
 # test deps
 hash-db = { version = "0.15.2", optional = true }
 triehash = { version = "0.8.4", optional = true }
-flate2 = { version = "1.0.35", optional = true }
+flate2 = { workspace = true, optional = true }
 eyre = { workspace = true, optional = true}
 
 [features]

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -85,11 +85,11 @@ csv = "1.2.2"
 zip = "0.6.6"
 atoi = "2.0.0"
 futures = "0.3.28"
-time = { version = "0.3.36", features = ["macros", "formatting", "parsing"] }
+time.workspace = true
 bigdecimal = "0.4.1"
 mempool-dumpster = "0.1.1"
 itertools = "0.11.0"
-clap = { workspace = true, features = ["derive", "env"] }
+clap.workspace = true
 priority-queue = "2.0.3"
 secp256k1 = { workspace = true, features = [
     "global-context",
@@ -97,7 +97,7 @@ secp256k1 = { workspace = true, features = [
     "recovery",
 ] }
 rayon = "1.8.0"
-flate2 = "1.0.27"
+flate2.workspace = true
 # Version required by ethereum-consensus beacon-api-client
 mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8", default-features = false }
 jsonrpsee = { version = "0.20.3", features = ["full"] }
@@ -106,13 +106,12 @@ beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus/"
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "cf3c404043230559660810bc0c9d6d5a8498d819" }
 ssz_rs_derive = { git = "https://github.com/ralexstokes/ssz-rs.git", version = "0.9.0" }
 uuid = { version = "1.6.1", features = ["serde", "v5", "v4"] }
-prometheus = "0.13.4"
-hyper = { version = "1.3.1", features = ["server", "full"] }
-warp = "0.3.7"
+prometheus.workspace = true
+warp.workspace = true
 lazy_static.workspace = true
-ctor = "0.2"
+ctor.workspace = true
 toml = "0.8.8"
-ahash = "0.8.6"
+ahash.workspace = true
 rand = "0.8.5"
 lru = "0.12.1"
 humantime = "2.1.0"

--- a/crates/rbuilder/src/lib.rs
+++ b/crates/rbuilder/src/lib.rs
@@ -9,4 +9,3 @@ pub mod provider;
 pub mod roothash;
 pub mod telemetry;
 pub mod utils;
-pub mod validation_api_client;

--- a/crates/rbuilder/src/live_builder/testdata/config_with_relay_override.toml
+++ b/crates/rbuilder/src/live_builder/testdata/config_with_relay_override.toml
@@ -22,9 +22,6 @@ extra_data = "⚡🤖"
 
 blocklist_file_path = "./blocklist.json"
 
-dry_run = true
-dry_run_validation_url = "http://localhost:8545"
-
 ignore_cancellable_orders = true
 
 # genesis_fork_version = "0x00112233"

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -545,12 +545,12 @@ pub fn mark_submission_start_time(block_sealed_at: OffsetDateTime) {
         .observe(value);
 }
 
-pub(super) fn gather_prometheus_metrics() -> String {
+pub fn gather_prometheus_metrics(registry: &Registry) -> String {
     use prometheus::Encoder;
     let encoder = prometheus::TextEncoder::new();
 
     let mut buffer = Vec::new();
-    if let Err(e) = encoder.encode(&REGISTRY.gather(), &mut buffer) {
+    if let Err(e) = encoder.encode(&registry.gather(), &mut buffer) {
         error!("could not encode custom metrics: {}", e);
     };
     let mut res = String::from_utf8(buffer.clone()).unwrap_or_else(|e| {
@@ -573,7 +573,7 @@ pub(super) fn gather_prometheus_metrics() -> String {
 }
 
 // Creates n exponential buckets that cover range from start to end.
-fn exponential_buckets_range(start: f64, end: f64, n: usize) -> Vec<f64> {
+pub fn exponential_buckets_range(start: f64, end: f64, n: usize) -> Vec<f64> {
     assert!(start > 0.0 && start < end);
     assert!(n > 1);
     let factor = (end / start).powf(1.0 / (n - 1) as f64);
@@ -581,7 +581,7 @@ fn exponential_buckets_range(start: f64, end: f64, n: usize) -> Vec<f64> {
 }
 
 // Creates n linear buckets that cover range from [start, end].
-fn linear_buckets_range(start: f64, end: f64, n: usize) -> Vec<f64> {
+pub fn linear_buckets_range(start: f64, end: f64, n: usize) -> Vec<f64> {
     assert!(start < end);
     let width = (end - start) / (n - 1) as f64;
     prometheus::linear_buckets(start, width, n).unwrap()

--- a/crates/rbuilder/src/telemetry/servers/full.rs
+++ b/crates/rbuilder/src/telemetry/servers/full.rs
@@ -16,6 +16,7 @@ use crate::{
     telemetry::{
         dynamic_logs::{default_log_config, reset_log_config, set_log_config},
         metrics::{gather_prometheus_metrics, set_version},
+        REGISTRY,
     },
     utils::build_info::Version,
 };
@@ -44,7 +45,7 @@ pub async fn spawn(
 }
 
 async fn metrics_handler() -> Result<impl Reply, Rejection> {
-    Ok(gather_prometheus_metrics())
+    Ok(gather_prometheus_metrics(&REGISTRY))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/test-relay/Cargo.toml
+++ b/crates/test-relay/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "test-relay"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[dependencies]
+rbuilder.workspace = true
+clap.workspace = true
+clap_builder.workspace = true
+eyre.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+
+alloy-json-rpc.workspace = true
+alloy-primitives.workspace = true
+alloy-provider.workspace = true
+alloy-consensus.workspace = true
+serde.workspace = true
+serde_with.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+warp.workspace = true
+flate2.workspace = true
+lazy_static.workspace = true
+metrics_macros.workspace = true
+
+prometheus.workspace = true
+ctor.workspace = true
+
+ethereum_ssz.workspace = true
+url.workspace = true
+ahash.workspace = true
+time.workspace = true

--- a/crates/test-relay/README.md
+++ b/crates/test-relay/README.md
@@ -1,0 +1,15 @@
+# About
+
+`test-relay` is a dummy relay implementation for block builders that can be used for testing without submitting to the real MEV-boost relay.
+
+To use test-relay, you need:
+* A real MEV-boost relay URL
+* A connection to a consensus layer node
+* (optional) A validation endpoint to validate blocks
+
+It provides the following API endpoints:
+* GET /relay/v1/builder/validators
+* POST /relay/v1/builder/blocks
+
+
+Additionally, it exposes metrics, including estimated slot auction winners among builders who submit to this relay.

--- a/crates/test-relay/src/main.rs
+++ b/crates/test-relay/src/main.rs
@@ -1,0 +1,117 @@
+use crate::validation_api_client::ValidationAPIClient;
+use metrics::spawn_metrics_server;
+use rbuilder::{
+    beacon_api_client::Client,
+    mev_boost::RelayClient,
+    primitives::mev_boost::MevBoostRelaySlotInfoProvider,
+    telemetry::{setup_reloadable_tracing_subscriber, LoggerConfig},
+};
+use relay::spawn_relay_server;
+use std::net::SocketAddr;
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+use clap::Parser;
+use tokio::signal::ctrl_c;
+
+pub mod metrics;
+pub mod relay;
+pub mod validation_api_client;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    #[clap(
+        short,
+        long,
+        help = "API listen address",
+        default_value = "0.0.0.0:80",
+        env = "LISTEN_ADDRESS"
+    )]
+    listen_address: SocketAddr,
+    #[clap(
+        short,
+        long,
+        help = "metrics API",
+        default_value = "0.0.0.0:6069",
+        env = "METRICS_LISTEN_ADDRESS"
+    )]
+    metrics_address: SocketAddr,
+    #[clap(long, action, default_value = "false", env = "LOG_JSON")]
+    log_json: bool,
+    #[clap(
+        long,
+        help = "Rust log describton",
+        default_value = "info",
+        env = "RUST_LOG"
+    )]
+    rust_log: String,
+    #[clap(
+        long,
+        help = "URL to validate submitted blocks",
+        env = "VALIDATION_URL"
+    )]
+    validation_url: Option<String>,
+    #[clap(
+        long,
+        help = "Relay to fetch current epoch data",
+        env = "MEV_BOOST_RELAY"
+    )]
+    relay: String,
+    #[clap(
+        long,
+        help = "CL clients to fetch mev boost slot data",
+        env = "CL_CLIENTS"
+    )]
+    cl_clients: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    let cli = Cli::parse();
+
+    let global_cancellation = CancellationToken::new();
+
+    let config = LoggerConfig {
+        env_filter: cli.rust_log,
+        file: None,
+        log_json: cli.log_json,
+        log_color: false,
+    };
+    setup_reloadable_tracing_subscriber(config)?;
+
+    spawn_metrics_server(cli.metrics_address);
+
+    let cl_clients = cli
+        .cl_clients
+        .iter()
+        .map(|c| {
+            let url = c.parse()?;
+            Ok(Client::new(url))
+        })
+        .collect::<eyre::Result<Vec<_>>>()?;
+
+    let relay = {
+        let url: Url = cli.relay.parse()?;
+        let client = RelayClient::from_url(url, None, None, None);
+        MevBoostRelaySlotInfoProvider::new(client, "relay".to_string(), 1)
+    };
+
+    let validation_client = if let Some(url) = cli.validation_url {
+        Some(ValidationAPIClient::new(&[&url])?)
+    } else {
+        None
+    };
+
+    spawn_relay_server(
+        cli.listen_address,
+        validation_client,
+        cl_clients,
+        relay,
+        global_cancellation.clone(),
+    )?;
+
+    ctrl_c().await.unwrap();
+    global_cancellation.cancel();
+
+    Ok(())
+}

--- a/crates/test-relay/src/metrics.rs
+++ b/crates/test-relay/src/metrics.rs
@@ -1,0 +1,116 @@
+use ctor::ctor;
+use lazy_static::lazy_static;
+use metrics_macros::register_metrics;
+use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry};
+use rbuilder::telemetry::{
+    exponential_buckets_range, gather_prometheus_metrics, linear_buckets_range,
+};
+use std::{net::SocketAddr, time::Duration};
+use warp::{reject::Rejection, reply::Reply, Filter};
+
+lazy_static! {
+    pub static ref REGISTRY: Registry = Registry::new();
+}
+
+register_metrics! {
+    // Statistics about finalized blocks
+    pub static PAYLOADS_RECEIVED: IntCounterVec = IntCounterVec::new(
+        Opts::new(
+            "payloads_received",
+            "payloads received"
+        ),
+        &["builder"]
+    )
+    .unwrap();
+
+    pub static PAYLOAD_VALIDATION_ERRORS: IntCounterVec = IntCounterVec::new(
+        Opts::new(
+            "payloads_validation_errors",
+            "payloads validation errors"
+        ),
+        &["builder"]
+    )
+    .unwrap();
+
+    pub static RELAY_ERRORS: IntCounterVec = IntCounterVec::new(
+        Opts::new(
+            "relay_errors",
+            "errors when fetching data from relays"
+        ),
+        &["relay"]
+    )
+    .unwrap();
+
+    pub static WINS: IntCounterVec = IntCounterVec::new(
+        Opts::new(
+            "wins",
+            "wins per builder (relay samples top bid close to the end to the slot)"
+        ),
+        &["builder"]
+    )
+    .unwrap();
+
+    pub static WINNER_ADVANTAGE: HistogramVec = HistogramVec::new(
+        HistogramOpts::new("winner_advantage", "Percentage of value that winner has over the next best bid")
+            .buckets(linear_buckets_range(0.0, 100.0, 100)),
+        &["builder"],
+    ).unwrap();
+
+
+    pub static PAYLOAD_PROCESSING_TIME: HistogramVec = HistogramVec::new(
+        HistogramOpts::new("payload_processing_time", "Time to fully process received payload (ms)")
+            .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
+        &[],
+    ).unwrap();
+
+    pub static PAYLOAD_VALIDATION_TIME: HistogramVec = HistogramVec::new(
+        HistogramOpts::new("payload_validation_time", "Time to validate received payload (ms)")
+            .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
+        &[],
+    ).unwrap();
+}
+
+pub fn inc_payloads_received(builder: &str) {
+    PAYLOADS_RECEIVED.with_label_values(&[builder]).inc();
+}
+
+pub fn inc_payload_validation_errors(builder: &str) {
+    PAYLOAD_VALIDATION_ERRORS
+        .with_label_values(&[builder])
+        .inc();
+}
+
+pub fn inc_relay_errors() {
+    RELAY_ERRORS.with_label_values(&[]).inc();
+}
+
+pub fn add_winning_bid(builder: &str, advantage: f64) {
+    WINS.with_label_values(&[builder]).inc();
+    if advantage != 0.0 {
+        // we filter 0.0 advantage to filter edge cases like the first bid in the slot, etc.
+        WINNER_ADVANTAGE
+            .with_label_values(&[builder])
+            .observe(advantage);
+    }
+}
+
+pub fn add_payload_processing_time(duration: Duration) {
+    PAYLOAD_PROCESSING_TIME
+        .with_label_values(&[])
+        .observe(duration.as_micros() as f64 / 1000.0);
+}
+
+pub fn add_payload_validation_time(duration: Duration) {
+    PAYLOAD_VALIDATION_TIME
+        .with_label_values(&[])
+        .observe(duration.as_micros() as f64 / 1000.0);
+}
+
+pub fn spawn_metrics_server(address: SocketAddr) {
+    let metrics_route = warp::path!("debug" / "metrics" / "prometheus").and_then(metrics_handler);
+    tokio::spawn(warp::serve(metrics_route).run(address));
+}
+
+async fn metrics_handler() -> Result<impl Reply, Rejection> {
+    Ok(gather_prometheus_metrics(&REGISTRY))
+}

--- a/crates/test-relay/src/metrics.rs
+++ b/crates/test-relay/src/metrics.rs
@@ -51,7 +51,7 @@ register_metrics! {
     .unwrap();
 
     pub static WINNER_ADVANTAGE: HistogramVec = HistogramVec::new(
-        HistogramOpts::new("winner_advantage", "Percentage of value that winner has over the next best bid")
+        HistogramOpts::new("winner_advantage", "Percentage of value that winner has over the next best bid by other builders")
             .buckets(linear_buckets_range(0.0, 100.0, 100)),
         &["builder"],
     ).unwrap();

--- a/crates/test-relay/src/relay.rs
+++ b/crates/test-relay/src/relay.rs
@@ -1,0 +1,564 @@
+use crate::{
+    metrics::{
+        add_payload_processing_time, add_payload_validation_time, add_winning_bid,
+        inc_payload_validation_errors, inc_payloads_received, inc_relay_errors,
+    },
+    validation_api_client::ValidationAPIClient,
+};
+use ahash::HashMap;
+use alloy_consensus::proofs::calculate_withdrawals_root;
+use alloy_primitives::{bytes::Bytes, utils::format_ether, B256, U256};
+use flate2::bufread::GzDecoder;
+use rbuilder::{
+    beacon_api_client::Client,
+    live_builder::{
+        block_list_provider::NullBlockListProvider,
+        payload_events::{MevBoostSlotData, MevBoostSlotDataGenerator},
+    },
+    mev_boost::submission::SubmitBlockRequest,
+    primitives::mev_boost::MevBoostRelaySlotInfoProvider,
+};
+use serde::{Deserialize, Serialize};
+use std::time::Instant;
+use std::{
+    collections::hash_map::Entry,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use std::{io::Read, net::SocketAddr};
+use time::OffsetDateTime;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+use warp::body;
+use warp::{
+    http::status::StatusCode,
+    query,
+    reject::Reject,
+    reply::{self, Reply},
+    Filter,
+};
+
+#[derive(Debug)]
+enum RelayError {
+    ValidatorsFetch,
+    InvalidParams,
+    BlockProcessing,
+    FailedToAcceptSubmission,
+    PastSlot,
+    PayloadAttributesNotKnown,
+    SimulationFailed(String),
+}
+
+impl RelayError {
+    fn reply(self) -> Box<dyn Reply> {
+        let (code, internal, message) = match self {
+            RelayError::ValidatorsFetch => (1, false, "Failed to fetch validators".to_string()),
+            RelayError::InvalidParams => (2, false, "Invalid request params".to_string()),
+            RelayError::BlockProcessing => (3, true, "Error processing block".to_string()),
+            RelayError::FailedToAcceptSubmission => {
+                (4, false, "Failed to accept submission".to_string())
+            }
+            RelayError::PastSlot => (5, false, "submission for past slot".to_string()),
+            RelayError::PayloadAttributesNotKnown => {
+                (6, false, "payload attributes not (yet) known".to_string())
+            }
+            RelayError::SimulationFailed(msg) => (7, false, format!("simulation failed: {}", msg)),
+        };
+        let json = RelayErrorResponse { code, message };
+        let status_code = if internal {
+            StatusCode::INTERNAL_SERVER_ERROR
+        } else {
+            StatusCode::BAD_REQUEST
+        };
+        Box::new(reply::with_status(reply::json(&json), status_code))
+    }
+}
+
+fn ok_json_reply<T: Serialize>(msg: &T) -> Box<dyn Reply> {
+    Box::new(reply::json(msg))
+}
+
+#[derive(Debug, Serialize)]
+struct RelayErrorResponse {
+    code: i64,
+    message: String,
+}
+
+impl Reject for RelayErrorResponse {}
+
+#[derive(Debug, Deserialize)]
+struct BlockQueryParams {
+    cancellations: Option<i32>,
+}
+
+pub fn spawn_relay_server(
+    address: SocketAddr,
+    validation_client: Option<ValidationAPIClient>,
+    cl_clients: Vec<Client>,
+    relay: MevBoostRelaySlotInfoProvider,
+    cancellation_token: CancellationToken,
+) -> eyre::Result<()> {
+    let relay_state = RelayState {
+        validation_client,
+        relay_for_slot_data: relay.clone(),
+        pending_slot_data: Arc::new(Mutex::new(None)),
+    };
+    spawn_mev_boost_slot_data_generator(
+        relay_state.clone(),
+        cl_clients,
+        relay,
+        cancellation_token.clone(),
+    )?;
+
+    tokio::spawn(run_winner_sampler(relay_state.clone(), cancellation_token));
+
+    let relay_handler = warp::any().map(move || relay_state.clone());
+
+    let validators_route = warp::path!("relay" / "v1" / "builder" / "validators")
+        .and(warp::get())
+        .and(relay_handler.clone())
+        .then(|state: RelayState| async move { state.handle_validators().await });
+
+    let submit_block_route = warp::path!("relay" / "v1" / "builder" / "blocks")
+        .and(warp::post())
+        .and(relay_handler.clone())
+        .and(query::query::<BlockQueryParams>())
+        .and(body::content_length_limit(20 * 1024 * 1024))
+        .and(body::bytes())
+        .and(warp::header::<String>("content-type"))
+        .and(warp::header::optional::<String>("content-encoding"))
+        .then(
+            |state: RelayState, query, body, content_type, content_encoding| async move {
+                state
+                    .handle_block(query, body, content_type, content_encoding)
+                    .await
+            },
+        );
+
+    let routes = submit_block_route.or(validators_route);
+    tokio::spawn(warp::serve(routes).run(address));
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct RelayState {
+    validation_client: Option<ValidationAPIClient>,
+    relay_for_slot_data: MevBoostRelaySlotInfoProvider,
+    pending_slot_data: Arc<Mutex<Option<PendingSlotData>>>,
+}
+
+impl RelayState {
+    async fn handle_validators(&self) -> Box<dyn Reply> {
+        match self
+            .relay_for_slot_data
+            .get_current_epoch_validators()
+            .await
+        {
+            Ok(slot_data) => ok_json_reply(&slot_data),
+            Err(err) => {
+                warn!(?err, "Failed to fetch epoch data from relay");
+                inc_relay_errors();
+                RelayError::ValidatorsFetch.reply()
+            }
+        }
+    }
+
+    async fn handle_block(
+        &self,
+        query: BlockQueryParams,
+        body: Bytes,
+        content_type: String,
+        content_encoding: Option<String>,
+    ) -> Box<dyn Reply> {
+        let processing_start = Instant::now();
+        let cancel = match query.cancellations {
+            Some(1) => true,
+            Some(0) | None => false,
+            _ => return RelayError::InvalidParams.reply(),
+        };
+
+        let ssz = match content_type.as_str() {
+            "application/octet-stream" => true,
+            "application/json" => false,
+            _ => return RelayError::InvalidParams.reply(),
+        };
+
+        let gzip = match content_encoding.as_deref() {
+            Some("gzip") => true,
+            None => false,
+            _ => return RelayError::InvalidParams.reply(),
+        };
+
+        let body_size = body.len();
+
+        let body = if gzip {
+            let mut result = Vec::new();
+            let mut decoder = GzDecoder::new(body.as_ref());
+            match decoder.read_to_end(&mut result) {
+                Ok(_) => {}
+                Err(err) => {
+                    warn!(?err, "Failed to ungzip body");
+                    return RelayError::BlockProcessing.reply();
+                }
+            }
+            result.into()
+        } else {
+            body
+        };
+
+        let payload_size = body.len();
+
+        let submission: SubmitBlockRequest = if ssz {
+            match SubmitBlockRequest::from_ssz_bytes(body.as_ref()) {
+                Ok(res) => res,
+                Err(err) => {
+                    warn!(?err, "Failed to parse ssz block submission");
+                    return RelayError::BlockProcessing.reply();
+                }
+            }
+        } else {
+            match serde_json::from_slice(body.as_ref()) {
+                Ok(res) => res,
+                Err(err) => {
+                    warn!(?err, "Failed to parse json block submission");
+                    return RelayError::BlockProcessing.reply();
+                }
+            }
+        };
+
+        let builder_id = builder_id(submission.bid_trace().builder_pubkey.as_ref());
+
+        inc_payloads_received(&builder_id);
+
+        let (withdrawals_root, registered_gas_limit, parent_beacon_block_root) = {
+            let pending_slot = self.pending_slot_data.lock().unwrap();
+            let pending_slot = if pending_slot.is_some() {
+                pending_slot.as_ref().unwrap()
+            } else {
+                return RelayError::PayloadAttributesNotKnown.reply();
+            };
+            if let Err(err) = pending_slot.is_submission_for_this_slot(&submission) {
+                return err.reply();
+            }
+
+            let withdrawals_root = pending_slot.withdrawals_root;
+            let registered_gas_limit = pending_slot.slot_data.suggested_gas_limit;
+            let parent_beacon_block_root = pending_slot
+                .slot_data
+                .payload_attributes_event
+                .attributes()
+                .parent_beacon_block_root;
+            (
+                withdrawals_root,
+                registered_gas_limit,
+                parent_beacon_block_root,
+            )
+        };
+
+        if let Some(validation) = &self.validation_client {
+            let validation_start = Instant::now();
+            match validation
+                .validate_block(
+                    &submission,
+                    registered_gas_limit,
+                    withdrawals_root,
+                    parent_beacon_block_root,
+                    CancellationToken::default(),
+                )
+                .await
+            {
+                Ok(_) => {}
+                Err(err) => {
+                    warn!(?err, "Failed to validate block");
+                    inc_payload_validation_errors(&builder_id);
+                    return RelayError::SimulationFailed(err.to_string()).reply();
+                }
+            }
+
+            add_payload_validation_time(validation_start.elapsed());
+        }
+
+        let bid_trace = submission.bid_trace();
+
+        debug!(
+            body_size,
+            payload_size,
+            slot = bid_trace.slot,
+            value = format_ether(bid_trace.value),
+            gas_used = bid_trace.gas_used,
+            builder = builder_id,
+            ssz,
+            gzip,
+            "Received a block"
+        );
+
+        {
+            let mut pending_slot = self.pending_slot_data.lock().unwrap();
+            let pending_slot = if pending_slot.is_some() {
+                pending_slot.as_mut().unwrap()
+            } else {
+                return RelayError::FailedToAcceptSubmission.reply();
+            };
+            pending_slot.add_new_submission(submission, cancel);
+        }
+
+        add_payload_processing_time(processing_start.elapsed());
+
+        Box::new(reply::reply())
+    }
+}
+
+fn spawn_mev_boost_slot_data_generator(
+    relay_state: RelayState,
+    cl_clients: Vec<Client>,
+    relay: MevBoostRelaySlotInfoProvider,
+    cancellation_token: CancellationToken,
+) -> eyre::Result<()> {
+    let slot_data_generator = MevBoostSlotDataGenerator::new(
+        cl_clients,
+        vec![relay],
+        Arc::new(NullBlockListProvider::default()),
+        cancellation_token.clone(),
+    );
+    let (_, slot_data_generator) = slot_data_generator.spawn();
+
+    tokio::spawn(run_slot_data_fetcher(
+        relay_state,
+        slot_data_generator,
+        cancellation_token,
+    ));
+    Ok(())
+}
+
+async fn run_slot_data_fetcher(
+    relay_state: RelayState,
+    mut slot_data_generator: mpsc::UnboundedReceiver<MevBoostSlotData>,
+    cancellation_token: CancellationToken,
+) {
+    'slot_data: loop {
+        let new_slot_data = tokio::select! {
+                data = slot_data_generator.recv() => if let Some(data) = data {
+                    data
+        } else {
+                    break 'slot_data;
+        },
+                _ = cancellation_token.cancelled() => break 'slot_data,
+        };
+        {
+            info!(slot = new_slot_data.slot(), "New slot data");
+            let mut current_slot_data = relay_state.pending_slot_data.lock().unwrap();
+            *current_slot_data = Some(PendingSlotData::new(new_slot_data));
+        }
+    }
+}
+
+async fn run_winner_sampler(relay_state: RelayState, cancellation_token: CancellationToken) {
+    const WINNER_SAMPLING_INTERVAL: Duration = Duration::from_millis(50);
+    const SAMPLING_RANGE_DELTA: time::Duration = time::Duration::seconds(2);
+
+    'sampling: loop {
+        tokio::select! {
+                _ = tokio::time::sleep(WINNER_SAMPLING_INTERVAL) => {},
+                _ = cancellation_token.cancelled() => break 'sampling,
+        };
+        {
+            let current_slot_data = relay_state.pending_slot_data.lock().unwrap();
+
+            let (slot_end, best_bid) = if let Some(value) = current_slot_data
+                .as_ref()
+                .map(|s| (s.slot_data.timestamp(), &s.best_bid))
+            {
+                value
+            } else {
+                continue 'sampling;
+            };
+
+            let best_bid = if let Some(best_bid) = best_bid {
+                best_bid
+            } else {
+                continue 'sampling;
+            };
+
+            let now = OffsetDateTime::now_utc();
+
+            let too_early = now < slot_end - SAMPLING_RANGE_DELTA;
+            let too_late = slot_end + SAMPLING_RANGE_DELTA < now;
+
+            if too_early || too_late {
+                continue 'sampling;
+            }
+
+            let builder = builder_id(&best_bid.builder);
+            add_winning_bid(&builder, best_bid.advantage);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PendingSlotData {
+    slot_data: MevBoostSlotData,
+    withdrawals_root: B256,
+    // best_bid: Option<U256>
+    best_bid: Option<BestBidData>,
+    // For empty key we store uncancallable bids
+    // for non-empty keys we use builder pubkeys
+    best_bid_by_replacement_key: HashMap<Bytes, BestBidData>,
+}
+
+impl PendingSlotData {
+    fn new(slot_data: MevBoostSlotData) -> Self {
+        let withdrawals_root = calculate_withdrawals_root(
+            &slot_data
+                .payload_attributes_event
+                .attributes()
+                .withdrawals
+                .clone()
+                .unwrap_or_default(),
+        );
+        Self {
+            slot_data,
+            withdrawals_root,
+            best_bid: None,
+            best_bid_by_replacement_key: HashMap::default(),
+        }
+    }
+
+    fn is_submission_for_this_slot(
+        &self,
+        submission: &SubmitBlockRequest,
+    ) -> Result<(), RelayError> {
+        let bid_trace = submission.bid_trace();
+        let relay_slot = self.slot_data.slot();
+        let bid_slot = bid_trace.slot;
+
+        #[allow(clippy::comparison_chain)]
+        if relay_slot > bid_slot {
+            return Err(RelayError::PastSlot);
+        } else if relay_slot < bid_slot {
+            return Err(RelayError::PayloadAttributesNotKnown);
+        }
+        if self.slot_data.parent_block_hash() != bid_trace.parent_hash {
+            return Err(RelayError::PayloadAttributesNotKnown);
+        }
+        Ok(())
+    }
+
+    fn add_new_submission(&mut self, submission: SubmitBlockRequest, cancellable: bool) {
+        if self.is_submission_for_this_slot(&submission).is_err() {
+            return;
+        }
+
+        let trace = submission.bid_trace();
+        let new_bid = BestBidData {
+            hash: trace.block_hash,
+            value: trace.value,
+            builder: trace.builder_pubkey.as_slice().to_vec().into(),
+            advantage: 0.0,
+        };
+
+        let update_best_bid = if cancellable {
+            match self
+                .best_bid_by_replacement_key
+                .entry(new_bid.builder.clone())
+            {
+                Entry::Occupied(mut prev_entry) => {
+                    let replacing_best_bid = self
+                        .best_bid
+                        .as_ref()
+                        .map(|best_bid| {
+                            let replaced_bid = prev_entry.get();
+                            best_bid.builder == replaced_bid.builder
+                                && best_bid.hash == replaced_bid.hash
+                        })
+                        .unwrap_or(false);
+                    prev_entry.insert(new_bid);
+                    replacing_best_bid
+                }
+                Entry::Vacant(vacant) => {
+                    let value_is_higher = self
+                        .best_bid
+                        .as_ref()
+                        .map(|best_bid| new_bid.value > best_bid.value)
+                        .unwrap_or(true);
+                    vacant.insert(new_bid);
+                    value_is_higher
+                }
+            }
+        } else {
+            let value_is_higher = self
+                .best_bid
+                .as_ref()
+                .map(|best_bid| new_bid.value > best_bid.value)
+                .unwrap_or(true);
+            match self.best_bid_by_replacement_key.entry(Bytes::default()) {
+                Entry::Occupied(mut prev_entry) => {
+                    if new_bid.value > prev_entry.get().value {
+                        prev_entry.insert(new_bid);
+                    }
+                }
+                Entry::Vacant(vacant) => {
+                    vacant.insert(new_bid);
+                }
+            }
+            value_is_higher
+        };
+
+        if update_best_bid {
+            self.best_bid = self
+                .best_bid_by_replacement_key
+                .values()
+                .max_by_key(|b| b.value)
+                .cloned();
+
+            // calculate new best bid advantage
+            let best_bid = if let Some(best_bid) = self.best_bid.as_mut() {
+                best_bid
+            } else {
+                return;
+            };
+            let best_bid_value = best_bid.value;
+            let next_best_bid_value = self
+                .best_bid_by_replacement_key
+                .values()
+                .filter(|bid| bid.builder != best_bid.builder)
+                .map(|bid| bid.value)
+                .max()
+                .unwrap_or_default();
+            let advantage = if best_bid_value.is_zero()
+                || next_best_bid_value.is_zero()
+                || best_bid_value <= next_best_bid_value
+            {
+                0.0
+            } else {
+                let advantage = (best_bid_value * U256::from(100u64)) / next_best_bid_value
+                    - U256::from(100u64);
+                advantage.into()
+            };
+            best_bid.advantage = advantage;
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BestBidData {
+    hash: B256,
+    value: U256,
+    builder: Bytes,
+    // advantage is percentage of value that this builder bid has over the next best bid by other builders
+    advantage: f64,
+}
+
+fn builder_id(pubkey: &[u8]) -> String {
+    let pubkey_hex = alloy_primitives::hex::encode(pubkey);
+    if pubkey_hex.len() < 8 {
+        return "incorrect_pubkey".to_string();
+    }
+
+    format!(
+        "{}..{}",
+        &pubkey_hex[0..4],
+        &pubkey_hex[pubkey_hex.len() - 4..]
+    )
+}

--- a/crates/test-relay/src/relay.rs
+++ b/crates/test-relay/src/relay.rs
@@ -34,7 +34,6 @@ use warp::body;
 use warp::{
     http::status::StatusCode,
     query,
-    reject::Reject,
     reply::{self, Reply},
     Filter,
 };
@@ -75,23 +74,21 @@ impl RelayError {
     }
 }
 
-fn ok_json_reply<T: Serialize>(msg: &T) -> Box<dyn Reply> {
-    Box::new(reply::json(msg))
-}
-
 #[derive(Debug, Serialize)]
 struct RelayErrorResponse {
     code: i64,
     message: String,
 }
 
-impl Reject for RelayErrorResponse {}
-
 #[derive(Debug, Deserialize)]
 struct BlockQueryParams {
     cancellations: Option<i32>,
 }
 
+/// It will run the following processes:
+/// * API server
+/// * mev boost slot info generator that will fetch data from CL nodes + relay
+/// * winner sampler that will sample top bid to estimate auction winner for the given slot
 pub fn spawn_relay_server(
     address: SocketAddr,
     validation_client: Option<ValidationAPIClient>,
@@ -144,8 +141,11 @@ pub fn spawn_relay_server(
 
 #[derive(Debug, Clone)]
 struct RelayState {
+    // Validation client that is used to validate blocks.
     validation_client: Option<ValidationAPIClient>,
+    // Relay used to fetch data for /relay/v1/builder/validators
     relay_for_slot_data: MevBoostRelaySlotInfoProvider,
+    // Slot data for the last payload arguments received from CL nodes and relay
     pending_slot_data: Arc<Mutex<Option<PendingSlotData>>>,
 }
 
@@ -156,7 +156,7 @@ impl RelayState {
             .get_current_epoch_validators()
             .await
         {
-            Ok(slot_data) => ok_json_reply(&slot_data),
+            Ok(slot_data) => Box::new(reply::json(&slot_data)),
             Err(err) => {
                 warn!(?err, "Failed to fetch epoch data from relay");
                 inc_relay_errors();
@@ -398,12 +398,18 @@ async fn run_winner_sampler(relay_state: RelayState, cancellation_token: Cancell
 
 #[derive(Debug)]
 struct PendingSlotData {
+    // Payload attributes for the slot
     slot_data: MevBoostSlotData,
+    // Withdrawals root is calculated from slot_data and used for validation call.
     withdrawals_root: B256,
-    // best_bid: Option<U256>
+    // Current best bid on the relay
+    // its calculated from best_bid_by_replacement_key by taking the highest value bid
     best_bid: Option<BestBidData>,
-    // For empty key we store uncancallable bids
-    // for non-empty keys we use builder pubkeys
+    // Best bid by builders.
+    // There are two types of bids: cancellable and not and
+    // we must store last cancellable bid by builder pubkey and replace when new bid arrives.
+    // For empty key we store uncancallable bids.
+    // For non-empty keys we use builder pubkeys.
     best_bid_by_replacement_key: HashMap<Bytes, BestBidData>,
 }
 
@@ -550,6 +556,7 @@ struct BestBidData {
     advantage: f64,
 }
 
+/// short readable builder id for metrics
 fn builder_id(pubkey: &[u8]) -> String {
     let pubkey_hex = alloy_primitives::hex::encode(pubkey);
     if pubkey_hex.len() < 8 {


### PR DESCRIPTION
## 📝 Summary

* removes dry run mode and validation from the rbuilder
* adds a test_relay binary that is used to accept and validate submissions
* removes optimistic mode validation feature

## 💡 Motivation and Context

Dry run mode does not allow us to fully test submissions to the relays so here its replaced with separate service that implements relay API. 

Test builders does not need to point to real relays as test relays can server validator data itself. This improves robustness in the tests as production relays are not even mentioned in the test builder configs.


## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
