### PR TITLE
fix(reth-builder): Remove duplicate engine extra arguments.

### DIFF
--- a/crates/reth-rbuilder/src/main.rs
+++ b/crates/reth-rbuilder/src/main.rs
@@ -16,7 +16,6 @@ use reth::{
     cli::Cli,
     primitives::Header,
 };
-use reth_node_builder::{engine_tree_config::TreeConfig, EngineNodeLauncher};
 use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
 use reth_provider::{
     providers::BlockchainProvider, BlockReader, ChainSpecProvider, DatabaseProviderFactory,
@@ -25,7 +24,7 @@ use reth_provider::{
 use reth_transaction_pool::{blobstore::DiskFileBlobStore, EthTransactionPool};
 use std::{path::PathBuf, process};
 use tokio::task;
-use tracing::{error, info, warn};
+use tracing::error;
 
 // Prefer jemalloc for performance reasons.
 #[cfg(all(feature = "jemalloc", unix))]
@@ -37,33 +36,6 @@ pub struct ExtraArgs {
     /// Path of the rbuilder config to use
     #[arg(long = "rbuilder.config")]
     pub rbuilder_config: PathBuf,
-
-    /// Enable the experimental engine features on reth binary
-    ///
-    /// DEPRECATED: experimental engine is default now, use --engine.legacy to enable the legacy
-    /// functionality
-    #[arg(long = "engine.experimental", default_value = "false")]
-    pub experimental: bool,
-
-    /// Enable the legacy engine on reth binary
-    #[arg(long = "engine.legacy", default_value = "false")]
-    pub legacy: bool,
-
-    /// Configure persistence threshold for engine experimental.
-    #[arg(
-        long = "engine.persistence-threshold",
-        conflicts_with = "legacy",
-        default_value_t = 0
-    )]
-    pub persistence_threshold: u64,
-
-    /// Configure the target number of blocks to keep in memory.
-    #[arg(
-        long = "engine.memory-block-buffer-target",
-        conflicts_with = "legacy",
-        default_value_t = 0
-    )]
-    pub memory_block_buffer_target: u64,
 }
 
 fn main() {
@@ -76,49 +48,21 @@ fn main() {
 
     if let Err(err) =
         Cli::<EthereumChainSpecParser, ExtraArgs>::parse().run(|builder, extra_args| async move {
-            if extra_args.experimental {
-                warn!(target: "reth::cli", "Experimental engine is default now, and the --engine.experimental flag is deprecated. To enable the legacy functionality, use --engine.legacy.");
-            }
-
-            let use_legacy_engine = extra_args.legacy;
-            match use_legacy_engine {
-                false => {
-                    let engine_tree_config = TreeConfig::default()
-                        .with_persistence_threshold(extra_args.persistence_threshold)
-                        .with_memory_block_buffer_target(extra_args.memory_block_buffer_target);
-                    let handle = builder
-                        .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
-                        .with_components(EthereumNode::components())
-                        .with_add_ons(EthereumAddOns::default())
-                        .on_node_started(move |node| {
-                            spawn_rbuilder(node.provider().clone(), node.pool().clone(), extra_args.rbuilder_config);
-                            Ok(())
-                        })
-                        .launch_with_fn(|builder| {
-                            let launcher = EngineNodeLauncher::new(
-                                builder.task_executor().clone(),
-                                builder.config().datadir(),
-                                engine_tree_config,
-                            );
-                            builder.launch_with(launcher)
-                        })
-                        .await?;
-                    handle.node_exit_future.await
-                }
-                true => {
-                    info!(target: "reth::cli", "Running with legacy engine");
-                    let handle = builder
-                        .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
-                        .with_components(EthereumNode::components())
-                        .with_add_ons::<EthereumAddOns<_>>(Default::default())
-                        .on_node_started(move |node| {
-                            spawn_rbuilder(node.provider().clone(), node.pool().clone(), extra_args.rbuilder_config);
-                            Ok(())
-                        })
-                        .launch().await?;
-                    handle.node_exit_future.await
-                }
-            }
+            let handle = builder
+                .with_types_and_provider::<EthereumNode, BlockchainProvider<_>>()
+                .with_components(EthereumNode::components())
+                .with_add_ons(EthereumAddOns::default())
+                .on_node_started(move |node| {
+                    spawn_rbuilder(
+                        node.provider().clone(),
+                        node.pool().clone(),
+                        extra_args.rbuilder_config,
+                    );
+                    Ok(())
+                })
+                .launch()
+                .await?;
+            handle.node_exit_future.await
         })
     {
         eprintln!("Error: {err:?}");


### PR DESCRIPTION
## 📝 Summary

This issue with #429 was found during devnet-6 testing.  Cherry picking this from #434.

![image](https://github.com/user-attachments/assets/09553b62-8a66-4259-99c2-bdbadbfb8e43)


## 💡 Motivation and Context

This fixes `reth-rbuilder` which is used by EF DevOps for devnets and kurtosis.

Longer term, we probably want to juse force reth to use the required values of `0` for `engine.persistence-threshold` and `engine.memory-block-buffer-target`.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
