### PR TITLE
Interop support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,13 +101,13 @@ version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18c5c520273946ecf715c0010b4e3503d7eba9893cd9ce6b7fff5654c4a3c470"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "arbitrary",
  "num_enum",
  "proptest",
  "serde",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4138dc275554afa6f18c4217262ac9388790b2fc393c2dfe03c51d357abf013"
 dependencies = [
  "alloy-eips 0.9.2",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-serde 0.9.2",
  "alloy-trie",
@@ -134,7 +134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-serde 0.11.1",
  "alloy-trie",
@@ -148,6 +148,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-consensus"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84efb7b8ddb9223346bfad9d8094e1a100c254037a3b5913243bfa8e04be266"
+dependencies = [
+ "alloy-eips 0.12.5",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "alloy-serde 0.12.5",
+ "alloy-trie",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 2.0.1",
+ "either",
+ "k256 0.13.4",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "alloy-consensus-any"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,7 +177,7 @@ checksum = "0fa04e1882c31288ce1028fdf31b6ea94cfa9eafa2e497f903ded631c8c6a42c"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
 ]
 
@@ -167,7 +189,7 @@ checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-serde 0.11.1",
  "serde",
@@ -180,7 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "555896f0b8578adb522b1453b6e6cc6704c3027bd0af20058befdde992cee8e9"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
@@ -197,7 +219,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "arbitrary",
  "crc",
@@ -212,7 +234,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "arbitrary",
  "rand 0.8.5",
@@ -221,18 +243,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabf647eb4650c91a9d38cb6f972bb320009e7e9d61765fb688a86f1563b33e8"
+checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "arbitrary",
- "derive_more 1.0.0",
  "k256 0.13.4",
  "rand 0.8.5",
  "serde",
  "serde_with",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -243,7 +265,7 @@ checksum = "52dd5869ed09e399003e0e0ec6903d981b2a92e74c5d37e6b40890bad2517526"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-serde 0.9.2",
  "c-kzg",
@@ -262,7 +284,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-serde 0.11.1",
  "arbitrary",
@@ -277,13 +299,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eips"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4bffedaddc627520eabdcbfe27a2d2c2f716e15295e2ed1010df3feae67040"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "alloy-serde 0.12.5",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 2.0.1",
+ "either",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "alloy-genesis"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cded3a2d4bd7173f696458c5d4c98c18a628dfcc9f194385e80a486e412e2e0"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-serde 0.11.1",
  "alloy-trie",
  "serde",
@@ -291,11 +333,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4012581681b186ba0882007ed873987cc37f86b1b488fe6b91d5efd0b585dc41"
+checksum = "ec80745c33797e8baf547a8cfeb850e60d837fe9b9e67b3f579c1fcd26f527e9"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -307,7 +349,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-sol-types",
  "serde",
  "serde_json",
@@ -326,7 +368,7 @@ dependencies = [
  "alloy-eips 0.11.1",
  "alloy-json-rpc",
  "alloy-network-primitives 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
@@ -348,7 +390,7 @@ checksum = "f31c3c6b71340a1d076831823f09cb6e02de01de5c6630a9631bdb36f947ff80"
 dependencies = [
  "alloy-consensus 0.9.2",
  "alloy-eips 0.9.2",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-serde 0.9.2",
  "serde",
 ]
@@ -361,7 +403,7 @@ checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-serde 0.11.1",
  "serde",
 ]
@@ -374,7 +416,7 @@ checksum = "81a3906afb50446392eb798dae4b918ba4ffcca47542efda7215776ddc8b5037"
 dependencies = [
  "alloy-genesis",
  "alloy-network",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-signer",
  "alloy-signer-local",
  "k256 0.13.4",
@@ -410,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478bedf4d24e71ea48428d1bc278553bd7c6ae07c30ca063beb0b09fe58a9e74"
+checksum = "eacedba97e65cdc7ab592f2b22ef5d3ab8d60b2056bc3a6e6363577e8270ec6f"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -420,7 +462,7 @@ dependencies = [
  "cfg-if",
  "const-hex",
  "derive_arbitrary",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "foldhash",
  "getrandom 0.2.15",
  "hashbrown 0.15.2",
@@ -451,7 +493,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth 0.11.1",
@@ -486,7 +528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3a68996f193f542f9e29c88dfa8ed1369d6ee04fa764c1bf23dc11b2f9e4a2"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-transport",
  "bimap",
  "futures",
@@ -500,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542548a609dca89fcd72b3b9f355928cf844d4363c5eed9c5273a3dd225e097"
+checksum = "3d6c1d995bff8d011f7cd6c81820d51825e6e06d6db73914c1630ecf544d83d6"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -511,13 +553,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a833d97bf8a5f0f878daf2c8451fff7de7f9de38baa5a45d936ec718d81255a"
+checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -527,7 +569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b37cc3c7883dc41be1b01460127ad7930466d0a4bb6ba15a02ee34d2745e2d7c"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -552,8 +594,8 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f18e68a3882f372e045ddc89eb455469347767d17878ca492cfbac81e71a111"
 dependencies = [
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
  "serde",
@@ -566,7 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4e30339fff15d53a3a258a7add476c7d24b61d6f4a71476cc39c8b567666772"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "serde",
  "serde_json",
 ]
@@ -577,7 +619,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d06300df4a87d960add35909240fc72da355dd2ac926fa6999f9efafbdc5a7"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
  "serde",
@@ -601,8 +643,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799103aa44270c7bea076ec5d3d7b6c6d29557ab5485c91a74d3068327adb485"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "serde",
@@ -616,7 +658,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2834b7012054cb2f90ee9893b7cc97702edca340ec1ef386c30c42e55e6cd691"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "serde",
 ]
 
@@ -628,7 +670,7 @@ checksum = "e83dde9fcf1ccb9b815cc0c89bba26bbbbaae5150a53ae624ed0fc63cb3676c1"
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-serde 0.11.1",
  "derive_more 1.0.0",
@@ -638,7 +680,24 @@ dependencies = [
  "jsonwebtoken",
  "rand 0.8.5",
  "serde",
- "strum",
+ "strum 0.26.3",
+]
+
+[[package]]
+name = "alloy-rpc-types-engine"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a1a0710dbfbab2b33200ef45c650963d63edf6a81b2c7399ede762b3586dfd"
+dependencies = [
+ "alloy-consensus 0.12.5",
+ "alloy-eips 0.12.5",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "alloy-serde 0.12.5",
+ "derive_more 2.0.1",
+ "rand 0.8.5",
+ "serde",
+ "strum 0.27.1",
 ]
 
 [[package]]
@@ -651,7 +710,7 @@ dependencies = [
  "alloy-consensus-any 0.9.2",
  "alloy-eips 0.9.2",
  "alloy-network-primitives 0.9.2",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-serde 0.9.2",
  "alloy-sol-types",
@@ -671,7 +730,7 @@ dependencies = [
  "alloy-consensus-any 0.11.1",
  "alloy-eips 0.11.1",
  "alloy-network-primitives 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-serde 0.11.1",
  "alloy-sol-types",
@@ -690,7 +749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418eb6584edd695dfe496dda85a19102c1ae4838f142efce11e2463ed2288d71"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
  "serde",
@@ -703,7 +762,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd38207e056cc7d1372367fbb4560ddf9107cbd20731743f641246bf0dede149"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.9.2",
  "alloy-serde 0.9.2",
  "serde",
@@ -717,7 +776,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd951155515fa452a2ca4b5434d4b3ab742bcd3d1d1b9a91704bcef5b8d2604"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
  "serde",
@@ -731,7 +790,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21d8dd5bd94993eda3d56a8c4c0d693548183a35462523ffc4385c0b020d3b0c"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
  "serde",
@@ -743,7 +802,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afa753a97002a33b2ccb707d9f15f31c81b8c1b786c95b73cc62bb1d1fd0c3f"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "serde",
  "serde_json",
 ]
@@ -754,7 +813,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae0465c71d4dced7525f408d84873aeebb71faf807d22d74c4a426430ccd9b55"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "serde",
  "serde_json",
 ]
@@ -765,8 +824,19 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "arbitrary",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9824e1bf92cd7848ca6fabb01c9aca15c9c5fb0ab96da5514ef0543f021c69f6"
+dependencies = [
+ "alloy-primitives 0.8.23",
  "serde",
  "serde_json",
 ]
@@ -777,7 +847,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f96b3526fdd779a4bd0f37319cfb4172db52a7ac24cdbb8804b72091c18e1701"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "async-trait",
  "auto_impl",
  "either",
@@ -794,7 +864,7 @@ checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-network",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-signer",
  "async-trait",
  "k256 0.13.4",
@@ -804,23 +874,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2708e27f58d747423ae21d31b7a6625159bd8d867470ddd0256f396a68efa11"
+checksum = "3637022e781bc73a9e300689cd91105a0e6be00391dd4e2110a71cc7e9f20a94"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b7984d7e085dec382d2c5ef022b533fcdb1fe6129200af30ebf5afddb6a361"
+checksum = "3b9bd22d0bba90e40f40c625c33d39afb7d62b22192476a2ce1dcf8409dce880"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -829,31 +899,32 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d6a9fc4ed1a3c70bdb2357bec3924551c1a59f24e5a04a74472c755b37f87d"
+checksum = "05ae4646e8123ec2fd10f9c22e361ffe4365c42811431829c2eabae528546bcc"
 dependencies = [
  "const-hex",
  "dunce",
  "heck 0.5.0",
+ "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b3e9a48a6dd7bb052a111c8d93b5afc7956ed5e2cb4177793dc63bb1d2a36"
+checksum = "488a747fdcefeec5c1ed5aa9e08becd775106777fdeae2a35730729fc8a95910"
 dependencies = [
  "serde",
  "winnow 0.7.2",
@@ -861,12 +932,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6044800da35c38118fd4b98e18306bd3b91af5dedeb54c1b768cf1b4fb68f549"
+checksum = "767957235807b021126dca1598ac3ef477007eace07961607dc5f490550909c7"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -950,7 +1021,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "arbitrary",
  "arrayvec",
@@ -1051,7 +1122,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1310,7 +1381,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1346,18 +1417,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1415,7 +1486,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1649,7 +1720,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.95",
+ "syn 2.0.100",
  "which",
 ]
 
@@ -1668,7 +1739,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1864,7 +1935,7 @@ checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
  "synstructure 0.13.1",
 ]
 
@@ -2028,7 +2099,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2292,7 +2363,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2342,7 +2413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
 dependencies = [
  "crossterm",
- "strum",
+ "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width 0.2.0",
 ]
@@ -2718,7 +2789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2749,7 +2820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2785,7 +2856,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2809,7 +2880,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2820,7 +2891,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2943,7 +3014,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2956,7 +3027,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2965,7 +3036,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -2977,7 +3057,19 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
  "unicode-xid",
 ]
 
@@ -3091,7 +3183,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3205,9 +3297,9 @@ checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
@@ -3321,7 +3413,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3333,7 +3425,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3344,7 +3436,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3387,7 +3479,7 @@ dependencies = [
 name = "eth-sparse-mpt"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-trie",
  "criterion 0.4.0",
@@ -3494,7 +3586,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70cbccfccf81d67bff0ab36e591fa536c8a935b078a7b0e58c1d00d418332fc9"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "hex",
  "serde",
  "serde_derive",
@@ -3507,7 +3599,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfbba28f4f3f32d92c06a64f5bf6c4537b5d4e21f28c689bd2bbaecfea4e0d3e"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "derivative",
  "ethereum_serde_utils",
  "itertools 0.13.0",
@@ -3526,7 +3618,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3549,7 +3641,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.26.3",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -3874,7 +3966,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3997,8 +4089,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -4864,7 +4958,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5056,7 +5150,7 @@ dependencies = [
  "pretty_assertions",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5216,10 +5310,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -5243,9 +5338,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
+checksum = "834af00800e962dee8f7bfc0f60601de215e73e78e5497d733a2919da837d3c8"
 dependencies = [
  "jsonrpsee-client-transport 0.24.7",
  "jsonrpsee-core 0.24.7",
@@ -5428,7 +5523,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5614,6 +5709,112 @@ checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
+]
+
+[[package]]
+name = "kona-genesis"
+version = "0.2.4"
+source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+dependencies = [
+ "alloy-consensus 0.12.5",
+ "alloy-eips 0.12.5",
+ "alloy-primitives 0.8.23",
+ "alloy-sol-types",
+ "derive_more 2.0.1",
+ "kona-serde",
+ "serde",
+ "serde_repr",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "kona-interop"
+version = "0.2.4"
+source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+dependencies = [
+ "alloy-consensus 0.12.5",
+ "alloy-eips 0.12.5",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "alloy-sol-types",
+ "async-trait",
+ "derive_more 2.0.1",
+ "kona-genesis",
+ "kona-registry",
+ "op-alloy-consensus 0.11.1",
+ "serde",
+ "thiserror 2.0.11",
+ "tracing",
+]
+
+[[package]]
+name = "kona-protocol"
+version = "0.2.4"
+source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloy-consensus 0.12.5",
+ "alloy-eips 0.12.5",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "alloy-serde 0.12.5",
+ "async-trait",
+ "brotli 7.0.0",
+ "kona-genesis",
+ "miniz_oxide",
+ "op-alloy-consensus 0.11.1",
+ "op-alloy-flz 0.11.1",
+ "rand 0.9.0",
+ "serde",
+ "thiserror 2.0.11",
+ "tracing",
+ "tracing-subscriber",
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "kona-registry"
+version = "0.2.4"
+source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+dependencies = [
+ "alloy-chains",
+ "alloy-primitives 0.8.23",
+ "kona-genesis",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "toml 0.8.19",
+]
+
+[[package]]
+name = "kona-rpc"
+version = "0.1.1"
+source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+dependencies = [
+ "alloy-eips 0.12.5",
+ "alloy-primitives 0.8.23",
+ "async-trait",
+ "derive_more 2.0.1",
+ "getrandom 0.3.1",
+ "jsonrpsee 0.24.8",
+ "kona-genesis",
+ "kona-interop",
+ "kona-protocol",
+ "op-alloy-rpc-jsonrpsee 0.11.1",
+ "op-alloy-rpc-types-engine 0.11.1",
+ "serde",
+ "thiserror 2.0.11",
+ "tokio",
+]
+
+[[package]]
+name = "kona-serde"
+version = "0.1.1"
+source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+dependencies = [
+ "alloy-primitives 0.8.23",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5999,6 +6200,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6116,7 +6328,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6189,7 +6401,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6250,9 +6462,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -6306,7 +6518,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6715,7 +6927,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -6780,7 +6992,7 @@ checksum = "23f7ff02e5f3ba62c8dd5d9a630c818f50147bca7b0d78e89de59ed46b5d02e1"
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-serde 0.11.1",
  "arbitrary",
@@ -6791,10 +7003,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "op-alloy-consensus"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5099f9c3a41a313dd5f7fe7657545d972781e53d70c62976858aba8dac9eef"
+dependencies = [
+ "alloy-consensus 0.12.5",
+ "alloy-eips 0.12.5",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "alloy-serde 0.12.5",
+ "derive_more 1.0.0",
+ "serde",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "op-alloy-flz"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740324977f089db5b2cd96975260308c3f52daeaa103570995211748d282e560"
+
+[[package]]
+name = "op-alloy-flz"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e131899557f463480ed72be8f784abfda198204d4fc17fa96dc587faf2898a62"
 
 [[package]]
 name = "op-alloy-network"
@@ -6804,10 +7038,10 @@ checksum = "eab4dd4e260be40a7ab8debf5300baf1f02f1d2a6e0c1ab5741732d612de7d6e"
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-network",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-signer",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "op-alloy-rpc-types",
 ]
 
@@ -6817,8 +7051,18 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "725e79490887d768e5f22badf93d8c8d12349aca6db63a050acb3472f2535e6c"
 dependencies = [
- "alloy-primitives 0.8.21",
- "jsonrpsee 0.24.7",
+ "alloy-primitives 0.8.23",
+ "jsonrpsee 0.24.8",
+]
+
+[[package]]
+name = "op-alloy-rpc-jsonrpsee"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ad24013146aecff6fb5cc5f3ed2273830b79a1b12c1bad0bdd76e2f5fe43c6"
+dependencies = [
+ "alloy-primitives 0.8.23",
+ "jsonrpsee 0.24.8",
 ]
 
 [[package]]
@@ -6830,11 +7074,11 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
  "alloy-network-primitives 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
  "derive_more 1.0.0",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "serde",
  "serde_json",
 ]
@@ -6847,14 +7091,31 @@ checksum = "20120c629465e52e5cdb0ac8df0ba45e184b456fcd55d17ea9ec1247d6968bb4"
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "alloy-serde 0.11.1",
  "derive_more 1.0.0",
  "ethereum_ssz",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "serde",
  "snap",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "op-alloy-rpc-types-engine"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e829ee4a0f373132258ccdce71ed1984cdbf7df83ab928522997ee79943879c2"
+dependencies = [
+ "alloy-consensus 0.12.5",
+ "alloy-eips 0.12.5",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.12.5",
+ "alloy-serde 0.12.5",
+ "derive_more 1.0.0",
+ "op-alloy-consensus 0.11.1",
+ "serde",
  "thiserror 2.0.11",
 ]
 
@@ -6865,11 +7126,11 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
  "alloy-network",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types-beacon",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.7.3",
  "alloy-transport",
@@ -6881,11 +7142,13 @@ dependencies = [
  "derive_more 1.0.0",
  "eyre",
  "futures-util",
- "jsonrpsee 0.24.7",
+ "jsonrpsee 0.24.8",
+ "kona-interop",
+ "kona-rpc",
  "metrics",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "op-alloy-network",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types-engine 0.10.3",
  "rand 0.8.5",
  "reth",
  "reth-basic-payload-builder",
@@ -6934,6 +7197,7 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
@@ -6991,7 +7255,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7363,7 +7627,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7401,7 +7665,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7836,7 +8100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
 dependencies = [
  "proc-macro2",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7935,7 +8199,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -8048,7 +8312,7 @@ checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -8071,7 +8335,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -8334,7 +8598,7 @@ dependencies = [
  "itertools 0.13.0",
  "lru 0.12.5",
  "paste",
- "strum",
+ "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-segmentation",
  "unicode-truncate",
@@ -8382,13 +8646,13 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives 0.11.1",
  "alloy-node-bindings",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
  "alloy-signer-local",
@@ -8691,7 +8955,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types",
  "aquamarine",
@@ -8762,7 +9026,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "futures-core",
  "futures-util",
  "metrics",
@@ -8789,7 +9053,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-signer",
  "alloy-signer-local",
  "derive_more 1.0.0",
@@ -8820,7 +9084,7 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
  "alloy-genesis",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-trie",
  "auto_impl",
  "derive_more 1.0.0",
@@ -8852,7 +9116,7 @@ dependencies = [
  "ahash",
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "backon",
  "clap 4.5.21",
@@ -8922,7 +9186,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "cfg-if",
  "eyre",
  "libc",
@@ -8942,12 +9206,12 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
  "alloy-genesis",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-trie",
  "arbitrary",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "reth-codecs-derive",
  "serde",
  "visibility",
@@ -8961,7 +9225,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -8985,7 +9249,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "auto_impl",
  "derive_more 1.0.0",
  "reth-primitives-traits",
@@ -8998,7 +9262,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -9011,9 +9275,9 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-provider",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "alloy-rpc-types-eth 0.11.1",
  "auto_impl",
  "eyre",
@@ -9034,7 +9298,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-consensus 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "bytes",
  "derive_more 1.0.0",
  "eyre",
@@ -9055,7 +9319,7 @@ dependencies = [
  "reth-trie-common",
  "rustc-hash 2.1.0",
  "serde",
- "strum",
+ "strum 0.26.3",
  "sysinfo 0.32.1",
  "tempfile",
  "thiserror 2.0.11",
@@ -9068,7 +9332,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-genesis",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "arbitrary",
  "bytes",
  "derive_more 1.0.0",
@@ -9096,7 +9360,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-genesis",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
@@ -9124,7 +9388,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -9139,7 +9403,7 @@ name = "reth-discv4"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "discv5",
  "enr 0.12.1",
@@ -9165,7 +9429,7 @@ name = "reth-discv5"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "derive_more 1.0.0",
  "discv5",
@@ -9189,7 +9453,7 @@ name = "reth-dns-discovery"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "data-encoding",
  "enr 0.12.1",
  "hickory-resolver",
@@ -9215,7 +9479,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "futures",
  "futures-util",
@@ -9247,7 +9511,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "aes",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "block-padding",
  "byteorder",
@@ -9278,11 +9542,11 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-consensus 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "eyre",
  "futures-util",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types-engine 0.10.3",
  "reth-chainspec",
  "reth-consensus",
  "reth-engine-primitives",
@@ -9310,8 +9574,8 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "auto_impl",
  "futures",
  "reth-chain-state",
@@ -9357,9 +9621,9 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "derive_more 1.0.0",
  "futures",
  "metrics",
@@ -9400,8 +9664,8 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "eyre",
  "futures",
  "itertools 0.13.0",
@@ -9446,7 +9710,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "bytes",
  "derive_more 1.0.0",
@@ -9476,7 +9740,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "bytes",
  "derive_more 1.0.0",
@@ -9506,7 +9770,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -9521,9 +9785,9 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-payload-primitives",
@@ -9540,7 +9804,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "arbitrary",
  "auto_impl",
  "dyn-clone",
@@ -9556,7 +9820,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-errors",
@@ -9583,7 +9847,7 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
  "alloy-network",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
@@ -9616,7 +9880,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "auto_impl",
  "futures-util",
  "metrics",
@@ -9642,7 +9906,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-sol-types",
  "derive_more 1.0.0",
  "reth-chainspec",
@@ -9662,7 +9926,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
@@ -9676,7 +9940,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "reth-execution-errors",
  "reth-primitives",
  "reth-primitives-traits",
@@ -9694,7 +9958,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "eyre",
  "futures",
  "itertools 0.13.0",
@@ -9730,7 +9994,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "reth-chain-state",
  "reth-execution-types",
  "reth-primitives",
@@ -9755,12 +10019,12 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-consensus 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "eyre",
  "futures",
- "jsonrpsee 0.24.7",
+ "jsonrpsee 0.24.8",
  "pretty_assertions",
  "reth-chainspec",
  "reth-engine-primitives",
@@ -9786,7 +10050,7 @@ dependencies = [
  "futures",
  "futures-util",
  "interprocess",
- "jsonrpsee 0.24.7",
+ "jsonrpsee 0.24.8",
  "pin-project",
  "serde_json",
  "thiserror 2.0.11",
@@ -9840,7 +10104,7 @@ name = "reth-net-banlist"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
 ]
 
 [[package]]
@@ -9864,7 +10128,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -9916,7 +10180,7 @@ name = "reth-network-api"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-admin",
  "auto_impl",
  "derive_more 1.0.0",
@@ -9941,7 +10205,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "auto_impl",
  "derive_more 1.0.0",
  "futures",
@@ -9962,7 +10226,7 @@ name = "reth-network-peers"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "enr 0.12.1",
  "secp256k1",
@@ -10008,7 +10272,7 @@ name = "reth-node-api"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "eyre",
  "reth-basic-payload-builder",
  "reth-consensus",
@@ -10034,13 +10298,13 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types",
  "aquamarine",
  "eyre",
  "fdlimit",
  "futures",
- "jsonrpsee 0.24.7",
+ "jsonrpsee 0.24.8",
  "rayon",
  "reth-basic-payload-builder",
  "reth-chain-state",
@@ -10096,8 +10360,8 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "clap 4.5.21",
  "derive_more 1.0.0",
  "dirs-next",
@@ -10131,7 +10395,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "shellexpand",
- "strum",
+ "strum 0.26.3",
  "thiserror 2.0.11",
  "toml 0.8.19",
  "tracing",
@@ -10175,8 +10439,8 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "derive_more 1.0.0",
  "futures",
  "humantime",
@@ -10236,10 +10500,10 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
  "alloy-genesis",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "derive_more 1.0.0",
  "once_cell",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "op-alloy-rpc-types",
  "reth-chainspec",
  "reth-ethereum-forks",
@@ -10257,13 +10521,13 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "clap 4.5.21",
  "derive_more 1.0.0",
  "eyre",
  "futures-util",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",
@@ -10304,9 +10568,9 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-trie",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -10325,9 +10589,9 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "derive_more 1.0.0",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -10352,7 +10616,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "auto_impl",
  "once_cell",
  "reth-ethereum-forks",
@@ -10366,12 +10630,12 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "clap 4.5.21",
  "eyre",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
+ "op-alloy-consensus 0.10.3",
+ "op-alloy-rpc-types-engine 0.10.3",
  "reth-chainspec",
  "reth-consensus",
  "reth-db",
@@ -10413,13 +10677,13 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "derive_more 1.0.0",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
+ "op-alloy-consensus 0.10.3",
+ "op-alloy-rpc-types-engine 0.10.3",
  "reth-basic-payload-builder",
  "reth-chain-state",
  "reth-chainspec",
@@ -10451,7 +10715,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
@@ -10459,7 +10723,7 @@ dependencies = [
  "bytes",
  "derive_more 1.0.0",
  "modular-bitfield",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "proptest",
  "rand 0.8.5",
  "reth-codecs",
@@ -10477,20 +10741,20 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "alloy-rpc-types-eth 0.11.1",
  "async-trait",
  "derive_more 1.0.0",
- "jsonrpsee 0.24.7",
+ "jsonrpsee 0.24.8",
  "jsonrpsee-core 0.24.7",
  "jsonrpsee-types 0.24.7",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "op-alloy-network",
- "op-alloy-rpc-jsonrpsee",
+ "op-alloy-rpc-jsonrpsee 0.10.3",
  "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types-engine 0.10.3",
  "parking_lot",
  "reqwest 0.12.9",
  "reth-chainspec",
@@ -10530,12 +10794,12 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "c-kzg",
  "derive_more 1.0.0",
- "op-alloy-consensus",
- "op-alloy-flz",
+ "op-alloy-consensus 0.10.3",
+ "op-alloy-flz 0.10.3",
  "parking_lot",
  "reth-chainspec",
  "reth-optimism-evm",
@@ -10585,10 +10849,10 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "auto_impl",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types-engine 0.10.3",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -10604,7 +10868,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-consensus 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "reth-transaction-pool",
 ]
 
@@ -10643,7 +10907,7 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
  "alloy-genesis",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-trie",
  "arbitrary",
@@ -10654,7 +10918,7 @@ dependencies = [
  "k256 0.13.4",
  "modular-bitfield",
  "once_cell",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.10.3",
  "proptest",
  "proptest-arbitrary-interop",
  "rayon",
@@ -10673,8 +10937,8 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "auto_impl",
  "dashmap 6.1.0",
  "eyre",
@@ -10706,7 +10970,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "revm",
- "strum",
+ "strum 0.26.3",
  "tokio",
  "tracing",
 ]
@@ -10718,7 +10982,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "itertools 0.13.0",
  "metrics",
  "rayon",
@@ -10745,7 +11009,7 @@ name = "reth-prune-types"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "arbitrary",
  "derive_more 1.0.0",
  "modular-bitfield",
@@ -10780,7 +11044,7 @@ name = "reth-revm"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -10798,13 +11062,13 @@ dependencies = [
  "alloy-eips 0.11.1",
  "alloy-genesis",
  "alloy-network",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace 0.11.1",
@@ -10818,7 +11082,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "hyper 1.5.0",
- "jsonrpsee 0.24.7",
+ "jsonrpsee 0.24.8",
  "jsonwebtoken",
  "parking_lot",
  "pin-project",
@@ -10867,19 +11131,19 @@ dependencies = [
  "alloy-eips 0.11.1",
  "alloy-genesis",
  "alloy-json-rpc",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace 0.11.1",
  "alloy-rpc-types-txpool",
  "alloy-serde 0.11.1",
- "jsonrpsee 0.24.7",
+ "jsonrpsee 0.24.8",
  "reth-engine-primitives",
  "reth-network-peers",
  "reth-rpc-eth-api",
@@ -10893,7 +11157,7 @@ dependencies = [
  "alloy-network",
  "alloy-provider",
  "http 1.1.0",
- "jsonrpsee 0.24.7",
+ "jsonrpsee 0.24.8",
  "metrics",
  "pin-project",
  "reth-chainspec",
@@ -10928,8 +11192,8 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "async-trait",
  "jsonrpsee-core 0.24.7",
  "jsonrpsee-types 0.24.7",
@@ -10962,7 +11226,7 @@ dependencies = [
  "alloy-eips 0.11.1",
  "alloy-json-rpc",
  "alloy-network",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-rpc-types-mev",
@@ -10971,7 +11235,7 @@ dependencies = [
  "auto_impl",
  "dyn-clone",
  "futures",
- "jsonrpsee 0.24.7",
+ "jsonrpsee 0.24.8",
  "jsonrpsee-types 0.24.7",
  "parking_lot",
  "reth-chainspec",
@@ -11003,7 +11267,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-sol-types",
  "derive_more 1.0.0",
@@ -11044,7 +11308,7 @@ name = "reth-rpc-layer"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-rpc-types-engine",
+ "alloy-rpc-types-engine 0.11.1",
  "http 1.1.0",
  "jsonrpsee-http-client 0.24.7",
  "pin-project",
@@ -11059,14 +11323,14 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "jsonrpsee-core 0.24.7",
  "jsonrpsee-types 0.24.7",
  "reth-errors",
  "reth-network-api",
  "serde",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -11075,7 +11339,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-consensus 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "jsonrpsee-types 0.24.7",
  "reth-primitives",
@@ -11090,7 +11354,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "bincode",
  "blake3",
  "futures-util",
@@ -11131,7 +11395,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "aquamarine",
  "auto_impl",
  "futures-util",
@@ -11157,7 +11421,7 @@ name = "reth-stages-types"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -11171,7 +11435,7 @@ name = "reth-static-file"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "parking_lot",
  "rayon",
  "reth-codecs",
@@ -11192,11 +11456,11 @@ name = "reth-static-file-types"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "clap 4.5.21",
  "derive_more 1.0.0",
  "serde",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -11206,8 +11470,8 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "auto_impl",
  "reth-chainspec",
  "reth-db",
@@ -11230,7 +11494,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "derive_more 1.0.0",
  "reth-primitives-traits",
@@ -11265,7 +11529,7 @@ dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
  "alloy-genesis",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "rand 0.8.5",
  "reth-primitives",
  "reth-primitives-traits",
@@ -11304,7 +11568,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -11342,7 +11606,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96a
 dependencies = [
  "alloy-consensus 0.11.1",
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
@@ -11366,7 +11630,7 @@ version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
  "alloy-consensus 0.11.1",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
@@ -11391,7 +11655,7 @@ name = "reth-trie-db"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "derive_more 1.0.0",
  "metrics",
@@ -11412,7 +11676,7 @@ name = "reth-trie-parallel"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "derive_more 1.0.0",
  "itertools 0.13.0",
@@ -11435,7 +11699,7 @@ name = "reth-trie-sparse"
 version = "1.2.2"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.2.2#2f4c509b3d01960f96abf2f9314b7d63db36977b"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rlp",
  "reth-execution-errors",
  "reth-primitives-traits",
@@ -11475,7 +11739,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc873bc873e12a1723493e1a35804fa79b673a0bfb1c19cfee659d46def8be42"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.9.2",
  "alloy-rpc-types-trace 0.9.2",
  "alloy-sol-types",
@@ -11492,7 +11756,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d87cdf1c0d878b48423f8a86232950657abaf72a2d0d14af609467542313b1a"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-rpc-types-trace 0.11.1",
  "alloy-sol-types",
@@ -11544,7 +11808,7 @@ checksum = "f0f987564210317706def498421dfba2ae1af64a8edce82c6102758b48133fcb"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "auto_impl",
  "bitflags 2.6.0",
  "bitvec",
@@ -11685,8 +11949,8 @@ version = "0.1.0"
 source = "git+http://github.com/flashbots/rollup-boost?rev=e74a1fd01366e4ddd13515da4efda59cdc8fbce0#e74a1fd01366e4ddd13515da4efda59cdc8fbce0"
 dependencies = [
  "alloy-eips 0.11.1",
- "alloy-primitives 0.8.21",
- "alloy-rpc-types-engine",
+ "alloy-primitives 0.8.23",
+ "alloy-rpc-types-engine 0.11.1",
  "alloy-rpc-types-eth 0.11.1",
  "alloy-serde 0.11.1",
  "clap 4.5.21",
@@ -11700,7 +11964,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
- "jsonrpsee 0.24.7",
+ "jsonrpsee 0.24.8",
  "lazy_static",
  "lru 0.10.1",
  "metrics",
@@ -11708,9 +11972,9 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util 0.18.0",
- "op-alloy-rpc-jsonrpsee",
+ "op-alloy-rpc-jsonrpsee 0.10.3",
  "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
+ "op-alloy-rpc-types-engine 0.10.3",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -12048,7 +12312,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -12249,29 +12513,29 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "indexmap 2.7.0",
  "itoa",
@@ -12289,6 +12553,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -12339,7 +12614,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -12956,7 +13231,7 @@ name = "ssz_rs"
 version = "0.9.0"
 source = "git+https://github.com/ralexstokes/ssz-rs.git#ec3073e2273b4d0873fcb6df68ff4eff79588e92"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "bitvec",
  "serde",
  "sha2 0.9.9",
@@ -13069,6 +13344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13078,7 +13362,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -13091,7 +13375,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.95",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -13126,9 +13423,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13137,14 +13434,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2de690018098e367beeb793991c7d4dc7270f42c9d2ac4ccc876c1368ca430"
+checksum = "d975606bae72d8aad5b07d9342465e123a2cccf53a5a735aedf81ca92a709ecb"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -13182,7 +13479,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -13230,7 +13527,7 @@ dependencies = [
 name = "sysperf"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "num_cpus",
  "rand 0.8.5",
  "rayon",
@@ -13334,7 +13631,7 @@ dependencies = [
  "ahash",
  "alloy-consensus 0.11.1",
  "alloy-json-rpc",
- "alloy-primitives 0.8.21",
+ "alloy-primitives 0.8.23",
  "alloy-provider",
  "clap 4.5.21",
  "clap_builder",
@@ -13366,7 +13663,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "reqwest 0.11.27",
- "syn 2.0.95",
+ "syn 2.0.100",
  "which",
 ]
 
@@ -13408,7 +13705,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -13419,7 +13716,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -13552,9 +13849,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -13570,13 +13867,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -13820,9 +14117,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -13844,20 +14141,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -13927,9 +14224,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -13937,9 +14234,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -14298,7 +14595,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -14393,27 +14690,27 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -14431,9 +14728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -14441,22 +14738,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -14641,7 +14941,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -14652,7 +14952,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -14663,7 +14963,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -14674,7 +14974,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -14982,7 +15282,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
  "synstructure 0.13.1",
 ]
 
@@ -15013,7 +15313,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -15024,7 +15324,7 @@ checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -15044,7 +15344,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
  "synstructure 0.13.1",
 ]
 
@@ -15065,7 +15365,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -15087,7 +15387,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ ethereum_ssz_derive = "0.8"
 ethereum_ssz = "0.8"
 
 alloy-primitives = { version = "0.8.15", default-features = false }
-alloy-rlp = "0.3.10"
+alloy-rlp = "0.3.11"
 alloy-chains = "0.1.33"
 alloy-provider = { version = "0.11.1", features = ["ipc", "pubsub"] }
 alloy-pubsub = { version = "0.11.1" }
@@ -136,6 +136,10 @@ op-alloy-rpc-types-engine = { version =  "0.10.3", default-features = false }
 op-alloy-rpc-jsonrpsee = { version =  "0.10.3", default-features = false }
 op-alloy-network = { version =  "0.10.3", default-features = false }
 op-alloy-consensus = { version =  "0.10.3", default-features = false }
+
+# kona
+kona-rpc = { git="https://github.com/op-rs/kona", rev="0493d8479e2ca9f0eb6d5c6154e2bedc61de7217", features = ["client", "interop", "jsonrpsee"]}
+kona-interop = { git="https://github.com/op-rs/kona", rev="0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"}
 
 async-trait = { version = "0.1.83" }
 clap = { version = "4.4.3", features = ["derive", "env"] }

--- a/Dockerfile.op-rbuilder
+++ b/Dockerfile.op-rbuilder
@@ -9,7 +9,7 @@
 ARG FEATURES
 ARG RBUILDER_BIN="op-rbuilder"
 
-FROM rust:1.82 AS base
+FROM rust:1.85 AS base
 ARG TARGETPLATFORM
 
 RUN apt-get update \

--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -56,6 +56,10 @@ op-alloy-consensus.workspace = true
 op-alloy-rpc-types-engine.workspace = true
 op-alloy-network.workspace = true
 
+# kona
+kona-rpc = {workspace = true, optional = true}
+kona-interop = {workspace = true, optional = true}
+
 revm.workspace = true
 
 tracing.workspace = true
@@ -85,6 +89,7 @@ alloy-serde = "0.7"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 
 rollup-boost = { git = "http://github.com/flashbots/rollup-boost", rev = "e74a1fd01366e4ddd13515da4efda59cdc8fbce0" }
+url = "2.5.3"
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }
@@ -113,7 +118,7 @@ min-info-logs = ["tracing/release_max_level_info"]
 min-debug-logs = ["tracing/release_max_level_debug"]
 min-trace-logs = ["tracing/release_max_level_trace"]
 
-optimism = ["reth-optimism-node/optimism", "reth-optimism-cli/optimism"]
+optimism = ["reth-optimism-node/optimism", "reth-optimism-cli/optimism", "kona-rpc", "kona-interop"]
 
 integration = []
 flashblocks = []

--- a/crates/op-rbuilder/src/args.rs
+++ b/crates/op-rbuilder/src/args.rs
@@ -44,7 +44,7 @@ pub struct OpRbuilderArgs {
     pub supervisor_url: Option<Url>,
     /// URL of the supervisor service for transaction validation
     #[arg(
-        long = "rollup.supervisor-url",
+        long = "rollup.supervisor_safety_level",
         env = "SUPERVISOR_SAFETY_LEVEL",
         help = "Safety level to pass to supervisor, values: finalized, safe, local-safe, cross-unsafe, unsafe, invalid"
     )]

--- a/crates/op-rbuilder/src/args.rs
+++ b/crates/op-rbuilder/src/args.rs
@@ -6,6 +6,7 @@
 use reth_optimism_node::args::RollupArgs;
 
 use crate::tx_signer::Signer;
+use alloy_transport_http::reqwest::Url;
 
 /// Parameters for rollup configuration
 #[derive(Debug, Clone, Default, PartialEq, Eq, clap::Args)]
@@ -38,7 +39,16 @@ pub struct OpRbuilderArgs {
         env = "FLASHBLOCK_BLOCK_TIME"
     )]
     pub flashblock_block_time: u64,
-
+    /// URL of the supervisor service for transaction validation
+    #[arg(long = "rollup.supervisor-url", env = "SUPERVISOR_URL")]
+    pub supervisor_url: Option<Url>,
+    /// URL of the supervisor service for transaction validation
+    #[arg(
+        long = "rollup.supervisor-url",
+        env = "SUPERVISOR_SAFETY_LEVEL",
+        help = "Safety level to pass to supervisor, values: finalized, safe, local-safe, cross-unsafe, unsafe, invalid"
+    )]
+    pub supervisor_safety_level: Option<String>,
     /// Signals whether to log pool transactions events
     #[arg(long = "builder.log-pool-transactions", default_value = "false")]
     pub log_pool_transactions: bool,

--- a/crates/op-rbuilder/src/lib.rs
+++ b/crates/op-rbuilder/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod integration;
+pub mod primitives;
 pub mod tester;
 pub mod tx_signer;

--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -42,6 +42,8 @@ fn main() {
                     builder_args.flashblocks_ws_url,
                     builder_args.chain_block_time,
                     builder_args.flashblock_block_time,
+                    builder_args.supervisor_url,
+                    builder_args.supervisor_safety_level,
                 )))
                 .with_add_ons(
                     OpAddOnsBuilder::default()

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -44,6 +44,14 @@ pub struct OpRBuilderMetrics {
     pub tx_byte_size: Histogram,
     /// Number of reverted transactions
     pub num_reverted_tx: Counter,
+    /// Number of cross-chain transactions
+    pub num_cross_chain_tx: Counter,
+    /// Number of cross-chain transactions that didn't pass supervisor validation
+    pub num_cross_chain_tx_fail: Counter,
+    /// Number of cross-chain transactions that weren't verified because of the timeout
+    pub num_cross_chain_tx_timeout: Counter,
+    /// Number of cross-chain transactions that weren't verified because of the server error
+    pub num_cross_chain_tx_server_error: Counter,
 }
 
 impl OpRBuilderMetrics {
@@ -69,5 +77,21 @@ impl OpRBuilderMetrics {
 
     pub fn set_builder_balance(&self, balance: f64) {
         self.builder_balance.set(balance);
+    }
+
+    pub fn inc_num_cross_chain_tx_fail(&self) {
+        self.num_cross_chain_tx_fail.increment(1);
+    }
+
+    pub fn inc_num_cross_chain_tx(&self) {
+        self.num_cross_chain_tx.increment(1);
+    }
+
+    pub fn inc_num_cross_chain_tx_timeout(&self) {
+        self.num_cross_chain_tx_timeout.increment(1);
+    }
+
+    pub fn inc_num_cross_chain_tx_server_error(&self) {
+        self.num_cross_chain_tx_server_error.increment(1);
     }
 }

--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -75,6 +75,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
 use tokio_tungstenite::accept_async;
 use tokio_tungstenite::WebSocketStream;
+use url::Url;
 
 use serde::{Deserialize, Serialize};
 
@@ -88,11 +89,15 @@ struct FlashblocksMetadata<N: NodePrimitives> {
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct CustomOpPayloadBuilder {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     builder_signer: Option<Signer>,
     flashblocks_ws_url: String,
     chain_block_time: u64,
     flashblock_block_time: u64,
+    #[expect(dead_code)]
+    supervisor_url: Option<Url>,
+    #[expect(dead_code)]
+    supervisor_safety_level: Option<String>,
 }
 
 impl CustomOpPayloadBuilder {
@@ -101,12 +106,16 @@ impl CustomOpPayloadBuilder {
         flashblocks_ws_url: String,
         chain_block_time: u64,
         flashblock_block_time: u64,
+        supervisor_url: Option<Url>,
+        supervisor_safety_level: Option<String>,
     ) -> Self {
         Self {
             builder_signer,
             flashblocks_ws_url,
             chain_block_time,
             flashblock_block_time,
+            supervisor_url,
+            supervisor_safety_level,
         }
     }
 }

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -1,9 +1,8 @@
-use crate::generator::BlockPayloadJobGenerator;
-use crate::generator::BuildArguments;
 use crate::{
-    generator::{BlockCell, PayloadBuilder},
+    generator::{BlockCell, BlockPayloadJobGenerator, BuildArguments, PayloadBuilder},
     metrics::OpRBuilderMetrics,
     primitives::reth::{ExecutedPayload, ExecutionInfo},
+    primitives::supervisor::SupervisorValidator,
     tx_signer::Signer,
 };
 use alloy_consensus::constants::EMPTY_WITHDRAWALS;
@@ -13,9 +12,12 @@ use alloy_consensus::{
 };
 use alloy_eips::merge::BEACON_NONCE;
 use alloy_primitives::private::alloy_rlp::Encodable;
-use alloy_primitives::{Address, Bytes, TxHash, TxKind, U256};
+use alloy_primitives::{Address, Bytes, TxHash, TxKind, B256, U256};
 use alloy_rpc_types_engine::PayloadId;
 use alloy_rpc_types_eth::Withdrawals;
+use jsonrpsee::http_client::HttpClientBuilder;
+use kona_interop::{ExecutingDescriptor, SafetyLevel};
+use kona_rpc::{InteropTxValidator, InteropTxValidatorError};
 use op_alloy_consensus::{OpDepositReceipt, OpTypedTransaction};
 use reth::builder::{components::PayloadServiceBuilder, node::FullNodeTypes, BuilderContext};
 use reth::core::primitives::InMemorySize;
@@ -76,7 +78,8 @@ use revm::{
 use std::error::Error as StdError;
 use std::{fmt::Display, sync::Arc, time::Instant};
 use tokio_util::sync::CancellationToken;
-use tracing::{info, trace, warn};
+use tracing::{error, info, trace, warn};
+use url::Url;
 
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
@@ -88,6 +91,8 @@ pub struct CustomOpPayloadBuilder {
     chain_block_time: u64,
     #[cfg(feature = "flashblocks")]
     flashblock_block_time: u64,
+    supervisor_url: Option<Url>,
+    supervisor_safety_level: Option<String>,
 }
 
 impl CustomOpPayloadBuilder {
@@ -97,12 +102,16 @@ impl CustomOpPayloadBuilder {
         flashblocks_ws_url: String,
         chain_block_time: u64,
         flashblock_block_time: u64,
+        supervisor_url: Option<Url>,
+        supervisor_safety_level: Option<String>,
     ) -> Self {
         Self {
             builder_signer,
             flashblocks_ws_url,
             chain_block_time,
             flashblock_block_time,
+            supervisor_url,
+            supervisor_safety_level,
         }
     }
 
@@ -112,8 +121,14 @@ impl CustomOpPayloadBuilder {
         _flashblocks_ws_url: String,
         _chain_block_time: u64,
         _flashblock_block_time: u64,
+        supervisor_url: Option<Url>,
+        supervisor_safety_level: Option<String>,
     ) -> Self {
-        Self { builder_signer }
+        Self {
+            builder_signer,
+            supervisor_url,
+            supervisor_safety_level,
+        }
     }
 }
 
@@ -143,6 +158,8 @@ where
             pool,
             ctx.provider().clone(),
             Arc::new(BasicOpReceiptBuilder::default()),
+            self.supervisor_url.clone(),
+            self.supervisor_safety_level.clone(),
         ))
     }
 
@@ -224,6 +241,10 @@ pub struct OpPayloadBuilderVanilla<Pool, Client, EvmConfig, N: NodePrimitives, T
     pub metrics: OpRBuilderMetrics,
     /// Node primitive types.
     pub receipt_builder: Arc<dyn OpReceiptBuilder<N::SignedTx, Receipt = N::Receipt>>,
+    /// Client to execute supervisor validation
+    pub supervisor_client: Option<SupervisorValidator>,
+    /// Level to use in supervisor validation
+    pub supervisor_safety_level: SafetyLevel,
 }
 
 impl<Pool, Client, EvmConfig, N: NodePrimitives>
@@ -236,6 +257,8 @@ impl<Pool, Client, EvmConfig, N: NodePrimitives>
         pool: Pool,
         client: Client,
         receipt_builder: Arc<dyn OpReceiptBuilder<N::SignedTx, Receipt = N::Receipt>>,
+        supervisor_url: Option<Url>,
+        supervisor_safety_level: Option<String>,
     ) -> Self {
         Self::with_builder_config(
             evm_config,
@@ -243,6 +266,8 @@ impl<Pool, Client, EvmConfig, N: NodePrimitives>
             pool,
             client,
             receipt_builder,
+            supervisor_url,
+            supervisor_safety_level,
             Default::default(),
         )
     }
@@ -253,8 +278,22 @@ impl<Pool, Client, EvmConfig, N: NodePrimitives>
         pool: Pool,
         client: Client,
         receipt_builder: Arc<dyn OpReceiptBuilder<N::SignedTx, Receipt = N::Receipt>>,
+        supervisor_url: Option<Url>,
+        supervisor_safety_level: Option<String>,
         config: OpBuilderConfig,
     ) -> Self {
+        let supervisor_client = supervisor_url.map(|url| {
+            SupervisorValidator::new(
+                HttpClientBuilder::default()
+                    .build(url)
+                    .expect("building supervisor http client"),
+            )
+        });
+        let supervisor_safety_level = supervisor_safety_level
+            .map(|level| {
+                serde_json::from_str(level.as_str()).expect("parsing supervisor_safety_level")
+            })
+            .unwrap_or(SafetyLevel::CrossUnsafe);
         Self {
             pool,
             client,
@@ -264,6 +303,8 @@ impl<Pool, Client, EvmConfig, N: NodePrimitives>
             best_transactions: (),
             metrics: Default::default(),
             builder_signer,
+            supervisor_client,
+            supervisor_safety_level,
         }
     }
 }
@@ -297,7 +338,7 @@ where
             },
             |hashes| {
                 #[allow(clippy::unit_arg)]
-                self.best_transactions.remove_reverted(pool.clone(), hashes)
+                self.best_transactions.remove_invalid(pool.clone(), hashes)
             },
         )? {
             BuildOutcome::Better { payload, .. } => {
@@ -371,6 +412,8 @@ where
             receipt_builder: self.receipt_builder.clone(),
             builder_signer: self.builder_signer,
             metrics: Default::default(),
+            supervisor_client: self.supervisor_client.clone(),
+            supervisor_safety_level: self.supervisor_safety_level,
         };
 
         let builder = OpBuilder::new(best, remove_reverted);
@@ -433,7 +476,7 @@ pub struct OpBuilder<'a, Txs> {
     best: Box<dyn FnOnce(BestTransactionsAttributes) -> Txs + 'a>,
     /// Removes reverted transactions from the tx pool
     #[debug(skip)]
-    remove_reverted: Box<dyn FnOnce(Vec<TxHash>) + 'a>,
+    remove_invalid: Box<dyn FnOnce(Vec<TxHash>) + 'a>,
 }
 
 impl<'a, Txs> OpBuilder<'a, Txs> {
@@ -443,7 +486,7 @@ impl<'a, Txs> OpBuilder<'a, Txs> {
     ) -> Self {
         Self {
             best: Box::new(best),
-            remove_reverted: Box::new(remove_reverted),
+            remove_invalid: Box::new(remove_reverted),
         }
     }
 }
@@ -465,7 +508,7 @@ impl<Txs> OpBuilder<'_, Txs> {
     {
         let Self {
             best,
-            remove_reverted,
+            remove_invalid,
         } = self;
         info!(target: "payload_builder", id=%ctx.payload_id(), parent_header = ?ctx.parent().hash(), parent_number = ctx.parent().number, "building new payload");
 
@@ -562,7 +605,7 @@ impl<Txs> OpBuilder<'_, Txs> {
             None
         };
 
-        remove_reverted(info.reverted_tx_hashes.iter().copied().collect());
+        remove_invalid(info.invalid_tx_hashes.iter().copied().collect());
 
         let payload = ExecutedPayload {
             info,
@@ -731,8 +774,8 @@ pub trait OpPayloadTransactions<Transaction>: Clone + Send + Sync + Unpin + 'sta
         attr: BestTransactionsAttributes,
     ) -> impl PayloadTransactions<Transaction = Transaction>;
 
-    /// Removes reverted transactions from the tx pool
-    fn remove_reverted<Pool: TransactionPool<Transaction = Transaction>>(
+    /// Removes invalid transactions from the tx pool
+    fn remove_invalid<Pool: TransactionPool<Transaction = Transaction>>(
         &self,
         pool: Pool,
         hashes: Vec<TxHash>,
@@ -748,7 +791,7 @@ impl<T: PoolTransaction> OpPayloadTransactions<T> for () {
         BestPayloadTransactions::new(pool.best_transactions_with_attributes(attr))
     }
 
-    fn remove_reverted<Pool: TransactionPool<Transaction = T>>(
+    fn remove_invalid<Pool: TransactionPool<Transaction = T>>(
         &self,
         pool: Pool,
         hashes: Vec<TxHash>,
@@ -778,6 +821,10 @@ pub struct OpPayloadBuilderCtx<EvmConfig: ConfigureEvmEnv, ChainSpec, N: NodePri
     pub builder_signer: Option<Signer>,
     /// The metrics for the builder
     pub metrics: OpRBuilderMetrics,
+    /// Client to execute supervisor validation
+    pub supervisor_client: Option<SupervisorValidator>,
+    /// Level to use in supervisor validation
+    pub supervisor_safety_level: SafetyLevel,
 }
 
 impl<EvmConfig, ChainSpec, N> OpPayloadBuilderCtx<EvmConfig, ChainSpec, N>
@@ -1035,6 +1082,18 @@ where
                     PayloadBuilderError::other(OpPayloadBuilderError::TransactionEcRecoverFailed)
                 })?;
 
+            // Check transactions against supervisor if it's cross chain
+            if let (false, _) = is_cross_tx_valid::<N>(
+                sequencer_tx.tx(),
+                self.supervisor_client.as_ref(),
+                self.supervisor_safety_level,
+                self.config.attributes.timestamp(),
+                &self.metrics,
+            ) {
+                // We skip this transaction because it's not possible to verify it's validity
+                continue;
+            }
+
             // Cache the depositor account prior to the state transition for the deposit nonce.
             //
             // Note that this *only* needs to be done post-regolith hardfork, as deposit nonces
@@ -1135,6 +1194,24 @@ where
                 continue;
             }
 
+            // Check transactions against supervisor if it's cross chain
+            if let (false, is_recoverable) = is_cross_tx_valid::<N>(
+                tx.tx(),
+                self.supervisor_client.as_ref(),
+                self.supervisor_safety_level,
+                self.config.attributes.timestamp(),
+                &self.metrics,
+            ) {
+                // We mark the tx invalid to ensure that it won't clog out pipeline
+                // in case there is bug in supervisor.
+                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                if !is_recoverable {
+                    // For some subset of errors we remove transaction from txpool
+                    info.invalid_tx_hashes.insert(*tx.tx_hash());
+                }
+                continue;
+            }
+
             // check if the job was cancelled, if so we can exit early
             if self.cancel.is_cancelled() {
                 return Ok(Some(()));
@@ -1177,7 +1254,7 @@ where
                 num_txs_simulated_fail += 1;
                 trace!(target: "payload_builder", ?tx, "skipping reverted transaction");
                 best_txs.mark_invalid(tx.signer(), tx.nonce());
-                info.reverted_tx_hashes.insert(*tx.tx_hash());
+                info.invalid_tx_hashes.insert(*tx.tx_hash());
                 continue;
             }
 
@@ -1354,4 +1431,92 @@ fn estimate_gas_for_builder_tx(input: Vec<u8>) -> u64 {
     let nonzero_cost = nonzero_bytes * 16;
 
     zero_cost + nonzero_cost + 21_000
+}
+
+/// Extracts commitment from access list entries, pointing to 0x420..022 and validates them
+/// against supervisor.
+///
+/// If commitment present pre-interop tx rejected.
+///
+/// Returns (is_valid, is_recoverable)
+pub fn is_cross_tx_valid<N: NodePrimitives>(
+    tx: &N::SignedTx,
+    client: Option<&SupervisorValidator>,
+    safety_level: SafetyLevel,
+    timestamp: u64,
+    metrics: &OpRBuilderMetrics,
+) -> (bool, bool) {
+    if tx.access_list().is_none() {
+        return (true, true);
+    }
+    let access_list = tx.access_list().unwrap();
+    let inbox_entries = SupervisorValidator::parse_access_list(access_list)
+        .cloned()
+        .collect::<Vec<_>>();
+    if !inbox_entries.is_empty() {
+        metrics.inc_num_cross_chain_tx();
+        if client.is_none() {
+            return (false, true);
+        }
+        match validate_supervisor_messages(inbox_entries, client.unwrap(), safety_level, timestamp)
+        {
+            Ok(res) => match res {
+                Ok(()) => (true, true),
+                Err(err) => {
+                    match err {
+                        InteropTxValidatorError::SupervisorServerError(err) => {
+                            warn!(target: "payload_builder", %err, ?tx, "Supervisor error, skipping.");
+                            metrics.inc_num_cross_chain_tx_server_error();
+                            (false, true)
+                        }
+                        InteropTxValidatorError::ValidationTimeout(_) => {
+                            warn!(target: "payload_builder", %err, ?tx, "Cross tx validation timed out, skipping.");
+                            metrics.inc_num_cross_chain_tx_timeout();
+                            (false, true)
+                        }
+                        err => {
+                            trace!(target: "payload_builder", %err, ?tx, "Cross tx rejected.");
+                            metrics.inc_num_cross_chain_tx_fail();
+                            // It's possible that transaction invalid now, but would be valid later.
+                            // We should keep limited queue for transactions that could become valid.
+                            // We should have the limit to ensure that builder won't get overwhelmed.
+                            (false, false)
+                        }
+                    }
+                }
+            },
+            Err(err) => {
+                error!(target: "payload_builder", %err, ?tx, "Client side error during cross tx validation, skipping.");
+                (false, true)
+            }
+        }
+    } else {
+        (true, true)
+    }
+}
+
+/// Validate inbox_entries against supervisor.
+pub fn validate_supervisor_messages(
+    inbox_entries: Vec<B256>,
+    client: &SupervisorValidator,
+    safety_level: SafetyLevel,
+    timestamp: u64,
+) -> Result<Result<(), InteropTxValidatorError>, PayloadBuilderError> {
+    // For block building the timestamp should be `expected time of inclusion` and timeout 0
+    let descriptor = ExecutingDescriptor::new(timestamp, None);
+    let (channel_tx, rx) = std::sync::mpsc::channel();
+    tokio::task::block_in_place(move || {
+        let res = tokio::runtime::Handle::current().block_on(async {
+            client
+                .validate_messages(
+                    inbox_entries.as_slice(),
+                    safety_level,
+                    descriptor,
+                    Some(core::time::Duration::from_millis(100)),
+                )
+                .await
+        });
+        let _ = channel_tx.send(res);
+    });
+    rx.recv().map_err(|_| PayloadBuilderError::ChannelClosed)
 }

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -272,6 +272,9 @@ impl<Pool, Client, EvmConfig, N: NodePrimitives>
         )
     }
 
+    // TODO: we will move supervisor_url and supervisor_safety_level into OpBuilderConfig to reduce
+    // number of args
+    #[allow(clippy::too_many_arguments)]
     pub fn with_builder_config(
         evm_config: EvmConfig,
         builder_signer: Option<Signer>,
@@ -282,6 +285,7 @@ impl<Pool, Client, EvmConfig, N: NodePrimitives>
         supervisor_safety_level: Option<String>,
         config: OpBuilderConfig,
     ) -> Self {
+        // TODO: we should make this client required if interop hardfork enabled, add this after spec rebase
         let supervisor_client = supervisor_url.map(|url| {
             SupervisorValidator::new(
                 HttpClientBuilder::default()
@@ -1441,6 +1445,7 @@ fn estimate_gas_for_builder_tx(input: Vec<u8>) -> u64 {
 /// Returns (is_valid, is_recoverable)
 pub fn is_cross_tx_valid<N: NodePrimitives>(
     tx: &N::SignedTx,
+    // TODO: after spec rebase we must make this field not optional
     client: Option<&SupervisorValidator>,
     safety_level: SafetyLevel,
     timestamp: u64,
@@ -1464,6 +1469,7 @@ pub fn is_cross_tx_valid<N: NodePrimitives>(
                 Ok(()) => (true, true),
                 Err(err) => {
                     match err {
+                        // TODO: we should add reconnecting to supervisor in case of disconnect
                         InteropTxValidatorError::SupervisorServerError(err) => {
                             warn!(target: "payload_builder", %err, ?tx, "Supervisor error, skipping.");
                             metrics.inc_num_cross_chain_tx_server_error();

--- a/crates/op-rbuilder/src/primitives/mod.rs
+++ b/crates/op-rbuilder/src/primitives/mod.rs
@@ -1,1 +1,3 @@
 pub mod reth;
+#[cfg(feature = "optimism")]
+pub mod supervisor;

--- a/crates/op-rbuilder/src/primitives/reth/execution.rs
+++ b/crates/op-rbuilder/src/primitives/reth/execution.rs
@@ -29,7 +29,7 @@ pub struct ExecutionInfo<N: NodePrimitives> {
     /// Tracks fees from executed mempool transactions
     pub total_fees: U256,
     /// Tracks the reverted transaction hashes to remove from the transaction pool
-    pub reverted_tx_hashes: HashSet<TxHash>,
+    pub invalid_tx_hashes: HashSet<TxHash>,
     #[cfg(feature = "flashblocks")]
     /// Index of the last consumed flashblock
     pub last_flashblock_index: usize,
@@ -45,7 +45,7 @@ impl<N: NodePrimitives> ExecutionInfo<N> {
             cumulative_gas_used: 0,
             cumulative_da_bytes_used: 0,
             total_fees: U256::ZERO,
-            reverted_tx_hashes: HashSet::new(),
+            invalid_tx_hashes: HashSet::new(),
             #[cfg(feature = "flashblocks")]
             last_flashblock_index: 0,
         }

--- a/crates/op-rbuilder/src/primitives/supervisor.rs
+++ b/crates/op-rbuilder/src/primitives/supervisor.rs
@@ -1,0 +1,25 @@
+//! This is our custom implementation of validator struct
+
+use jsonrpsee::http_client::HttpClient;
+use kona_rpc::InteropTxValidator;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct SupervisorValidator {
+    inner: HttpClient,
+}
+
+impl SupervisorValidator {
+    pub fn new(client: HttpClient) -> Self {
+        Self { inner: client }
+    }
+}
+
+impl InteropTxValidator for SupervisorValidator {
+    type SupervisorClient = HttpClient;
+    const DEFAULT_TIMEOUT: Duration = Duration::from_millis(100);
+
+    fn supervisor_client(&self) -> &Self::SupervisorClient {
+        &self.inner
+    }
+}


### PR DESCRIPTION
Cherry-pick kona structs that we are using for interop validation
Implement SupervisorValidator to be used in rbuilder 
Add additional primitives crate, that is used for storing external code

## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
