### PR TITLE
Add revert protection and integration tests

### DIFF
--- a/crates/op-rbuilder/src/integration/integration_test.rs
+++ b/crates/op-rbuilder/src/integration/integration_test.rs
@@ -4,10 +4,17 @@ mod tests {
         op_rbuilder::OpRbuilderConfig, op_reth::OpRethConfig, IntegrationFramework,
     };
     use crate::tester::{BlockGenerator, EngineApi};
+    use crate::tx_signer::Signer;
+    use alloy_consensus::TxEip1559;
+    use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
+    use alloy_eips::eip2718::Encodable2718;
+    use alloy_primitives::hex;
     use alloy_provider::Identity;
     use alloy_provider::{Provider, ProviderBuilder};
     use alloy_rpc_types_eth::BlockTransactionsKind;
+    use op_alloy_consensus::OpTypedTransaction;
     use op_alloy_network::Optimism;
+    use std::cmp::max;
     use std::path::PathBuf;
     use uuid::Uuid;
 
@@ -80,6 +87,130 @@ mod tests {
         op_rbuilder
             .find_log_line("Committed block built by builder")
             .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn integration_test_revert_protection() -> eyre::Result<()> {
+        // This is a simple test using the integration framework to test that the chain
+        // produces blocks.
+        let mut framework = IntegrationFramework::new().unwrap();
+
+        // we are going to use a genesis file pre-generated before the test
+        let mut genesis_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        genesis_path.push("../../genesis.json");
+        assert!(genesis_path.exists());
+
+        // create the builder
+        let builder_data_dir = std::env::temp_dir().join(Uuid::new_v4().to_string());
+        let op_rbuilder_config = OpRbuilderConfig::new()
+            .chain_config_path(genesis_path.clone())
+            .data_dir(builder_data_dir)
+            .auth_rpc_port(1244)
+            .network_port(1245)
+            .http_port(1248)
+            .with_builder_private_key(BUILDER_PRIVATE_KEY);
+
+        // create the validation reth node
+        let reth_data_dir = std::env::temp_dir().join(Uuid::new_v4().to_string());
+        let reth = OpRethConfig::new()
+            .chain_config_path(genesis_path)
+            .data_dir(reth_data_dir)
+            .auth_rpc_port(1246)
+            .network_port(1247);
+
+        framework.start("op-reth", &reth).await.unwrap();
+
+        let _ = framework
+            .start("op-rbuilder", &op_rbuilder_config)
+            .await
+            .unwrap();
+
+        let engine_api = EngineApi::new("http://localhost:1244").unwrap();
+        let validation_api = EngineApi::new("http://localhost:1246").unwrap();
+
+        let mut generator = BlockGenerator::new(&engine_api, Some(&validation_api), false, 1);
+        let latest_block = generator.init().await?;
+
+        let provider = ProviderBuilder::<Identity, Identity, Optimism>::default()
+            .on_http("http://localhost:1248".parse()?);
+
+        let mut base_fee = max(
+            latest_block.header.base_fee_per_gas.unwrap(),
+            MIN_PROTOCOL_BASE_FEE,
+        );
+        for _ in 0..10 {
+            // Get builder's address
+            let known_wallet = Signer::try_from_secret(BUILDER_PRIVATE_KEY.parse()?)?;
+            let builder_address = known_wallet.address;
+            // Get current nonce from chain
+            let nonce = provider.get_transaction_count(builder_address).await?;
+            // Transaction from builder should succeed
+            let tx_request = OpTypedTransaction::Eip1559(TxEip1559 {
+                chain_id: 901,
+                nonce,
+                gas_limit: 210000,
+                max_fee_per_gas: base_fee.into(),
+                ..Default::default()
+            });
+            let signed_tx = known_wallet.sign_tx(tx_request)?;
+            let known_tx = provider
+                .send_raw_transaction(signed_tx.encoded_2718().as_slice())
+                .await?;
+
+            // Create a reverting transaction
+            let tx_request = OpTypedTransaction::Eip1559(TxEip1559 {
+                chain_id: 901,
+                nonce: nonce + 1,
+                gas_limit: 300000,
+                max_fee_per_gas: base_fee.into(),
+                input: hex!("60006000fd").into(), // PUSH1 0x00 PUSH1 0x00 REVERT
+                ..Default::default()
+            });
+            let signed_tx = known_wallet.sign_tx(tx_request)?;
+            let reverting_tx = provider
+                .send_raw_transaction(signed_tx.encoded_2718().as_slice())
+                .await?;
+
+            let block_hash = generator.generate_block().await?;
+
+            // query the block and the transactions inside the block
+            let block = provider
+                .get_block_by_hash(block_hash, BlockTransactionsKind::Hashes)
+                .await?
+                .expect("block");
+
+            // Verify known transaction is included
+            assert!(
+                block
+                    .transactions
+                    .hashes()
+                    .any(|hash| hash == *known_tx.tx_hash()),
+                "successful transaction missing from block"
+            );
+
+            // Verify reverted transaction is NOT included
+            assert!(
+                !block
+                    .transactions
+                    .hashes()
+                    .any(|hash| hash == *reverting_tx.tx_hash()),
+                "reverted transaction unexpectedly included in block"
+            );
+            for hash in block.transactions.hashes() {
+                let receipt = provider
+                    .get_transaction_receipt(hash)
+                    .await?
+                    .expect("receipt");
+                let success = receipt.inner.inner.status();
+                assert!(success);
+            }
+            base_fee = max(
+                block.header.base_fee_per_gas.unwrap(),
+                MIN_PROTOCOL_BASE_FEE,
+            );
+        }
 
         Ok(())
     }

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -1091,16 +1091,8 @@ where
                 num_txs_simulated_success += 1;
             } else {
                 num_txs_simulated_fail += 1;
+                continue;
             }
-            self.metrics
-                .payload_num_tx_simulated
-                .record(num_txs_simulated as f64);
-            self.metrics
-                .payload_num_tx_simulated_success
-                .record(num_txs_simulated_success as f64);
-            self.metrics
-                .payload_num_tx_simulated_fail
-                .record(num_txs_simulated_fail as f64);
 
             // commit changes
             evm.db_mut().commit(state);
@@ -1132,6 +1124,15 @@ where
         self.metrics
             .payload_num_tx_considered
             .record(num_txs_considered as f64);
+        self.metrics
+            .payload_num_tx_simulated
+            .record(num_txs_simulated as f64);
+        self.metrics
+            .payload_num_tx_simulated_success
+            .record(num_txs_simulated_success as f64);
+        self.metrics
+            .payload_num_tx_simulated_fail
+            .record(num_txs_simulated_fail as f64);
 
         Ok(None)
     }

--- a/crates/op-rbuilder/src/tester/mod.rs
+++ b/crates/op-rbuilder/src/tester/mod.rs
@@ -12,6 +12,7 @@ use alloy_rpc_types_engine::ExecutionPayloadV2;
 use alloy_rpc_types_engine::PayloadAttributes;
 use alloy_rpc_types_engine::PayloadStatusEnum;
 use alloy_rpc_types_engine::{ExecutionPayloadV3, ForkchoiceUpdated, PayloadStatus};
+use alloy_rpc_types_eth::Block;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::http_client::{transport::HttpBackend, HttpClient};
 use jsonrpsee::proc_macros::rpc;
@@ -212,7 +213,7 @@ impl<'a> BlockGenerator<'a> {
     }
 
     /// Initialize the block generator by fetching the latest block
-    pub async fn init(&mut self) -> eyre::Result<()> {
+    pub async fn init(&mut self) -> eyre::Result<Block> {
         let latest_block = self.engine_api.latest().await?.expect("block not found");
         self.latest_hash = latest_block.header.hash;
 
@@ -221,7 +222,7 @@ impl<'a> BlockGenerator<'a> {
             self.sync_validation_node(validation_api).await?;
         }
 
-        Ok(())
+        Ok(latest_block)
     }
 
     /// Sync the validation node to the current state

--- a/crates/rbuilder/benches/benchmarks/txpool_fetcher.rs
+++ b/crates/rbuilder/benches/benchmarks/txpool_fetcher.rs
@@ -1,7 +1,7 @@
 use alloy_network::{EthereumWallet, TransactionBuilder};
 use alloy_node_bindings::Anvil;
 use alloy_primitives::U256;
-use alloy_provider::{Provider, ProviderBuilder};
+use alloy_provider::ProviderBuilder;
 use alloy_rpc_types::TransactionRequest;
 use alloy_signer_local::PrivateKeySigner;
 use criterion::{criterion_group, Criterion};


### PR DESCRIPTION
## 📝 Summary

Adds revert protection and integration tests to the transactions in the payload builder of the op-rbuilder.

## 💡 Motivation and Context


---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
