### PR TITLE
Fix sim thread util regression

### DIFF
--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -206,8 +206,12 @@ impl DummyBuildingAlgorithm {
     where
         P: StateProviderFactory + Clone + 'static,
     {
+        let block_state = provider
+            .history_by_block_hash(ctx.attributes.parent)?
+            .into();
+
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
-            provider.clone(),
+            block_state,
             ctx.clone(),
             None,
             BUILDER_NAME.to_string(),

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -1,7 +1,9 @@
 use alloy_primitives::{utils::format_ether, U256};
 use reth::revm::cached::CachedReads;
+use reth_provider::StateProvider;
 use std::{
     cmp::max,
+    sync::Arc,
     time::{Duration, Instant},
 };
 use time::OffsetDateTime;
@@ -16,7 +18,6 @@ use crate::{
         PartialBlock, Sorting,
     },
     primitives::SimulatedOrder,
-    provider::StateProviderFactory,
     telemetry::{self, add_block_fill_time, add_order_simulation_time},
     utils::{check_block_hash_reader_health, HistoricalBlockError},
 };
@@ -124,10 +125,7 @@ impl BiddableUnfinishedBlock {
 
 /// Implementation of BlockBuildingHelper based on a generic Provider
 #[derive(Clone)]
-pub struct BlockBuildingHelperFromProvider<P>
-where
-    P: StateProviderFactory,
-{
+pub struct BlockBuildingHelperFromProvider {
     /// Balance of fee recipient before we stared building.
     _fee_recipient_balance_start: U256,
     /// Accumulated changes for the block (due to commit_order calls).
@@ -141,8 +139,6 @@ where
     builder_name: String,
     building_ctx: BlockBuildingContext,
     built_block_trace: BuiltBlockTrace,
-    /// Needed to get the initial state and the final root hash calculation.
-    provider: P,
     /// Token to cancel in case of fatal error (if we believe that it's impossible to build for this block).
     cancel_on_fatal_error: CancellationToken,
 }
@@ -188,10 +184,7 @@ pub struct FinalizeBlockResult {
     pub cached_reads: CachedReads,
 }
 
-impl<P> BlockBuildingHelperFromProvider<P>
-where
-    P: StateProviderFactory + Clone + 'static,
-{
+impl BlockBuildingHelperFromProvider {
     /// allow_tx_skip: see [`PartialBlockFork`]
     /// Performs initialization:
     /// - Query fee_recipient_balance_start.
@@ -199,7 +192,7 @@ where
     /// - Estimate payout tx cost.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        provider: P,
+        state_provider: Arc<dyn StateProvider>,
         building_ctx: BlockBuildingContext,
         cached_reads: Option<CachedReads>,
         builder_name: String,
@@ -207,9 +200,6 @@ where
         enforce_sorting: Option<Sorting>,
         cancel_on_fatal_error: CancellationToken,
     ) -> Result<Self, BlockBuildingHelperError> {
-        // @Maybe an issue - we have 2 db txs here (one for hash and one for finalize)
-        let state_provider = provider.history_by_block_hash(building_ctx.attributes.parent)?;
-
         let last_committed_block = building_ctx.block() - 1;
         check_block_hash_reader_health(last_committed_block, &state_provider)?;
 
@@ -219,7 +209,7 @@ where
         let mut partial_block = PartialBlock::new(discard_txs, enforce_sorting)
             .with_tracer(GasUsedSimulationTracer::default());
         let mut block_state =
-            BlockState::new(state_provider).with_cached_reads(cached_reads.unwrap_or_default());
+            BlockState::new_arc(state_provider).with_cached_reads(cached_reads.unwrap_or_default());
         partial_block
             .pre_block_call(&building_ctx, &mut block_state)
             .map_err(|_| BlockBuildingHelperError::PreBlockCallFailed)?;
@@ -244,7 +234,6 @@ where
             builder_name,
             building_ctx,
             built_block_trace: BuiltBlockTrace::new(),
-            provider,
             cancel_on_fatal_error,
         })
     }
@@ -343,10 +332,7 @@ where
     }
 }
 
-impl<P> BlockBuildingHelper for BlockBuildingHelperFromProvider<P>
-where
-    P: StateProviderFactory + Clone + 'static,
-{
+impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
     /// Forwards to partial_block and updates trace.
     fn commit_order(
         &mut self,
@@ -425,12 +411,9 @@ where
             Ok(finalized_block) => finalized_block,
             Err(err) => {
                 if err.is_consistent_db_view_err() {
-                    let last_block_number = self.provider.last_block_number().unwrap_or_default();
-
                     debug!(
                         block_number,
                         payload_id = self.building_ctx.payload_id,
-                        last_block_number,
                         "Can't build on this head, cancelling slot"
                     );
                     self.cancel_on_fatal_error.cancel();

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -19,9 +19,14 @@ use crate::{
     utils::NonceCache,
 };
 use ahash::{HashMap, HashSet};
+use derivative::Derivative;
 use reth::revm::cached::CachedReads;
+use reth_provider::StateProvider;
 use serde::Deserialize;
-use std::time::{Duration, Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info_span, trace};
 
@@ -65,29 +70,28 @@ where
 {
     let payload_id = input.ctx.payload_id;
 
-    let nonces = {
-        let block_state = match input
-            .provider
-            .history_by_block_hash(input.ctx.attributes.parent)
-        {
-            Ok(state) => state,
-            Err(err) => {
-                error!(
-                    ?err,
-                    payload_id,
-                    builder = input.builder_name,
-                    "Failed to get history_by_block_hash, cancelling builder job"
-                );
-                return;
-            }
-        };
-        NonceCache::new(block_state)
+    let block_state: Arc<dyn StateProvider> = match input
+        .provider
+        .history_by_block_hash(input.ctx.attributes.parent)
+    {
+        Ok(state) => Arc::from(state),
+        Err(err) => {
+            error!(
+                ?err,
+                payload_id,
+                builder = input.builder_name,
+                "Failed to get history_by_block_hash, cancelling builder job"
+            );
+            return;
+        }
     };
+
+    let nonces = NonceCache::new(block_state.clone());
 
     let mut order_intake_consumer = OrderIntakeConsumer::new(nonces, input.input, config.sorting);
 
     let mut builder = OrderingBuilderContext::new(
-        input.provider.clone(),
+        block_state.clone(),
         input.builder_name,
         input.ctx,
         config.clone(),
@@ -155,7 +159,7 @@ where
     let block_orders =
         block_orders_from_sim_orders(input.sim_orders, ordering_config.sorting, &state_provider)?;
     let mut builder = OrderingBuilderContext::new(
-        input.provider.clone(),
+        Arc::from(state_provider),
         input.builder_name,
         input.ctx.clone(),
         ordering_config,
@@ -179,9 +183,11 @@ where
     ))
 }
 
-#[derive(Debug)]
-pub struct OrderingBuilderContext<P> {
-    provider: P,
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct OrderingBuilderContext {
+    #[derivative(Debug = "ignore")]
+    state: Arc<dyn StateProvider>,
     builder_name: String,
     ctx: BlockBuildingContext,
     config: OrderingBuilderConfig,
@@ -194,18 +200,15 @@ pub struct OrderingBuilderContext<P> {
     order_attempts: HashMap<OrderId, usize>,
 }
 
-impl<P> OrderingBuilderContext<P>
-where
-    P: StateProviderFactory + Clone + 'static,
-{
+impl OrderingBuilderContext {
     pub fn new(
-        provider: P,
+        state: Arc<dyn StateProvider>,
         builder_name: String,
         ctx: BlockBuildingContext,
         config: OrderingBuilderConfig,
     ) -> Self {
         Self {
-            provider,
+            state,
             builder_name,
             ctx,
             config,
@@ -250,7 +253,7 @@ where
         self.order_attempts.clear();
 
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
-            self.provider.clone(),
+            self.state.clone(),
             new_ctx,
             self.cached_reads.take(),
             self.builder_name.clone(),

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -5,6 +5,7 @@ use super::{
 use ahash::HashMap;
 use alloy_primitives::utils::format_ether;
 use reth::revm::cached::CachedReads;
+use reth_provider::StateProvider;
 use std::{sync::Arc, time::Instant};
 use time::OffsetDateTime;
 use tokio_util::sync::CancellationToken;
@@ -20,13 +21,12 @@ use crate::{
         },
         BlockBuildingContext,
     },
-    provider::StateProviderFactory,
     telemetry::mark_builder_considers_order,
 };
 
 /// Assembles block building results from the best orderings of order groups.
-pub struct BlockBuildingResultAssembler<P> {
-    provider: P,
+pub struct BlockBuildingResultAssembler {
+    state: Arc<dyn StateProvider>,
     ctx: BlockBuildingContext,
     cancellation_token: CancellationToken,
     cached_reads: Option<CachedReads>,
@@ -40,10 +40,7 @@ pub struct BlockBuildingResultAssembler<P> {
     last_version: Option<u64>,
 }
 
-impl<P> BlockBuildingResultAssembler<P>
-where
-    P: StateProviderFactory + Clone + 'static,
-{
+impl BlockBuildingResultAssembler {
     /// Creates a new `BlockBuildingResultAssembler`.
     ///
     /// # Arguments
@@ -56,7 +53,7 @@ where
     pub fn new(
         config: &ParallelBuilderConfig,
         best_results: Arc<BestResults>,
-        provider: P,
+        state: Arc<dyn StateProvider>,
         ctx: BlockBuildingContext,
         cancellation_token: CancellationToken,
         builder_name: String,
@@ -64,7 +61,7 @@ where
         sink: Option<Arc<dyn UnfinishedBlockBuildingSink>>,
     ) -> Self {
         Self {
-            provider,
+            state,
             ctx,
             cancellation_token,
             cached_reads: None,
@@ -198,7 +195,7 @@ where
         }
 
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
-            self.provider.clone(),
+            self.state.clone(),
             ctx,
             self.cached_reads.clone(),
             self.builder_name.clone(),
@@ -270,7 +267,7 @@ where
         orders_closed_at: OffsetDateTime,
     ) -> eyre::Result<Box<dyn BlockBuildingHelper>> {
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
-            self.provider.clone(),
+            self.state.clone(),
             self.ctx.clone(),
             None, // No cached reads for backtest start
             String::from("backtest_builder"),

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
@@ -1,5 +1,6 @@
 use ahash::HashMap;
 use alloy_primitives::{Address, U256};
+use derivative::Derivative;
 use eyre::Result;
 use itertools::Itertools;
 use rand::{seq::SliceRandom, SeedableRng};
@@ -16,23 +17,22 @@ use super::{
 use crate::{
     building::{BlockBuildingContext, BlockState, ExecutionError, ExecutionResult, PartialBlock},
     primitives::{OrderId, SimulatedOrder},
-    provider::StateProviderFactory,
 };
 
 /// Context for resolving conflicts in merging tasks.
-#[derive(Debug)]
-pub struct ResolverContext<P> {
-    pub provider: P,
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct ResolverContext {
+    #[derivative(Debug = "ignore")]
+    pub state: Arc<dyn StateProvider>,
     pub ctx: BlockBuildingContext,
     pub cancellation_token: CancellationToken,
     pub cache: Option<CachedReads>,
     pub simulation_cache: Arc<SharedSimulationCache>,
 }
 
-impl<P> ResolverContext<P>
-where
-    P: StateProviderFactory,
-{
+impl ResolverContext {
     /// Creates a new `ResolverContext`.
     ///
     /// # Arguments
@@ -43,14 +43,14 @@ where
     /// * `cache` - Optional cached reads for optimization.
     /// * `simulation_cache` - Shared cache for simulation results.
     pub fn new(
-        provider: P,
+        state: Arc<dyn StateProvider>,
         ctx: BlockBuildingContext,
         cancellation_token: CancellationToken,
         cache: Option<CachedReads>,
         simulation_cache: Arc<SharedSimulationCache>,
     ) -> Self {
         ResolverContext {
-            provider,
+            state,
             ctx,
             cancellation_token,
             cache,
@@ -73,11 +73,6 @@ where
             task.group.id,
             task.algorithm
         );
-        // TODO: refactor to get history_by_block_hash only once per block but not per conflict task
-        let state_provider = self
-            .provider
-            .history_by_block_hash(self.ctx.attributes.parent)?;
-        let state_provider: Arc<dyn StateProvider> = Arc::from(state_provider);
 
         let sequence_to_try = generate_sequences_of_orders_to_try(&task);
 
@@ -88,7 +83,7 @@ where
 
         for sequence_of_orders in sequence_to_try {
             let (resolution_result, state) =
-                self.process_sequence_of_orders(sequence_of_orders, &task, &state_provider)?;
+                self.process_sequence_of_orders(sequence_of_orders, &task, self.state.clone())?;
             self.update_best_result(resolution_result, &mut best_resolution_result);
 
             let (new_cached_reads, _, _) = state.into_parts();
@@ -136,7 +131,7 @@ where
         &mut self,
         sequence_of_orders: Vec<usize>,
         task: &ConflictTask,
-        state_provider: &Arc<dyn StateProvider>,
+        state_provider: Arc<dyn StateProvider>,
     ) -> Result<(ResolutionResult, BlockState)> {
         let order_id_to_index = self.initialize_order_id_to_index_map(task);
         let full_sequence_of_orders = self.initialize_full_order_ids_vec(&sequence_of_orders, task);
@@ -287,7 +282,7 @@ where
     fn initialize_block_state(
         &mut self,
         cached_state_option: &Option<Arc<CachedSimulationState>>,
-        state_provider: &Arc<dyn StateProvider>,
+        state_provider: Arc<dyn StateProvider>,
     ) -> BlockState {
         if let Some(cached_state) = &cached_state_option {
             // Use cached state
@@ -297,9 +292,9 @@ where
         } else {
             // If we don't have a cached state from the simulation cache, we use the cached reads from the block state in some cases
             if let Some(cache) = &self.cache {
-                BlockState::new_arc(state_provider.clone()).with_cached_reads(cache.clone())
+                BlockState::new_arc(state_provider).with_cached_reads(cache.clone())
             } else {
-                BlockState::new_arc(state_provider.clone())
+                BlockState::new_arc(state_provider)
             }
         }
     }

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
@@ -73,6 +73,7 @@ where
             task.group.id,
             task.algorithm
         );
+        // TODO: refactor to get history_by_block_hash only once per block but not per conflict task
         let state_provider = self
             .provider
             .history_by_block_hash(self.ctx.attributes.parent)?;

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::utils::format_ether;
 use crossbeam_queue::SegQueue;
 use eyre::Result;
+use reth_provider::StateProvider;
 use std::{
     sync::{mpsc as std_mpsc, Arc},
     thread,
@@ -53,15 +54,18 @@ where
         }
     }
 
-    pub fn start(&self) {
+    pub fn start(&self) -> eyre::Result<()> {
         for _ in 0..self.num_threads {
             let task_queue = self.task_queue.clone();
             let cancellation_token = self.cancellation_token.clone();
-            let provider = self.provider.clone();
             let group_result_sender = self.group_result_sender.clone();
             let simulation_cache = self.simulation_cache.clone();
             let ctx = self.ctx.clone();
 
+            let block_state: Arc<dyn StateProvider> = self
+                .provider
+                .history_by_block_hash(self.ctx.attributes.parent)?
+                .into();
             thread::spawn(move || {
                 while !cancellation_token.is_cancelled() {
                     if let Some(task) = task_queue.pop() {
@@ -72,7 +76,7 @@ where
                         if let Ok((task_id, result)) = Self::process_task(
                             task,
                             &ctx,
-                            &provider,
+                            block_state.clone(),
                             cancellation_token.clone(),
                             Arc::clone(&simulation_cache),
                         ) {
@@ -99,17 +103,18 @@ where
                 }
             });
         }
+        Ok(())
     }
 
     fn process_task(
         task: ConflictTask,
         ctx: &BlockBuildingContext,
-        provider: &P,
+        state: Arc<dyn StateProvider>,
         cancellation_token: CancellationToken,
         simulation_cache: Arc<SharedSimulationCache>,
     ) -> Result<(GroupId, (ResolutionResult, ConflictGroup))> {
         let mut merging_context = ResolverContext::new(
-            provider.clone(),
+            state,
             ctx.clone(),
             cancellation_token.clone(),
             None,
@@ -149,7 +154,7 @@ where
         &mut self,
         new_groups: Vec<ConflictGroup>,
         ctx: &BlockBuildingContext,
-        provider: &P,
+        state: Arc<dyn StateProvider>,
         simulation_cache: Arc<SharedSimulationCache>,
     ) -> Vec<(GroupId, (ResolutionResult, ConflictGroup))> {
         let mut results = Vec::new();
@@ -160,7 +165,7 @@ where
                 let result = Self::process_task(
                     task,
                     ctx,
-                    provider,
+                    state.clone(),
                     CancellationToken::new(),
                     simulation_cache,
                 );

--- a/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
@@ -16,6 +16,7 @@ use crossbeam::queue::SegQueue;
 use eyre::Result;
 use itertools::Itertools;
 use results_aggregator::BestResults;
+use reth_provider::StateProvider;
 use serde::Deserialize;
 use simulation_cache::SharedSimulationCache;
 use std::{
@@ -76,7 +77,7 @@ struct ParallelBuilder<P> {
     conflict_task_generator: ConflictTaskGenerator,
     conflict_resolving_pool: ConflictResolvingPool<P>,
     results_aggregator: ResultsAggregator,
-    block_building_result_assembler: BlockBuildingResultAssembler<P>,
+    block_building_result_assembler: BlockBuildingResultAssembler,
 }
 
 impl<P> ParallelBuilder<P>
@@ -85,7 +86,10 @@ where
 {
     /// Creates a ParallelBuilder.
     /// Sets up the various components and communication channels.
-    pub fn new(input: LiveBuilderInput<P>, config: &ParallelBuilderConfig) -> Self {
+    pub fn try_new(
+        input: LiveBuilderInput<P>,
+        config: &ParallelBuilderConfig,
+    ) -> eyre::Result<Self> {
         let (group_result_sender, group_result_receiver) = get_communication_channels();
         let group_result_sender_for_task_generator = group_result_sender.clone();
 
@@ -113,10 +117,15 @@ where
         let results_aggregator =
             ResultsAggregator::new(group_result_receiver, Arc::clone(&best_results));
 
+        let block_state = input
+            .provider
+            .history_by_block_hash(input.ctx.attributes.parent)?
+            .into();
+
         let block_building_result_assembler = BlockBuildingResultAssembler::new(
             config,
             Arc::clone(&best_results),
-            input.provider.clone(),
+            block_state,
             input.ctx.clone(),
             input.cancel.clone(),
             input.builder_name.clone(),
@@ -126,14 +135,14 @@ where
 
         let order_intake_consumer = OrderIntakeStore::new(input.input);
 
-        Self {
+        Ok(Self {
             order_intake_consumer,
             conflict_finder,
             conflict_task_generator,
             conflict_resolving_pool,
             results_aggregator,
             block_building_result_assembler,
-        }
+        })
     }
 
     /// Initializes the orders in the cached groups.
@@ -182,13 +191,26 @@ where
     let cancel_for_block_building_result_assembler = input.cancel.clone();
     let cancel_for_process_orders_loop = input.cancel.clone();
 
-    let mut builder = ParallelBuilder::new(input, config);
+    let mut builder = match ParallelBuilder::try_new(input, config) {
+        Ok(builder) => builder,
+        Err(err) => {
+            error!(?err, "Failed to create parallel builder, cancelling");
+            return;
+        }
+    };
     builder.initialize_orders();
 
     // Start task processing
-    thread::spawn(move || {
-        builder.conflict_resolving_pool.start();
-    });
+    match builder.conflict_resolving_pool.start() {
+        Ok(()) => {}
+        Err(err) => {
+            error!(
+                ?err,
+                "Failed to start parallel builder conflict_resolving_pool, cancelling"
+            );
+            return;
+        }
+    }
 
     // Process that collects conflict resolution results from workers and triggers block building
     tokio::spawn(async move {
@@ -299,13 +321,18 @@ where
 
     let setup_duration = setup_start.elapsed();
 
+    let block_state: Arc<dyn StateProvider> = input
+        .provider
+        .history_by_block_hash(input.ctx.attributes.parent)?
+        .into();
+
     // Group processing
     let processing_start = Instant::now();
     let groups = conflict_finder.get_order_groups();
     let results = conflict_resolving_pool.process_groups_backtest(
         groups,
         &input.ctx,
-        &input.provider,
+        block_state.clone(),
         Arc::clone(&simulation_cache),
     );
     let processing_duration = processing_start.elapsed();
@@ -315,7 +342,7 @@ where
     let block_building_result_assembler = BlockBuildingResultAssembler::new(
         &config,
         Arc::clone(&best_results),
-        input.provider.clone(),
+        block_state.clone(),
         input.ctx.clone(),
         CancellationToken::new(),
         String::from("backtest_builder"),

--- a/crates/rbuilder/src/building/sim.rs
+++ b/crates/rbuilder/src/building/sim.rs
@@ -312,7 +312,7 @@ where
 {
     let nonces = {
         let state = provider.history_by_block_hash(ctx.attributes.parent)?;
-        NonceCache::new(state)
+        NonceCache::new(state.into())
     };
     let mut sim_tree = SimTree::new(nonces);
 

--- a/crates/rbuilder/src/live_builder/simulation/mod.rs
+++ b/crates/rbuilder/src/live_builder/simulation/mod.rs
@@ -134,7 +134,7 @@ where
                             return;
                         }
                     };
-                    NonceCache::new(state)
+                    NonceCache::new(state.into())
                 };
 
                 let sim_tree = SimTree::new(nonces);

--- a/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
+++ b/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
@@ -28,7 +28,7 @@ pub fn run_sim_worker<P>(
 ) where
     P: StateProviderFactory,
 {
-    loop {
+    'main: loop {
         if global_cancellation.is_cancelled() {
             return;
         }
@@ -48,24 +48,23 @@ pub fn run_sim_worker<P>(
 
         let mut cached_reads = CachedReads::default();
         let mut last_sim_finished = Instant::now();
+
+        let state_provider =
+            match provider.history_by_block_hash(current_sim_context.block_ctx.attributes.parent) {
+                Ok(state_provider) => Arc::new(state_provider),
+                Err(err) => {
+                    error!(?err, "Error while getting state for block");
+                    continue 'main;
+                }
+            };
         while let Ok(task) = current_sim_context.requests.recv() {
             let sim_thread_wait_time = last_sim_finished.elapsed();
             let sim_start = Instant::now();
 
-            let state_provider = match provider
-                .history_by_block_hash(current_sim_context.block_ctx.attributes.parent)
-            {
-                Ok(state_provider) => state_provider,
-                Err(err) => {
-                    error!(?err, "Error while getting state for block");
-                    // break here so we can try to get new context
-                    // @Metric
-                    break;
-                }
-            };
             let order_id = task.order.id();
             let start_time = Instant::now();
-            let mut block_state = BlockState::new(state_provider).with_cached_reads(cached_reads);
+            let mut block_state =
+                BlockState::new_arc(state_provider.clone()).with_cached_reads(cached_reads);
             let sim_result = simulate_order(
                 task.parents.clone(),
                 task.order,

--- a/crates/rbuilder/src/utils/noncer.rs
+++ b/crates/rbuilder/src/utils/noncer.rs
@@ -1,8 +1,8 @@
 use alloy_primitives::Address;
 use dashmap::DashMap;
 use derivative::Derivative;
-use reth::providers::StateProviderBox;
 use reth_errors::ProviderResult;
+use reth_provider::StateProvider;
 use std::sync::Arc;
 
 /// Struct to get nonces for Addresses, caching the results.
@@ -10,12 +10,12 @@ use std::sync::Arc;
 #[derivative(Debug)]
 pub struct NonceCache {
     #[derivative(Debug = "ignore")]
-    state: StateProviderBox,
+    state: Arc<dyn StateProvider>,
     cache: Arc<DashMap<Address, u64>>,
 }
 
 impl NonceCache {
-    pub fn new(state: StateProviderBox) -> Self {
+    pub fn new(state: Arc<dyn StateProvider>) -> Self {
         Self {
             state,
             cache: Arc::new(DashMap::default()),


### PR DESCRIPTION
## 📝 Summary

This fixes a perf regression that we added when we started to check provider factory health on each check. The core part of this PR is https://github.com/flashbots/rbuilder/commit/ae8177ee1d63db5ca6350ab92748c0c481c9445c since its directly fixed problem at hand: simulation thread utilization is up from 2% to 20%.

This affects simulation the most since we would open a db transaction for each order that we simulate.
It does not affect block building that much since we open a db transaction per block building attempt instead of per block.

I've added [this](https://github.com/flashbots/rbuilder/commit/54827e74e2a3610dc29377c109143815c74dfebf) commit with more changes to make builders more efficient at opening db transactions. Now we do it once per block instead of once per block building attempt. 

There are no other places in the code that do this reopening check in a hot loop. The only thing that uses it like wallet balance watcher are doing this per block. The exception is the code that checks last block in a loop to cancel slots but its not critical to performance.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
