### PR TITLE
fix(playground): Use required root_hash options

### DIFF
--- a/config-playground.toml
+++ b/config-playground.toml
@@ -7,3 +7,6 @@ live_builders = ["mgp-ordering"]
 enabled_relays = ["playground"]
 log_level = "info,rbuilder=debug"
 coinbase_secret_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+root_hash_use_sparse_trie=true
+root_hash_compare_sparse_trie=false


### PR DESCRIPTION
## 📝 Summary

As part of #429 the check was added to prevent start-up if the `root_hash_use_sparse_trie` and `root_hash_compare_sparse_trie` values weren't set correctly.  This updates those values for the playground (I'm not sure if we want to update other config examples as well).

## 💡 Motivation and Context

Without this change `cargo run --bin rbuilder run config-playground.toml` (correctly) fails with:

```
Error: root_hash_use_sparse_trie=true and root_hash_compare_sparse_trie=false must be set, otherwise node will produce incorrect blocks or confusing error messages. These settings are enforced temporarily because upstream parallel root hash implementation is not correct.

Location:
    crates/rbuilder/src/live_builder/base_config.rs:303:13
```

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
