### PR TITLE
Make block times dynamic in flashblock builder

### DIFF
--- a/crates/op-rbuilder/src/args.rs
+++ b/crates/op-rbuilder/src/args.rs
@@ -25,9 +25,17 @@ pub struct OpRbuilderArgs {
     )]
     pub flashblocks_ws_url: String,
     /// chain block time in milliseconds
-    #[arg(long = "rollup.chain-block-time", default_value = "1000")]
+    #[arg(
+        long = "rollup.chain-block-time",
+        default_value = "1000",
+        env = "CHAIN_BLOCK_TIME"
+    )]
     pub chain_block_time: u64,
     /// flashblock block time in milliseconds
-    #[arg(long = "rollup.flashblock-block-time", default_value = "250")]
+    #[arg(
+        long = "rollup.flashblock-block-time",
+        default_value = "250",
+        env = "FLASHBLOCK_BLOCK_TIME"
+    )]
     pub flashblock_block_time: u64,
 }

--- a/crates/op-rbuilder/src/args.rs
+++ b/crates/op-rbuilder/src/args.rs
@@ -24,4 +24,10 @@ pub struct OpRbuilderArgs {
         default_value = "127.0.0.1:1111"
     )]
     pub flashblocks_ws_url: String,
+    /// chain block time in milliseconds
+    #[arg(long = "rollup.chain-block-time", default_value = "1000")]
+    pub chain_block_time: u64,
+    /// flashblock block time in milliseconds
+    #[arg(long = "rollup.flashblock-block-time", default_value = "250")]
+    pub flashblock_block_time: u64,
 }

--- a/crates/op-rbuilder/src/integration/integration_test.rs
+++ b/crates/op-rbuilder/src/integration/integration_test.rs
@@ -370,7 +370,9 @@ mod tests {
             .network_port(1235)
             .http_port(1238)
             .with_builder_private_key(BUILDER_PRIVATE_KEY)
-            .with_flashblocks_ws_url("localhost:1239");
+            .with_flashblocks_ws_url("localhost:1239")
+            .with_chain_block_time(2000)
+            .with_flashbots_block_time(200);
 
         // create the validation reth node
         let reth_data_dir = std::env::temp_dir().join(Uuid::new_v4().to_string());
@@ -407,7 +409,7 @@ mod tests {
         let engine_api = EngineApi::new("http://localhost:1234").unwrap();
         let validation_api = EngineApi::new("http://localhost:1236").unwrap();
 
-        let mut generator = BlockGenerator::new(&engine_api, Some(&validation_api), false, 1, None);
+        let mut generator = BlockGenerator::new(&engine_api, Some(&validation_api), false, 2, None);
         generator.init().await?;
 
         let provider = ProviderBuilder::<Identity, Identity, Optimism>::default()
@@ -433,6 +435,9 @@ mod tests {
         op_rbuilder
             .find_log_line("Processing new chain commit") // no builder tx for flashblocks builder
             .await?;
+
+        // check there's 10 flashblocks log lines (2000ms / 200ms)
+        op_rbuilder.find_log_line("Building flashblock 9").await?;
 
         // Process websocket messages
         let timeout_duration = Duration::from_secs(10);

--- a/crates/op-rbuilder/src/integration/op_rbuilder.rs
+++ b/crates/op-rbuilder/src/integration/op_rbuilder.rs
@@ -25,6 +25,8 @@ pub struct OpRbuilderConfig {
     network_port: Option<u16>,
     builder_private_key: Option<String>,
     flashblocks_ws_url: Option<String>,
+    chain_block_time: Option<u64>,
+    flashbots_block_time: Option<u64>,
 }
 
 impl OpRbuilderConfig {
@@ -64,6 +66,16 @@ impl OpRbuilderConfig {
 
     pub fn with_flashblocks_ws_url(mut self, url: &str) -> Self {
         self.flashblocks_ws_url = Some(url.to_string());
+        self
+    }
+
+    pub fn with_chain_block_time(mut self, time: u64) -> Self {
+        self.chain_block_time = Some(time);
+        self
+    }
+
+    pub fn with_flashbots_block_time(mut self, time: u64) -> Self {
+        self.flashbots_block_time = Some(time);
         self
     }
 }
@@ -116,6 +128,16 @@ impl Service for OpRbuilderConfig {
         if let Some(flashblocks_ws_url) = &self.flashblocks_ws_url {
             cmd.arg("--rollup.flashblocks-ws-url")
                 .arg(flashblocks_ws_url);
+        }
+
+        if let Some(chain_block_time) = self.chain_block_time {
+            cmd.arg("--rollup.chain-block-time")
+                .arg(chain_block_time.to_string());
+        }
+
+        if let Some(flashbots_block_time) = self.flashbots_block_time {
+            cmd.arg("--rollup.flashblock-block-time")
+                .arg(flashbots_block_time.to_string());
         }
 
         cmd

--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -36,6 +36,8 @@ fn main() {
                 .with_components(op_node.components().payload(CustomOpPayloadBuilder::new(
                     builder_args.builder_signer,
                     builder_args.flashblocks_ws_url,
+                    builder_args.chain_block_time,
+                    builder_args.flashblock_block_time,
                 )))
                 .with_add_ons(
                     OpAddOnsBuilder::default()

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -84,19 +84,35 @@ pub struct CustomOpPayloadBuilder {
     builder_signer: Option<Signer>,
     #[cfg(feature = "flashblocks")]
     flashblocks_ws_url: String,
+    #[cfg(feature = "flashblocks")]
+    chain_block_time: u64,
+    #[cfg(feature = "flashblocks")]
+    flashblock_block_time: u64,
 }
 
 impl CustomOpPayloadBuilder {
     #[cfg(feature = "flashblocks")]
-    pub fn new(builder_signer: Option<Signer>, flashblocks_ws_url: String) -> Self {
+    pub fn new(
+        builder_signer: Option<Signer>,
+        flashblocks_ws_url: String,
+        chain_block_time: u64,
+        flashblock_block_time: u64,
+    ) -> Self {
         Self {
             builder_signer,
             flashblocks_ws_url,
+            chain_block_time,
+            flashblock_block_time,
         }
     }
 
     #[cfg(not(feature = "flashblocks"))]
-    pub fn new(builder_signer: Option<Signer>, _flashblocks_ws_url: String) -> Self {
+    pub fn new(
+        builder_signer: Option<Signer>,
+        _flashblocks_ws_url: String,
+        _chain_block_time: u64,
+        _flashblock_block_time: u64,
+    ) -> Self {
         Self { builder_signer }
     }
 }


### PR DESCRIPTION
## 📝 Summary
Currently the block time is hard coded to assume the chain block time is 1s and flashblock time is 250ms. But for Base the chain block time is 2s. Thus fixing this by adding args to make it dynamic.

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
