### PR TITLE
Improved readme and config-live-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Example of how to use test relay:
 ```
 For relay flag, instead of Holesky, you can use:
 
-- [https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net/](https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net/)
-- [https://boost-relay-sepolia.flashbots.net/](https://boost-relay-sepolia.flashbots.net/)
+- Mainnet: [https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net/](https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net/)
+- Sepolia: [https://boost-relay-sepolia.flashbots.net/](https://boost-relay-sepolia.flashbots.net/)
 
-When validation-url is passed, the block produced by the `rbuilder` is validated by the EL node which must support Flashbots validation API (e.g. `flashbots_validateBuilderSubmissionV3`)
+When validation-url is passed, blocks produced by the `rbuilder` are validated by the EL node. This node must support Flashbots validation API (e.g. `flashbots_validateBuilderSubmissionV3`).
 
 For rbuilder to use fake (`test-relay`), config.toml must include it as (one of) the relays. Example:
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,30 @@ This repo includes a `test-relay` tool for testing live builders without submitt
 
 The test relay exposes several Prometheus metrics about the blocks it received.
 
+Example of how to use test relay:
+
+```bash
+./test-relay \
+    --relay "https://boost-relay-holesky.flashbots.net" \
+    --validation-url "http://localhost:8545" \
+    --cl-clients "http://localhost:5052" 
+```
+For relay flag, instead of Holesky, you can use:
+
+- [https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net/](https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net/)
+- [https://boost-relay-sepolia.flashbots.net/](https://boost-relay-sepolia.flashbots.net/)
+
+When validation-url is passed, the block produced by the `rbuilder` is validated by the EL node which must support Flashbots validation API (e.g. `flashbots_validateBuilderSubmissionV3`)
+
+For rbuilder to use fake (`test-relay`), config.toml must include it as (one of) the relays. Example:
+
+```TOML
+[[relays]]
+name = "flashbots-test"
+url = "http://localhost:80"
+priority = 0
+```
+
 ### End-to-end local testing
 
 You can use [builder-playground](https://github.com/flashbots/builder-playground) to deploy a fully functional local setup for the builder ([Lighthouse](https://github.com/sigp/lighthouse) consensus client (proposer + validator) + [Reth](https://github.com/paradigmxyz/reth/) execution client + [MEV-Boost-Relay](https://github.com/flashbots/mev-boost-relay))) to test rbuilder.

--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -24,12 +24,21 @@ blocklist_file_path = "./blocklist.json"
 
 ignore_cancellable_orders = true
 
+# watchdog_timeout_sec = 600
+# simulation_threads = 4
+
 # genesis_fork_version = "0x00112233"
 
 sbundle_mergeable_signers = []
-live_builders = ["mp-ordering", "mgp-ordering", "merging"]
+live_builders = ["mp-ordering", "mgp-ordering", "parallel"]
 
 enabled_relays = ["flashbots"]
+
+# This can be used with test-relay
+# [[relays]]
+# name = "flashbots_test"
+# url = "http://localhost:80"
+# priority = 0
 
 [[builders]]
 name = "mgp-ordering"


### PR DESCRIPTION
## 📝 Summary

As title suggests, the PR ads small improvements to README and `config-live-example.toml` 

## 💡 Motivation and Context

Motivation was to make it easier for newcomers to use `rbuilder`

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
