### PR TITLE
IPC state provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,14 +110,31 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
+dependencies = [
+ "alloy-eips 0.11.1",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "alloy-serde 0.11.1",
+ "alloy-trie",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fbf458101ed6c389e9bb70a34ebc56039868ad10472540614816cdedc8f5265"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "alloy-trie",
  "arbitrary",
  "auto_impl",
@@ -134,15 +151,29 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
+dependencies = [
+ "alloy-consensus 0.11.1",
+ "alloy-eips 0.11.1",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "alloy-serde 0.11.1",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fafded0c1ff8f0275c4a484239058e1c01c0c2589f8a16e03669ef7094a06f9b"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "serde",
 ]
 
@@ -210,6 +241,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "alloy-serde 0.11.1",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "once_cell",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-eips"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e86967eb559920e4b9102e4cb825fe30f2e9467988353ce4809f0d3f2c90cd4"
@@ -219,7 +270,7 @@ dependencies = [
  "alloy-eip7702",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "arbitrary",
  "auto_impl",
  "c-kzg",
@@ -238,8 +289,8 @@ version = "0.1.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40fe575395f20dc9527c2dc65350786492e9723d2035e9f716269b65be34c9c"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-hardforks",
  "alloy-primitives 0.8.23",
  "alloy-sol-types",
@@ -256,9 +307,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a40de6f5b53ecf5fd7756072942f41335426d9a3704cd961f77d854739933bcf"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "alloy-trie",
  "serde",
 ]
@@ -291,6 +342,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
+dependencies = [
+ "alloy-primitives 0.8.23",
+ "alloy-sol-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-json-rpc"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27434beae2514d4a2aa90f53832cbdf6f23e4b5e2656d95eaf15f9276e2418b6"
@@ -309,15 +374,15 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26a33a38c7486b1945f8d093ff027add2f3a8f83c7300dbad6165cc49150085e"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network-primitives",
+ "alloy-consensus 0.12.6",
+ "alloy-consensus-any 0.12.5",
+ "alloy-eips 0.12.6",
+ "alloy-json-rpc 0.12.6",
+ "alloy-network-primitives 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -331,14 +396,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
+dependencies = [
+ "alloy-consensus 0.11.1",
+ "alloy-eips 0.11.1",
+ "alloy-primitives 0.8.23",
+ "alloy-serde 0.11.1",
+ "serde",
+]
+
+[[package]]
+name = "alloy-network-primitives"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db973a7a23cbe96f2958e5687c51ce2d304b5c6d0dc5ccb3de8667ad8476f50b"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "serde",
 ]
 
@@ -369,8 +447,8 @@ version = "0.1.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ed217773009445cba32f02418828a282c7bcb7721909cf4f6aaa9a263618817"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-evm",
  "alloy-op-hardforks",
  "alloy-primitives 0.8.23",
@@ -450,15 +528,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b03bde77ad73feae14aa593bcabb932c8098c0f0750ead973331cfc0003a4e1"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
+ "alloy-json-rpc 0.12.6",
  "alloy-network",
- "alloy-network-primitives",
+ "alloy-network-primitives 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
@@ -489,7 +567,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721aca709a9231815ad5903a2d284042cc77e7d9d382696451b30c9ee0950001"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-transport",
  "bimap",
@@ -530,7 +608,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445a3298c14fae7afb5b9f2f735dead989f3dd83020c2ab8e48ed95d7b6d1acb"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-pubsub",
  "alloy-transport",
@@ -560,8 +638,8 @@ checksum = "9157deaec6ba2ad7854f16146e4cd60280e76593eed79fdcb06e0fa8b6c60f77"
 dependencies = [
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "serde",
 ]
 
@@ -584,8 +662,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a80ee83ef97e7ffd667a81ebdb6154558dfd5e8f20d8249a10a12a1671a04b3"
 dependencies = [
  "alloy-primitives 0.8.23",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "serde",
 ]
 
@@ -595,9 +673,9 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd4ceea38ea27eeb26f021df34ed5b7b793704ad7a2a009f16137a19461e7ca"
 dependencies = [
- "alloy-consensus-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-consensus-any 0.12.5",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
 ]
 
 [[package]]
@@ -606,7 +684,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645455186916281e0b3f063fd07d007711257cf90c3499ff3569a39ffdfc9d2f"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "ethereum_ssz",
@@ -634,11 +712,11 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "874ac9d1249ece0453e262d9ba72da9dbb3b7a2866220ded5940c2e47f1aa04d"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "derive_more 2.0.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -651,17 +729,37 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
+dependencies = [
+ "alloy-consensus 0.11.1",
+ "alloy-consensus-any 0.11.1",
+ "alloy-eips 0.11.1",
+ "alloy-network-primitives 0.11.1",
+ "alloy-primitives 0.8.23",
+ "alloy-rlp",
+ "alloy-serde 0.11.1",
+ "alloy-sol-types",
+ "itertools 0.13.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e13d71eac04513a71af4b3df580f52f2b4dcbff9d971cc9a52519acf55514cb"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
+ "alloy-consensus 0.12.6",
+ "alloy-consensus-any 0.12.5",
+ "alloy-eips 0.12.6",
+ "alloy-network-primitives 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -677,10 +775,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "505d73db6217e6abcdeba4bf025fb9db79577d6b06e092d24e7c11ed0360743b"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "serde",
  "serde_json",
 ]
@@ -692,8 +790,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4747763aee39c1b0f5face79bde9be8932be05b2db7d8bdcebb93490f32c889c"
 dependencies = [
  "alloy-primitives 0.8.23",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "serde",
  "serde_json",
  "thiserror 2.0.11",
@@ -706,9 +804,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70132ebdbea1eaa68c4d6f7a62c2fadf0bdce83b904f895ab90ca4ec96f63468"
 dependencies = [
  "alloy-primitives 0.8.23",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "serde",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
+dependencies = [
+ "alloy-primitives 0.8.23",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -744,7 +853,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6e72002cc1801d8b41e9892165e3a6551b7bd382bd9d0414b21e90c0c62551"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-network",
  "alloy-primitives 0.8.23",
  "alloy-signer",
@@ -831,7 +940,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec325c2af8562ef355c02aeb527c755a07e9d8cf6a1e65dda8d0bf23e29b2c"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.12.6",
  "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
@@ -853,7 +962,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a082c9473c6642cce8b02405a979496126a03b096997888e86229afad05db06c"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.12.6",
  "alloy-transport",
  "reqwest 0.12.9",
  "serde_json",
@@ -868,7 +977,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e61e2b5cbf16f7588e4420848b61824f6514944773732534f4129ba6a251e059"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.12.6",
  "alloy-pubsub",
  "alloy-transport",
  "bytes",
@@ -5702,8 +5811,8 @@ name = "kona-genesis"
 version = "0.2.4"
 source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-sol-types",
  "derive_more 2.0.1",
@@ -5718,8 +5827,8 @@ name = "kona-interop"
 version = "0.2.4"
 source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-sol-types",
@@ -5739,11 +5848,11 @@ version = "0.2.4"
 source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
 dependencies = [
  "alloc-no-stdlib",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "async-trait",
  "brotli 7.0.0",
  "kona-genesis",
@@ -5777,7 +5886,7 @@ name = "kona-rpc"
 version = "0.1.1"
 source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "async-trait",
  "derive_more 2.0.1",
@@ -6962,11 +7071,11 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "971eaae9cfc8b6aabb62cef8d7d49640d2e8e948e5aa3177788c4dea3d226452"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "arbitrary",
  "derive_more 1.0.0",
  "serde",
@@ -6986,10 +7095,10 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "697a00d2d89e2e44c0ef2d1b3b7181dd529f5665c9c574bcfda5f975821a000f"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-network",
  "alloy-primitives 0.8.23",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "alloy-signer",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
@@ -7011,12 +7120,12 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "398b77b1fe4a9ca83d031d59a19fa9aa4ffcc2a896a83b7861a94292c2098412"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network-primitives",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
+ "alloy-network-primitives 0.12.6",
  "alloy-primitives 0.8.23",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "derive_more 1.0.0",
  "op-alloy-consensus",
  "serde",
@@ -7029,11 +7138,11 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b59251cd112cb10792a041ea68d9423391e0e9e3576605ee52800890fdaa483c"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "derive_more 1.0.0",
  "ethereum_ssz",
  "op-alloy-consensus",
@@ -7046,8 +7155,8 @@ dependencies = [
 name = "op-rbuilder"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-network",
  "alloy-op-evm",
  "alloy-primitives 0.8.23",
@@ -7055,8 +7164,8 @@ dependencies = [
  "alloy-rpc-client",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "alloy-transport",
  "alloy-transport-http",
  "async-trait",
@@ -8566,12 +8675,12 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-evm",
- "alloy-json-rpc",
+ "alloy-json-rpc 0.12.6",
  "alloy-network",
- "alloy-network-primitives",
+ "alloy-network-primitives 0.12.6",
  "alloy-node-bindings",
  "alloy-primitives 0.8.23",
  "alloy-provider",
@@ -8580,8 +8689,8 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
@@ -8779,8 +8888,8 @@ name = "reipc"
 version = "0.1.0"
 source = "git+https://github.com/nethermindeth/reipc.git?rev=806abf826a1ba54a8d291cac585be3e14a09418a#806abf826a1ba54a8d291cac585be3e14a09418a"
 dependencies = [
- "alloy-json-rpc",
- "alloy-primitives 0.8.21",
+ "alloy-json-rpc 0.11.1",
+ "alloy-primitives 0.8.23",
  "alloy-rpc-types-eth 0.11.1",
  "bytes",
  "crossbeam",
@@ -8897,8 +9006,8 @@ name = "reth"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types",
@@ -8970,8 +9079,8 @@ name = "reth-basic-payload-builder"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "futures-core",
  "futures-util",
@@ -8994,8 +9103,8 @@ name = "reth-chain-state"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-signer",
  "alloy-signer-local",
@@ -9025,8 +9134,8 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives 0.8.23",
@@ -9059,8 +9168,8 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "ahash",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "backon",
@@ -9129,7 +9238,7 @@ name = "reth-cli-util"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "cfg-if",
  "eyre",
@@ -9147,8 +9256,8 @@ name = "reth-codecs"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-genesis",
  "alloy-primitives 0.8.23",
  "alloy-trie",
@@ -9191,7 +9300,7 @@ name = "reth-consensus"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-primitives 0.8.23",
  "auto_impl",
  "reth-execution-types",
@@ -9204,8 +9313,8 @@ name = "reth-consensus-common"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -9216,8 +9325,8 @@ name = "reth-consensus-debug-client"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-provider",
  "alloy-rpc-types-engine",
@@ -9265,7 +9374,7 @@ name = "reth-db-api"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-genesis",
  "alloy-primitives 0.8.23",
  "arbitrary",
@@ -9293,7 +9402,7 @@ name = "reth-db-common"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-genesis",
  "alloy-primitives 0.8.23",
  "boyer-moore-magiclen",
@@ -9322,7 +9431,7 @@ name = "reth-db-models"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "arbitrary",
  "bytes",
@@ -9411,8 +9520,8 @@ name = "reth-downloaders"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "futures",
@@ -9472,7 +9581,7 @@ name = "reth-engine-local"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "eyre",
@@ -9503,7 +9612,7 @@ name = "reth-engine-primitives"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -9550,8 +9659,8 @@ name = "reth-engine-tree"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-evm",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
@@ -9595,7 +9704,7 @@ name = "reth-engine-util"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-rpc-types-engine",
  "eyre",
  "futures",
@@ -9663,8 +9772,8 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "bytes",
@@ -9693,8 +9802,8 @@ name = "reth-ethereum-consensus"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "reth-chainspec",
  "reth-consensus",
@@ -9709,7 +9818,7 @@ name = "reth-ethereum-engine-primitives"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -9740,8 +9849,8 @@ name = "reth-ethereum-payload-builder"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
@@ -9767,14 +9876,14 @@ name = "reth-ethereum-primitives"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "arbitrary",
  "derive_more 2.0.1",
  "modular-bitfield",
@@ -9803,8 +9912,8 @@ name = "reth-evm"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-evm",
  "alloy-primitives 0.8.23",
  "auto_impl",
@@ -9829,8 +9938,8 @@ name = "reth-evm-ethereum"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-evm",
  "alloy-primitives 0.8.23",
  "reth-chainspec",
@@ -9860,8 +9969,8 @@ name = "reth-execution-types"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-evm",
  "alloy-primitives 0.8.23",
  "derive_more 2.0.1",
@@ -9878,8 +9987,8 @@ name = "reth-exex"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "eyre",
  "futures",
@@ -9916,7 +10025,7 @@ name = "reth-exex-types"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "reth-chain-state",
  "reth-execution-types",
@@ -9940,7 +10049,7 @@ name = "reth-invalid-block-hooks"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -10047,8 +10156,8 @@ name = "reth-network"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "aquamarine",
@@ -10125,8 +10234,8 @@ name = "reth-network-p2p"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "auto_impl",
  "derive_more 2.0.1",
@@ -10218,8 +10327,8 @@ name = "reth-node-builder"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
@@ -10280,8 +10389,8 @@ name = "reth-node-core"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "clap 4.5.21",
@@ -10331,7 +10440,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "eyre",
  "reth-chainspec",
  "reth-consensus",
@@ -10365,8 +10474,8 @@ name = "reth-node-events"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
@@ -10424,8 +10533,8 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-genesis",
  "alloy-primitives 0.8.23",
  "derive_more 2.0.1",
@@ -10447,8 +10556,8 @@ name = "reth-optimism-cli"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "clap 4.5.21",
@@ -10494,8 +10603,8 @@ name = "reth-optimism-consensus"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-trie",
  "op-alloy-consensus",
@@ -10520,8 +10629,8 @@ name = "reth-optimism-evm"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-evm",
  "alloy-op-evm",
  "alloy-primitives 0.8.23",
@@ -10564,11 +10673,11 @@ name = "reth-optimism-node"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "clap 4.5.21",
  "eyre",
  "op-alloy-consensus",
@@ -10616,8 +10725,8 @@ name = "reth-optimism-payload-builder"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -10654,13 +10763,13 @@ name = "reth-optimism-primitives"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-evm",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
@@ -10683,12 +10792,12 @@ name = "reth-optimism-rpc"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "async-trait",
  "derive_more 2.0.1",
  "jsonrpsee 0.24.9",
@@ -10735,10 +10844,10 @@ name = "reth-optimism-txpool"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "c-kzg",
  "derive_more 2.0.1",
  "futures-util",
@@ -10763,7 +10872,7 @@ name = "reth-payload-builder"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-rpc-types",
  "futures-util",
  "metrics",
@@ -10795,7 +10904,7 @@ name = "reth-payload-primitives"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10814,7 +10923,7 @@ name = "reth-payload-util"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-primitives 0.8.23",
  "reth-transaction-pool",
 ]
@@ -10824,7 +10933,7 @@ name = "reth-payload-validator"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-rpc-types-engine",
  "reth-primitives-traits",
 ]
@@ -10834,7 +10943,7 @@ name = "reth-primitives"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "arbitrary",
  "c-kzg",
  "once_cell",
@@ -10849,8 +10958,8 @@ name = "reth-primitives-traits"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-genesis",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
@@ -10882,8 +10991,8 @@ name = "reth-provider"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -10928,8 +11037,8 @@ name = "reth-prune"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "itertools 0.14.0",
  "metrics",
@@ -10989,7 +11098,7 @@ name = "reth-ress-protocol"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "futures",
@@ -11008,7 +11117,7 @@ name = "reth-ress-provider"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-primitives 0.8.23",
  "eyre",
  "futures",
@@ -11050,9 +11159,9 @@ name = "reth-rpc"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -11063,11 +11172,11 @@ dependencies = [
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -11121,9 +11230,9 @@ name = "reth-rpc-api"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-genesis",
- "alloy-json-rpc",
+ "alloy-json-rpc 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
@@ -11131,11 +11240,11 @@ dependencies = [
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "jsonrpsee 0.24.9",
  "reth-engine-primitives",
  "reth-network-peers",
@@ -11184,7 +11293,7 @@ name = "reth-rpc-engine-api"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "async-trait",
@@ -11214,16 +11323,16 @@ name = "reth-rpc-eth-api"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-dyn-abi",
- "alloy-eips",
- "alloy-json-rpc",
+ "alloy-eips 0.12.6",
+ "alloy-json-rpc 0.12.6",
  "alloy-network",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "alloy-rpc-types-mev",
- "alloy-serde",
+ "alloy-serde 0.12.6",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -11257,10 +11366,10 @@ name = "reth-rpc-eth-types"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "alloy-sol-types",
  "derive_more 2.0.1",
  "futures",
@@ -11313,7 +11422,7 @@ name = "reth-rpc-server-types"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "jsonrpsee-core 0.24.9",
@@ -11329,9 +11438,9 @@ name = "reth-rpc-types-compat"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-primitives 0.8.23",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "jsonrpsee-types 0.24.9",
  "reth-primitives-traits",
  "serde",
@@ -11342,8 +11451,8 @@ name = "reth-stages"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "bincode",
  "blake3",
@@ -11384,7 +11493,7 @@ name = "reth-stages-api"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "aquamarine",
  "auto_impl",
@@ -11458,8 +11567,8 @@ name = "reth-storage-api"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -11482,7 +11591,7 @@ name = "reth-storage-errors"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "derive_more 2.0.1",
@@ -11516,8 +11625,8 @@ name = "reth-testing-utils"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-genesis",
  "alloy-primitives 0.8.23",
  "rand 0.8.5",
@@ -11556,8 +11665,8 @@ name = "reth-transaction-pool"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "aquamarine",
@@ -11594,8 +11703,8 @@ name = "reth-trie"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.12.6",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
  "alloy-trie",
@@ -11619,11 +11728,11 @@ name = "reth-trie-common"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "alloy-trie",
  "arbitrary",
  "bytes",
@@ -11778,7 +11887,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47887f741101187d1bde69c8840eefefd6152788f5e0d4fc2eb5068a1ae16483"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "auto_impl",
  "revm-bytecode",
  "revm-database-interface",
@@ -11841,7 +11950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1504e2851a11562fb350a9f408e5783351650aef11790aea0b0d0d9ab961c40"
 dependencies = [
  "alloy-primitives 0.8.23",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.12.6",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
@@ -12038,11 +12147,11 @@ name = "rollup-boost"
 version = "0.1.0"
 source = "git+http://github.com/flashbots/rollup-boost?rev=6b94e1037f41e0817f2bcb1f1ca5013a5359616a#6b94e1037f41e0817f2bcb1f1ca5013a5359616a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.12.6",
+ "alloy-serde 0.12.6",
  "clap 4.5.21",
  "dotenv",
  "eyre",
@@ -13708,8 +13817,8 @@ name = "test-relay"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "alloy-consensus",
- "alloy-json-rpc",
+ "alloy-consensus 0.12.6",
+ "alloy-json-rpc 0.12.6",
  "alloy-primitives 0.8.23",
  "alloy-provider",
  "clap 4.5.21",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8300,6 +8300,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick_cache"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af25b4e960ffdf0dead61cf0cec0c2e44c76927bf933ab4f02e2858fb449397"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.15.2",
+ "parking_lot",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8615,6 +8627,7 @@ dependencies = [
  "primitive-types",
  "priority-queue",
  "prometheus",
+ "quick_cache",
  "rand 0.8.5",
  "rayon",
  "redis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8886,7 +8886,7 @@ dependencies = [
 [[package]]
 name = "reipc"
 version = "0.1.0"
-source = "git+https://github.com/nethermindeth/reipc.git?rev=806abf826a1ba54a8d291cac585be3e14a09418a#806abf826a1ba54a8d291cac585be3e14a09418a"
+source = "git+https://github.com/nethermindeth/reipc.git?rev=8a9c31f7a4b7dfdd828020222ae1ccdff802cbc9#8a9c31f7a4b7dfdd828020222ae1ccdff802cbc9"
 dependencies = [
  "alloy-json-rpc 0.11.1",
  "alloy-primitives 0.8.23",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8618,6 +8618,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "redis",
+ "reipc",
  "reqwest 0.12.9",
  "reth",
  "reth-basic-payload-builder",
@@ -8758,6 +8759,22 @@ checksum = "1541daf4e4ed43a0922b7969bdc2170178bcacc5dabf7e39bc508a9fa3953a7a"
 dependencies = [
  "hashbrown 0.14.5",
  "memchr",
+]
+
+[[package]]
+name = "reipc"
+version = "0.1.0"
+source = "git+https://github.com/nethermindeth/reipc.git?rev=806abf826a1ba54a8d291cac585be3e14a09418a#806abf826a1ba54a8d291cac585be3e14a09418a"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives 0.8.21",
+ "alloy-rpc-types-eth 0.11.1",
+ "bytes",
+ "crossbeam",
+ "dashmap 6.1.0",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -137,7 +137,7 @@ parking_lot.workspace = true
 dashmap = "6.1.0"
 
 # IPC state provider deps
-reipc = { git = "https://github.com/nethermindeth/reipc.git", rev = "806abf826a1ba54a8d291cac585be3e14a09418a" }
+reipc = { git = "https://github.com/nethermindeth/reipc.git", rev = "8a9c31f7a4b7dfdd828020222ae1ccdff802cbc9" }
 quick_cache = "0.6.11"
 
 

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -135,7 +135,10 @@ sysperf.workspace = true
 crossbeam = "0.8.4"
 parking_lot.workspace = true
 dashmap = "6.1.0"
+
+# IPC state provider deps
 reipc = { git = "https://github.com/nethermindeth/reipc.git", rev = "806abf826a1ba54a8d291cac585be3e14a09418a" }
+quick_cache = "0.6.11"
 
 
 

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -135,6 +135,8 @@ sysperf.workspace = true
 crossbeam = "0.8.4"
 parking_lot.workspace = true
 dashmap = "6.1.0"
+reipc = { git = "https://github.com/nethermindeth/reipc.git", rev = "806abf826a1ba54a8d291cac585be3e14a09418a" }
+
 
 
 [build-dependencies]

--- a/crates/rbuilder/src/backtest/backtest_build_range.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_range.rs
@@ -111,7 +111,7 @@ where
         result
     };
 
-    let provider_factory = config.base_config().create_provider_factory(true)?;
+    let provider_factory = config.base_config().create_reth_provider_factory(true)?;
     let chain_spec = config.base_config().chain_spec()?;
 
     let mut profits = Vec::new();

--- a/crates/rbuilder/src/backtest/build_block/landed_block_from_db.rs
+++ b/crates/rbuilder/src/backtest/build_block/landed_block_from_db.rs
@@ -111,7 +111,7 @@ impl<ConfigType: LiveBuilderConfig>
         &self,
     ) -> eyre::Result<ProviderFactoryReopener<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>>
     {
-        self.config.base_config().create_provider_factory(true)
+        self.config.base_config().create_reth_provider_factory(true)
     }
 
     fn create_block_building_context(&self) -> eyre::Result<BlockBuildingContext> {

--- a/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
@@ -67,7 +67,7 @@ where
     let mut historical_data_storage =
         HistoricalDataStorage::new_from_path(&config.base_config().backtest_fetch_output_file)
             .await?;
-    let provider = config.base_config().create_provider_factory(true)?;
+    let provider = config.base_config().create_reth_provider_factory(true)?;
     let csv_writer = cli
         .csv
         .map(|path| -> io::Result<_> { CSVResultWriter::new(path) })

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -42,7 +42,7 @@ async fn main() -> eyre::Result<()> {
 
     let chain_spec = config.base_config().chain_spec()?;
 
-    let provider_factory = config.base_config().create_provider_factory(false)?;
+    let provider_factory = config.base_config().create_reth_provider_factory(false)?;
 
     let last_block = provider_factory.last_block_number()?;
 

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -26,8 +26,8 @@ use rbuilder::{
         block_list_provider::NullBlockListProvider,
         config::create_provider_factory,
         order_input::{
-            OrderInputConfig, DEFAULT_INPUT_CHANNEL_BUFFER_SIZE, DEFAULT_RESULTS_CHANNEL_TIMEOUT,
-            DEFAULT_SERVE_MAX_CONNECTIONS,
+            OrderInputConfig, TxpoolSource, DEFAULT_INPUT_CHANNEL_BUFFER_SIZE,
+            DEFAULT_RESULTS_CHANNEL_TIMEOUT, DEFAULT_SERVE_MAX_CONNECTIONS,
         },
         payload_events::{MevBoostSlotData, MevBoostSlotDataGenerator},
         simulation::SimulatedOrderCommand,
@@ -76,7 +76,7 @@ async fn main() -> eyre::Result<()> {
     let order_input_config = OrderInputConfig::new(
         false,
         true,
-        Some(PathBuf::from(DEFAULT_EL_NODE_IPC_PATH)),
+        Some(TxpoolSource::Ipc(PathBuf::from(DEFAULT_EL_NODE_IPC_PATH))),
         DEFAULT_INCOMING_BUNDLES_PORT,
         default_ip(),
         DEFAULT_SERVE_MAX_CONNECTIONS,

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -26,7 +26,7 @@ use rbuilder::{
         block_list_provider::NullBlockListProvider,
         config::create_provider_factory,
         order_input::{
-            OrderInputConfig, TxpoolSource, DEFAULT_INPUT_CHANNEL_BUFFER_SIZE,
+            MempoolSource, OrderInputConfig, DEFAULT_INPUT_CHANNEL_BUFFER_SIZE,
             DEFAULT_RESULTS_CHANNEL_TIMEOUT, DEFAULT_SERVE_MAX_CONNECTIONS,
         },
         payload_events::{MevBoostSlotData, MevBoostSlotDataGenerator},
@@ -76,7 +76,7 @@ async fn main() -> eyre::Result<()> {
     let order_input_config = OrderInputConfig::new(
         false,
         true,
-        Some(TxpoolSource::Ipc(PathBuf::from(DEFAULT_EL_NODE_IPC_PATH))),
+        Some(MempoolSource::Ipc(PathBuf::from(DEFAULT_EL_NODE_IPC_PATH))),
         DEFAULT_INCOMING_BUNDLES_PORT,
         default_ip(),
         DEFAULT_SERVE_MAX_CONNECTIONS,

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -305,7 +305,7 @@ impl BaseConfig {
 
         Ok(IpcStateProviderFactory::new(
             &ipc_provider_config.ipc_path,
-            ipc_provider_config.request_timeout,
+            Duration::from_millis(ipc_provider_config.request_timeout),
         ))
     }
 

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -305,7 +305,7 @@ impl BaseConfig {
 
         Ok(IpcStateProviderFactory::new(
             &ipc_provider_config.ipc_path,
-            Duration::from_millis(ipc_provider_config.request_timeout),
+            Duration::from_millis(ipc_provider_config.request_timeout_ms),
         ))
     }
 

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -5,7 +5,7 @@ use crate::{
     live_builder::{order_input::OrderInputConfig, LiveBuilder},
     provider::{
         ipc_state_provider::{IpcProviderConfig, IpcStateProviderFactory},
-        StateProviderFactories, StateProviderFactory,
+        StateProviderFactory,
     },
     roothash::RootHashContext,
     telemetry::{setup_reloadable_tracing_subscriber, LoggerConfig},
@@ -307,19 +307,6 @@ impl BaseConfig {
             &ipc_provider_config.ipc_path,
             Duration::from_millis(ipc_provider_config.request_timeout_ms),
         ))
-    }
-
-    pub fn create_provider_factory_from_config(
-        &self,
-        skip_root_hash: bool,
-    ) -> eyre::Result<StateProviderFactories> {
-        if self.ipc_provider.is_some() {
-            self.create_ipc_provider_factory()
-                .map(StateProviderFactories::Ipc)
-        } else {
-            self.create_reth_provider_factory(skip_root_hash)
-                .map(StateProviderFactories::Reth)
-        }
     }
 
     /// live_root_hash_config creates a root hash thread pool

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -277,7 +277,7 @@ impl BaseConfig {
 
     /// Open reth db and DB should be opened once per process but it can be cloned and moved to different threads.
     /// skip_root_hash -> will create a mock roothasher. Used on backtesting since reth can't compute roothashes on the past.
-    pub fn create_provider_factory(
+    pub fn create_reth_provider_factory(
         &self,
         skip_root_hash: bool,
     ) -> eyre::Result<ProviderFactoryReopener<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>>
@@ -309,7 +309,7 @@ impl BaseConfig {
         ))
     }
 
-    pub fn get_provider_factory_from_config(
+    pub fn create_provider_factory_from_config(
         &self,
         skip_root_hash: bool,
     ) -> eyre::Result<StateProviderFactories> {
@@ -317,7 +317,7 @@ impl BaseConfig {
             self.create_ipc_provider_factory()
                 .map(StateProviderFactories::Ipc)
         } else {
-            self.create_provider_factory(skip_root_hash)
+            self.create_reth_provider_factory(skip_root_hash)
                 .map(StateProviderFactories::Reth)
         }
     }

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -120,7 +120,9 @@ where
         config.base_config().log_enable_dynamic,
     )
     .await?;
-    let provider = config.base_config().create_provider_factory(false)?;
+    let provider = config
+        .base_config()
+        .get_provider_factory_from_config(false)?;
     let builder = config.new_builder(provider, cancel.clone()).await?;
 
     let ctrlc = tokio::spawn(async move {

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -122,7 +122,7 @@ where
     .await?;
     let provider = config
         .base_config()
-        .get_provider_factory_from_config(false)?;
+        .create_provider_factory_from_config(false)?;
     let builder = config.new_builder(provider, cancel.clone()).await?;
 
     let ctrlc = tokio::spawn(async move {

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -107,8 +107,6 @@ where
     let config: ConfigType = load_config_toml_and_env(cli.config)?;
     config.base_config().setup_tracing_subscriber()?;
 
-    let cancel = CancellationToken::new();
-
     // Spawn redacted server that is safe for tdx builders to expose
     telemetry::servers::redacted::spawn(config.base_config().redacted_telemetry_server_address())
         .await?;
@@ -120,9 +118,25 @@ where
         config.base_config().log_enable_dynamic,
     )
     .await?;
-    let provider = config
-        .base_config()
-        .create_provider_factory_from_config(false)?;
+    if config.base_config().ipc_provider.is_some() {
+        let provider = config.base_config().create_ipc_provider_factory()?;
+        run_builder(provider, config, on_run).await
+    } else {
+        let provider = config.base_config().create_reth_provider_factory(false)?;
+        run_builder(provider, config, on_run).await
+    }
+}
+
+async fn run_builder<P, ConfigType>(
+    provider: P,
+    config: ConfigType,
+    on_run: Option<fn()>,
+) -> eyre::Result<()>
+where
+    ConfigType: LiveBuilderConfig,
+    P: StateProviderFactory + Clone + 'static,
+{
+    let cancel = CancellationToken::new();
     let builder = config.new_builder(provider, cancel.clone()).await?;
 
     let ctrlc = tokio::spawn(async move {
@@ -133,7 +147,6 @@ where
         on_run();
     }
     builder.run().await?;
-
     ctrlc.await.unwrap_or_default();
     Ok(())
 }

--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -130,7 +130,7 @@ impl OrderInputConfig {
 
     pub fn from_config(config: &BaseConfig) -> eyre::Result<Self> {
         let mempool = if let Some(provider) = &config.ipc_provider {
-            Some(MempoolSource::Ws(provider.txpool_server_url.clone()))
+            Some(MempoolSource::Ws(provider.mempool_server_url.clone()))
         } else if let Some(path) = &config.el_node_ipc_path {
             let expanded_path = expand_path(path.as_path())?;
             Some(MempoolSource::Ipc(expanded_path))

--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -232,7 +232,7 @@ where
     let mut handles = vec![clean_job, rpc_server];
 
     if config.mempool_source.is_some() {
-        info!("IPC path configured, starting txpool subscription");
+        info!("Txpool source configured, starting txpool subscription");
         let txpool_fetcher = txpool_fetcher::subscribe_to_txpool_with_blobs(
             config.clone(),
             order_sender.clone(),
@@ -241,7 +241,7 @@ where
         .await?;
         handles.push(txpool_fetcher);
     } else {
-        info!("No IPC path configured, skipping txpool subscription");
+        info!("No Txpool source configured, skipping txpool subscription");
     }
 
     let handle = tokio::spawn(async move {

--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -75,7 +75,7 @@ impl Drop for AutoRemovingOrderPoolSubscriptionId {
 }
 
 #[derive(Debug, Clone)]
-pub enum TxpoolSource {
+pub enum MempoolSource {
     Ipc(PathBuf),
     Ws(String),
 }
@@ -87,8 +87,8 @@ pub struct OrderInputConfig {
     ignore_cancellable_orders: bool,
     /// if true -- txs with blobs are ignored
     ignore_blobs: bool,
-    /// Txpool source
-    tx_source: Option<TxpoolSource>,
+    /// Tx pool source
+    mempool_source: Option<MempoolSource>,
     /// Input RPC port
     server_port: u16,
     /// Input RPC ip
@@ -109,7 +109,7 @@ impl OrderInputConfig {
     pub fn new(
         ignore_cancellable_orders: bool,
         ignore_blobs: bool,
-        tx_source: Option<TxpoolSource>,
+        mempool_source: Option<MempoolSource>,
         server_port: u16,
         server_ip: Ipv4Addr,
         serve_max_connections: u32,
@@ -119,7 +119,7 @@ impl OrderInputConfig {
         Self {
             ignore_cancellable_orders,
             ignore_blobs,
-            tx_source,
+            mempool_source,
             server_port,
             server_ip,
             serve_max_connections,
@@ -129,11 +129,11 @@ impl OrderInputConfig {
     }
 
     pub fn from_config(config: &BaseConfig) -> eyre::Result<Self> {
-        let tx_source = if let Some(provider) = &config.ipc_provider {
-            Some(TxpoolSource::Ws(provider.txpool_server_url.clone()))
+        let mempool = if let Some(provider) = &config.ipc_provider {
+            Some(MempoolSource::Ws(provider.txpool_server_url.clone()))
         } else if let Some(path) = &config.el_node_ipc_path {
             let expanded_path = expand_path(path.as_path())?;
-            Some(TxpoolSource::Ipc(expanded_path))
+            Some(MempoolSource::Ipc(expanded_path))
         } else {
             None
         };
@@ -141,7 +141,7 @@ impl OrderInputConfig {
         Ok(OrderInputConfig {
             ignore_cancellable_orders: config.ignore_cancellable_orders,
             ignore_blobs: config.ignore_blobs,
-            tx_source,
+            mempool_source: mempool,
             server_port: config.jsonrpc_server_port,
             server_ip: config.jsonrpc_server_ip,
             serve_max_connections: 4096,
@@ -152,7 +152,7 @@ impl OrderInputConfig {
 
     pub fn default_e2e() -> Self {
         Self {
-            tx_source: Some(TxpoolSource::Ipc(PathBuf::from("/tmp/anvil.ipc"))),
+            mempool_source: Some(MempoolSource::Ipc(PathBuf::from("/tmp/anvil.ipc"))),
             results_channel_timeout: Duration::new(5, 0),
             ignore_cancellable_orders: false,
             ignore_blobs: false,
@@ -231,7 +231,7 @@ where
 
     let mut handles = vec![clean_job, rpc_server];
 
-    if config.tx_source.is_some() {
+    if config.mempool_source.is_some() {
         info!("IPC path configured, starting txpool subscription");
         let txpool_fetcher = txpool_fetcher::subscribe_to_txpool_with_blobs(
             config.clone(),

--- a/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
+++ b/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
@@ -26,7 +26,7 @@ pub async fn subscribe_to_txpool_with_blobs(
 ) -> eyre::Result<JoinHandle<()>> {
     let mempool = config
         .mempool_source
-        .ok_or_else(|| eyre::eyre!("No TX source configured"))?;
+        .ok_or_else(|| eyre::eyre!("No txpool source configured"))?;
 
     let provider = match mempool {
         MempoolSource::Ipc(path) => {

--- a/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
+++ b/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
@@ -1,4 +1,4 @@
-use super::{OrderInputConfig, ReplaceableOrderPoolCommand, TxpoolSource};
+use super::{MempoolSource, OrderInputConfig, ReplaceableOrderPoolCommand};
 use crate::{
     primitives::{MempoolTx, Order, TransactionSignedEcRecoveredWithBlobs},
     telemetry::{add_txfetcher_time_to_query, mark_command_received},
@@ -24,16 +24,16 @@ pub async fn subscribe_to_txpool_with_blobs(
     results: mpsc::Sender<ReplaceableOrderPoolCommand>,
     global_cancel: CancellationToken,
 ) -> eyre::Result<JoinHandle<()>> {
-    let tx_source = config
-        .tx_source
+    let mempool = config
+        .mempool_source
         .ok_or_else(|| eyre::eyre!("No TX source configured"))?;
 
-    let provider = match tx_source {
-        TxpoolSource::Ipc(path) => {
+    let provider = match mempool {
+        MempoolSource::Ipc(path) => {
             let ipc = IpcConnect::new(path);
             ProviderBuilder::new().on_ipc(ipc).await?
         }
-        TxpoolSource::Ws(url) => {
+        MempoolSource::Ws(url) => {
             let ws_conn = alloy_provider::WsConnect::new(url);
             ProviderBuilder::new().on_ws(ws_conn).await?
         }
@@ -64,7 +64,7 @@ pub async fn subscribe_to_txpool_with_blobs(
                     continue;
                 }
                 Err(err) => {
-                    error!(?tx_hash, ?err, "Failed to get tx pool");
+                    error!(?tx_hash, ?err, "Failed to get tx from pool");
                     continue;
                 }
             };
@@ -136,7 +136,7 @@ mod test {
         let (sender, mut receiver) = mpsc::channel(10);
         subscribe_to_txpool_with_blobs(
             OrderInputConfig {
-                tx_source: Some(TxpoolSource::Ipc(PathBuf::from("/tmp/anvil.ipc"))),
+                mempool_source: Some(MempoolSource::Ipc(PathBuf::from("/tmp/anvil.ipc"))),
                 ..OrderInputConfig::default_e2e()
             },
             sender,

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -66,7 +66,7 @@ impl IpcStateProviderFactory {
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields)]
 pub struct IpcProviderConfig {
-    pub(crate) request_timeout: Duration,
+    pub(crate) request_timeout: u64,
     pub(crate) ipc_path: PathBuf,
     pub(crate) txpool_server_url: String,
 }
@@ -74,7 +74,7 @@ pub struct IpcProviderConfig {
 impl Default for IpcProviderConfig {
     fn default() -> Self {
         Self {
-            request_timeout: Duration::from_millis(DEFAULT_IPC_REQUEST_TIMEOUT_MS),
+            request_timeout: DEFAULT_IPC_REQUEST_TIMEOUT_MS,
             txpool_server_url: String::new(),
             ipc_path: PathBuf::new(),
         }

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -1,0 +1,554 @@
+use std::{fmt::Debug, path::Path, sync::Arc, time::Duration};
+
+use alloy_consensus::{constants::KECCAK_EMPTY, Header};
+use alloy_eips::{BlockId, BlockNumHash, BlockNumberOrTag};
+use alloy_primitives::{BlockHash, BlockNumber, StorageKey, StorageValue, U64};
+use dashmap::DashMap;
+use reipc::rpc_provider::RpcProvider;
+use reth_errors::{ProviderError, ProviderResult};
+use reth_primitives::{Account, Bytecode};
+use reth_provider::{
+    AccountReader, BlockHashReader, HashedPostStateProvider, StateProofProvider, StateProvider,
+    StateProviderBox, StateRootProvider, StorageRootProvider,
+};
+use reth_trie::{
+    updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
+    MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
+};
+use revm::db::{BundleAccount, BundleState};
+use revm_primitives::{map::B256HashMap, Address, Bytes, HashMap, B256, U256};
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+use tracing::{trace, trace_span};
+
+use crate::live_builder::simulation::SimulatedOrderCommand;
+
+use super::{RootHasher, StateProviderFactory};
+
+/// After how many milliseconds should we give up on an IPC request (consider it failed)
+/// 100ms was picked up after initial testing using Nethermind client as state provider
+/// 99.9% requests return within 50ms; using 100ms gives us error rate of ~0.03%
+/// Median response time is ~300 micro_sec.
+const IPC_REQUEST_TIMEOUT_MS: u64 = 100;
+
+/// Remote state provider factory allows providing state via remote RPC calls over IPC
+/// Specifically UnixDomainSockets
+#[derive(Clone)]
+pub struct IpcStateProviderFactory {
+    ipc_provider: RpcProvider,
+
+    code_cache: Arc<DashMap<B256, Bytecode>>,
+    //TODO: invalidate cache for old blocks
+    state_provider_by_hash: Arc<DashMap<BlockHash, Arc<IpcStateProvider>>>,
+}
+
+impl IpcStateProviderFactory {
+    pub fn new(ipc_path: &Path) -> Self {
+        let ipc_provider = RpcProvider::try_connect(
+            ipc_path,
+            Duration::from_millis(IPC_REQUEST_TIMEOUT_MS).into(),
+        )
+        // there is no need to gracefully handle (or propagate) this error, if we cannot connect
+        // to IPC, then rbuilder cannot work
+        .expect("Can't connect to IPC");
+
+        Self {
+            ipc_provider,
+            code_cache: Arc::new(DashMap::new()),
+            state_provider_by_hash: Arc::new(DashMap::new()),
+        }
+    }
+}
+
+impl StateProviderFactory for IpcStateProviderFactory {
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
+        let state = IpcStateProvider::into_boxed(
+            self.ipc_provider.clone(),
+            BlockNumberOrTag::Latest.into(),
+            self.code_cache.clone(),
+        );
+
+        Ok(state)
+    }
+
+    // We are not caching state provider by block number to avoid any issues with reorgs
+    // The calls to  history_by_block_number are rare and we shouldn't be loosing perf by not
+    // leveraging caching here
+    fn history_by_block_number(&self, block: BlockNumber) -> ProviderResult<StateProviderBox> {
+        let state = IpcStateProvider::into_boxed(
+            self.ipc_provider.clone(),
+            block.into(),
+            self.code_cache.clone(),
+        );
+
+        Ok(state)
+    }
+
+    fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
+        if let Some(state) = self.state_provider_by_hash.get(&block) {
+            return Ok(Box::new(state.clone()));
+        }
+
+        let state = IpcStateProvider::into_boxed(
+            self.ipc_provider.clone(),
+            block.into(),
+            self.code_cache.clone(),
+        );
+
+        self.state_provider_by_hash.insert(block, *state.clone());
+        Ok(state)
+    }
+
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
+        let id: u64 = rand::random();
+        let span = trace_span!("header", id, block_hash = %block_hash.to_string());
+        let _guard = span.enter();
+        trace!("header: get");
+
+        let header = self
+            .ipc_provider
+            .call::<_, Option<<alloy_network::Ethereum as alloy_network::Network>::BlockResponse>>(
+                "eth_getBlockByHash",
+                (block_hash, false),
+            )
+            .map_err(transport_to_provider_error)?
+            .map(|b| b.header.inner);
+
+        if header.is_none() {
+            trace!("header: got none");
+            return Ok(None);
+        }
+
+        trace!("header: got");
+
+        Ok(header)
+    }
+
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        let id: u64 = rand::random();
+        let span = trace_span!("block_hash provider factory", id, block_num = number);
+        let _guard = span.enter();
+        trace!("block_hash:get");
+
+        let block_hash = self
+            .ipc_provider
+            .call::<_, B256>("rbuilder_getBlockHash", (BlockNumberOrTag::Number(number),))
+            .map_err(transport_to_provider_error)?;
+
+        trace!("block_hash: got");
+        Ok(Some(block_hash))
+    }
+
+    //TODO: is this correct?
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        self.last_block_number()
+    }
+
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
+        let id: u64 = rand::random();
+        let span = trace_span!("header_by_number", id, block_num = num);
+        let _guard = span.enter();
+        trace!("header_by_num:get");
+
+        let block = self
+            .ipc_provider
+            .call::<_, Option<<alloy_network::Ethereum as alloy_network::Network>::BlockResponse>>(
+                "eth_getBlockByNumber",
+                (num, false),
+            )
+            .map_err(transport_to_provider_error)?;
+
+        if block.is_none() {
+            trace!("header_by_num: got none");
+            return Ok(None);
+        }
+
+        trace!("header_by_num: got");
+
+        Ok(block.map(|b| b.header.inner))
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        let id: u64 = rand::random();
+        let span = trace_span!("last_block_num", id);
+        let _guard = span.enter();
+        trace!("last_block_num:get");
+
+        let block_num = self
+            .ipc_provider
+            .call::<_, U64>("eth_blockNumber", ())
+            .map_err(transport_to_provider_error)?
+            .to::<u64>();
+
+        trace!("last_block_num: got");
+        Ok(block_num)
+    }
+
+    fn root_hasher(&self, parent_hash: BlockNumHash) -> ProviderResult<Box<dyn RootHasher>> {
+        Ok(Box::new(StatRootHashCalculator {
+            remote_provider: self.ipc_provider.clone(),
+            parent_hash: parent_hash.hash,
+        }))
+    }
+}
+
+#[derive(Clone)]
+pub struct IpcStateProvider {
+    ipc_provider: RpcProvider,
+    block_id: BlockId,
+
+    //Per block cache
+    block_hash_cache: DashMap<u64, BlockHash>,
+    storage_cache: DashMap<(Address, StorageKey), StorageValue>,
+    account_cache: DashMap<Address, Account>,
+
+    // Global cache (cache not related to specific block)
+    code_cache: Arc<DashMap<B256, Bytecode>>,
+}
+
+impl IpcStateProvider {
+    /// Crates new instance of state provider
+    fn new(
+        ipc_provider: RpcProvider,
+        block_id: BlockId,
+        code_cache: Arc<DashMap<B256, Bytecode>>,
+    ) -> Self {
+        Self {
+            ipc_provider,
+            block_id,
+
+            code_cache,
+
+            block_hash_cache: DashMap::new(),
+            storage_cache: DashMap::new(),
+            account_cache: DashMap::new(),
+        }
+    }
+
+    /// Crates new instance of state provider on the heap
+    // Box::new(Arc::new(Self)) is required because StateProviderFactory returns Box<dyn StateProvider>
+    fn into_boxed(
+        ipc_provider: RpcProvider,
+        block_id: BlockId,
+        code_cache: Arc<DashMap<B256, Bytecode>>,
+    ) -> Box<Arc<Self>> {
+        Box::new(Arc::new(Self::new(ipc_provider, block_id, code_cache)))
+    }
+}
+
+impl StateProvider for IpcStateProvider {
+    /// Get storage of given account
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        let id: u64 = rand::random();
+        let span = trace_span!("storage", id);
+        let _guard = span.enter();
+        trace!("storage:get");
+
+        if let Some(storage) = self.storage_cache.get(&(account, storage_key)) {
+            return Ok(Some(*storage));
+        }
+
+        let key: U256 = storage_key.into();
+        let storage = self
+            .ipc_provider
+            .call::<_, StorageValue>("eth_getStorageAt", (account, key))
+            .map_err(transport_to_provider_error)?;
+
+        self.storage_cache.insert((account, storage_key), storage);
+
+        trace!("got storage");
+        Ok(Some(storage))
+    }
+
+    /// Get account code by its hash
+    /// IMPORTANT: Assumes remote provider (node) has RPC call:"rbuilder_getCodeByHash"
+    fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
+        let id: u64 = rand::random();
+        let span = trace_span!("bytecode", id);
+        let _guard = span.enter();
+        trace!("bytecode:get");
+
+        if code_hash.is_zero() {
+            trace!("bytecode: hash is zero");
+            return Ok(None);
+        }
+
+        if *code_hash == KECCAK_EMPTY {
+            trace!("bytecode: hash is empty");
+            return Ok(None);
+        }
+
+        if let Some(bytecode) = self.code_cache.get(code_hash) {
+            trace!("bytecode: cache hit");
+            return Ok(Some(bytecode.clone()));
+        }
+
+        let bytes = self
+            .ipc_provider
+            .call::<_, Bytes>("rbuilder_getCodeByHash", (code_hash,))
+            .map_err(transport_to_provider_error)?;
+
+        let bytecode = Bytecode::new_raw(bytes);
+
+        self.code_cache.insert(*code_hash, bytecode.clone());
+        trace!("bytecode: got");
+
+        Ok(Some(bytecode))
+    }
+}
+
+impl BlockHashReader for IpcStateProvider {
+    /// Get the hash of the block with the given number. Returns `None` if no block with this number exists
+    /// IMPORTANT: Assumes IPC provider (node) has RPC call:"rbuilder_getBlockHash"
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        let id: u64 = rand::random();
+        let span = trace_span!("block_hash provider", id);
+        let _guard = span.enter();
+        trace!("block_hash: get");
+
+        if let Some(hash) = self.block_hash_cache.get(&number) {
+            return Ok(Some(*hash));
+        }
+        let block_hash = self
+            .ipc_provider
+            .call::<_, B256>("rbuilder_getBlockHash", (BlockNumberOrTag::Number(number),))
+            .map_err(transport_to_provider_error)?;
+
+        self.block_hash_cache.insert(number, block_hash);
+        trace!("block_hash provider: got");
+        Ok(Some(block_hash))
+    }
+
+    fn canonical_hashes_range(
+        &self,
+        _start: BlockNumber,
+        _end: BlockNumber,
+    ) -> ProviderResult<Vec<B256>> {
+        unimplemented!()
+    }
+}
+
+impl AccountReader for IpcStateProvider {
+    /// Get basic account information.
+    /// IMPORTANT: Assumes IPC provider (node) has RPC call:"rbuilder_getAccount"
+    /// Returns `None` if the account doesn't exist.
+    fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
+        let id: u64 = rand::random();
+        let span = trace_span!("account", id, address = address.to_string());
+        let _guard = span.enter();
+        trace!("account: get");
+
+        if let Some(account) = self.account_cache.get(address) {
+            return Ok(Some(*account));
+        }
+
+        let account = self
+            .ipc_provider
+            .call::<_, AccountState>("rbuilder_getAccount", (*address, self.block_id))
+            .map_err(transport_to_provider_error)?;
+
+        let account = Account {
+            nonce: account.nonce.try_into().unwrap(),
+            bytecode_hash: account.code_hash.into(),
+            balance: account.balance,
+        };
+
+        self.account_cache.insert(*address, account);
+
+        trace!("account: got");
+        Ok(Some(account))
+    }
+}
+
+impl StateRootProvider for IpcStateProvider {
+    fn state_root(&self, _hashed_state: HashedPostState) -> ProviderResult<B256> {
+        unimplemented!()
+    }
+
+    fn state_root_from_nodes(&self, _input: TrieInput) -> ProviderResult<B256> {
+        unimplemented!()
+    }
+
+    fn state_root_with_updates(
+        &self,
+        _hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        unimplemented!()
+    }
+
+    fn state_root_from_nodes_with_updates(
+        &self,
+        _input: TrieInput,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        unimplemented!()
+    }
+}
+
+impl StorageRootProvider for IpcStateProvider {
+    fn storage_root(
+        &self,
+        _address: Address,
+        _hashed_storage: HashedStorage,
+    ) -> ProviderResult<B256> {
+        unimplemented!()
+    }
+
+    fn storage_proof(
+        &self,
+        _address: Address,
+        _slot: B256,
+        _hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageProof> {
+        unimplemented!()
+    }
+
+    fn storage_multiproof(
+        &self,
+        _address: Address,
+        _slots: &[B256],
+        _hashed_storage: HashedStorage,
+    ) -> ProviderResult<StorageMultiProof> {
+        unimplemented!()
+    }
+}
+
+impl StateProofProvider for IpcStateProvider {
+    fn proof(
+        &self,
+        _input: TrieInput,
+        _address: Address,
+        _slots: &[B256],
+    ) -> ProviderResult<AccountProof> {
+        unimplemented!()
+    }
+
+    fn multiproof(
+        &self,
+        _input: TrieInput,
+        _targets: MultiProofTargets,
+    ) -> ProviderResult<MultiProof> {
+        unimplemented!()
+    }
+
+    fn witness(
+        &self,
+        _input: TrieInput,
+        _target: HashedPostState,
+    ) -> ProviderResult<B256HashMap<Bytes>> {
+        unimplemented!()
+    }
+}
+
+impl HashedPostStateProvider for IpcStateProvider {
+    fn hashed_post_state(&self, _bundle_state: &BundleState) -> HashedPostState {
+        unimplemented!()
+    }
+}
+
+#[derive(Clone)]
+pub struct StatRootHashCalculator {
+    remote_provider: RpcProvider,
+    parent_hash: B256,
+}
+
+impl RootHasher for StatRootHashCalculator {
+    fn run_prefetcher(
+        &self,
+        _simulated_orders: broadcast::Receiver<SimulatedOrderCommand>,
+        _cancel: CancellationToken,
+    ) {
+        unimplemented!()
+    }
+
+    /// Calculates the state root given changed accounts
+    /// IMPORTANT: Assumes IPC provider (node) has RPC call:"rbuilder_calculateStateRoot"
+    fn state_root(
+        &self,
+        outcome: &reth_provider::ExecutionOutcome,
+    ) -> Result<B256, crate::roothash::RootHashError> {
+        let id: u64 = rand::random();
+        let span = trace_span!("state_root", id, block = outcome.first_block);
+        let _guard = span.enter();
+        trace!("state_root: get");
+
+        let account_diff: HashMap<Address, AccountDiff> = outcome
+            .bundle
+            .state
+            .iter()
+            .map(|(address, diff)| (*address, diff.clone().into()))
+            .collect();
+
+        let hash = self
+            .remote_provider
+            .call::<_, B256>(
+                "rbuilder_calculateStateRoot",
+                (BlockId::Hash(self.parent_hash.into()), account_diff),
+            )
+            .map_err(|_| crate::roothash::RootHashError::Verification)?;
+
+        trace!("state_root: got");
+
+        Ok(hash)
+    }
+}
+
+impl derive_more::Debug for StatRootHashCalculator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StatRootHashCalculator").finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AccountDiff {
+    pub nonce: Option<U256>,
+    pub balance: Option<U256>,
+    pub self_destructed: bool,
+    pub changed_slots: HashMap<U256, U256>,
+    pub code_hash: Option<B256>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct AccountState {
+    pub nonce: U256,
+    pub balance: U256,
+    pub code_hash: B256,
+}
+
+impl From<BundleAccount> for AccountDiff {
+    fn from(value: BundleAccount) -> Self {
+        let self_destructed = value.was_destroyed();
+
+        let changed_slots = value
+            .storage
+            .iter()
+            .map(|(k, v)| (*k, v.present_value))
+            .collect();
+
+        match value.info {
+            Some(info) => Self {
+                changed_slots,
+                self_destructed,
+                balance: Some(info.balance),
+                nonce: Some(U256::from(info.nonce)),
+                code_hash: Some(info.code_hash),
+            },
+            None => Self {
+                changed_slots,
+                self_destructed,
+                balance: None,
+                nonce: None,
+                code_hash: None,
+            },
+        }
+    }
+}
+
+//TODO: this is temp hack, fix it properly
+fn transport_to_provider_error(e: reipc::errors::RpcError) -> ProviderError {
+    ProviderError::Database(reth_db::DatabaseError::Other(format!("IPC ERROR: {e}")))
+}

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -9,7 +9,9 @@ use std::{
 use alloy_consensus::{constants::KECCAK_EMPTY, Header};
 use alloy_eips::{BlockId, BlockNumHash, BlockNumberOrTag};
 use alloy_json_rpc::RpcSend;
-use alloy_primitives::{BlockHash, BlockNumber, StorageKey, StorageValue, U64};
+use alloy_primitives::{
+    Address, BlockHash, BlockNumber, Bytes, StorageKey, StorageValue, B256, U256, U64,
+};
 use dashmap::DashMap;
 use quick_cache::sync::Cache;
 use reipc::rpc_provider::RpcProvider;
@@ -23,8 +25,10 @@ use reth_trie::{
     updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
     MultiProofTargets, StorageMultiProof, StorageProof, TrieInput,
 };
-use revm::db::{BundleAccount, BundleState};
-use revm_primitives::{map::B256HashMap, Address, Bytes, HashMap, B256, U256};
+use revm::{
+    database::{BundleAccount, BundleState},
+    primitives::HashMap,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -410,11 +414,7 @@ impl StateProofProvider for IpcStateProvider {
         unimplemented!()
     }
 
-    fn witness(
-        &self,
-        _input: TrieInput,
-        _target: HashedPostState,
-    ) -> ProviderResult<B256HashMap<Bytes>> {
+    fn witness(&self, _input: TrieInput, _target: HashedPostState) -> ProviderResult<Vec<Bytes>> {
         unimplemented!()
     }
 }
@@ -515,7 +515,7 @@ fn rpc_call<Param, Resp>(
 ) -> ProviderResult<Resp>
 where
     Param: RpcSend,
-    Resp: DeserializeOwned + derive_more::Debug,
+    Resp: DeserializeOwned + derive_more::with_trait::Debug,
 {
     let span = trace_span!("rpc_call", rpc_method, id = rand::random::<u64>());
     let _guard = span.enter();

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -138,7 +138,7 @@ impl StateProviderFactory for IpcStateProviderFactory {
     /// Gets block header given block hash
     fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
         let header = rpc_call::<
-            _,
+            (&BlockHash, bool),
             Option<<alloy_network::Ethereum as alloy_network::Network>::BlockResponse>,
         >(
             &self.ipc_provider,
@@ -152,7 +152,7 @@ impl StateProviderFactory for IpcStateProviderFactory {
 
     /// Gets block hash given block number
     fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
-        let block_hash = rpc_call::<_, Option<B256>>(
+        let block_hash = rpc_call::<(BlockNumberOrTag,), Option<B256>>(
             &self.ipc_provider,
             "rbuilder_getBlockHash",
             (BlockNumberOrTag::Number(number),),
@@ -169,7 +169,7 @@ impl StateProviderFactory for IpcStateProviderFactory {
     /// Gets block header given block hash
     fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
         let block = rpc_call::<
-            _,
+            (u64, bool),
             Option<<alloy_network::Ethereum as alloy_network::Network>::BlockResponse>,
         >(&self.ipc_provider, "eth_getBlockByNumber", (num, false))?
         .map(|b| b.header.inner);
@@ -179,7 +179,7 @@ impl StateProviderFactory for IpcStateProviderFactory {
 
     /// Gets block number of latest known block
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {
-        Ok(rpc_call::<_, U64>(&self.ipc_provider, "eth_blockNumber", ())?.to::<u64>())
+        Ok(rpc_call::<(), U64>(&self.ipc_provider, "eth_blockNumber", ())?.to::<u64>())
     }
 
     /// Creates new root hasher - struct responsible for calculating root hash
@@ -270,7 +270,7 @@ impl StateProvider for IpcStateProvider {
             return Ok(Some(bytecode.clone()));
         }
 
-        let bytecode = rpc_call::<_, Option<Bytes>>(
+        let bytecode = rpc_call::<(&B256,), Option<Bytes>>(
             &self.ipc_provider,
             "rbuilder_getCodeByHash",
             (code_hash,),
@@ -293,7 +293,7 @@ impl BlockHashReader for IpcStateProvider {
             return Ok(Some(*hash));
         }
 
-        let block_hash = rpc_call::<_, Option<B256>>(
+        let block_hash = rpc_call::<(BlockNumberOrTag,), Option<B256>>(
             &self.ipc_provider,
             "rbuilder_getBlockHash",
             (BlockNumberOrTag::Number(number),),
@@ -324,7 +324,7 @@ impl AccountReader for IpcStateProvider {
             return Ok(*account);
         }
 
-        let account = rpc_call::<_, Option<AccountState>>(
+        let account = rpc_call::<(Address, BlockId), Option<AccountState>>(
             &self.ipc_provider,
             "rbuilder_getAccount",
             (*address, self.block_id),
@@ -453,7 +453,7 @@ impl RootHasher for StatRootHashCalculator {
             .map(|(address, diff)| (*address, diff.clone().into()))
             .collect();
 
-        let hash = rpc_call::<_, B256>(
+        let hash = rpc_call::<(BlockId, HashMap<Address, AccountDiff>), B256>(
             &self.remote_provider,
             "rbuilder_calculateStateRoot",
             (BlockId::Hash(self.parent_hash.into()), account_diff),

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     fmt::Debug,
     path::{Path, PathBuf},
     sync::Arc,
@@ -7,6 +8,7 @@ use std::{
 
 use alloy_consensus::{constants::KECCAK_EMPTY, Header};
 use alloy_eips::{BlockId, BlockNumHash, BlockNumberOrTag};
+use alloy_json_rpc::RpcSend;
 use alloy_primitives::{BlockHash, BlockNumber, StorageKey, StorageValue, U64};
 use dashmap::DashMap;
 use quick_cache::sync::Cache;
@@ -23,7 +25,7 @@ use reth_trie::{
 };
 use revm::db::{BundleAccount, BundleState};
 use revm_primitives::{map::B256HashMap, Address, Bytes, HashMap, B256, U256};
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use tracing::{trace, trace_span};
@@ -131,40 +133,27 @@ impl StateProviderFactory for IpcStateProviderFactory {
 
     /// Gets block header given block hash
     fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
-        let span =
-            trace_span!("header", id = rand::random::<u64>(), block_hash = %block_hash.to_string());
-        let _guard = span.enter();
-        trace!("header: get");
+        let header = rpc_call::<
+            _,
+            Option<<alloy_network::Ethereum as alloy_network::Network>::BlockResponse>,
+        >(
+            &self.ipc_provider,
+            "eth_getBlockByHash",
+            (block_hash, false),
+        )?
+        .map(|b| b.header.inner);
 
-        let header = self
-            .ipc_provider
-            .call::<_, Option<<alloy_network::Ethereum as alloy_network::Network>::BlockResponse>>(
-                "eth_getBlockByHash",
-                (block_hash, false),
-            )
-            .map_err(ipc_to_provider_error)?
-            .map(|b| b.header.inner);
-
-        trace!("header: got");
         Ok(header)
     }
 
     /// Gets block hash given block number
     fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
-        let span = trace_span!(
-            "block_hash provider factory",
-            id = rand::random::<u64>(),
-            block_num = number
-        );
-        let _guard = span.enter();
-        trace!("block_hash:get");
+        let block_hash = rpc_call::<_, Option<B256>>(
+            &self.ipc_provider,
+            "rbuilder_getBlockHash",
+            (BlockNumberOrTag::Number(number),),
+        )?;
 
-        let block_hash = self
-            .ipc_provider
-            .call::<_, Option<B256>>("rbuilder_getBlockHash", (BlockNumberOrTag::Number(number),))
-            .map_err(ipc_to_provider_error)?;
-
-        trace!("block_hash: got");
         Ok(block_hash)
     }
 
@@ -175,41 +164,18 @@ impl StateProviderFactory for IpcStateProviderFactory {
 
     /// Gets block header given block hash
     fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
-        let span = trace_span!(
-            "header_by_number",
-            id = rand::random::<u64>(),
-            block_num = num
-        );
-        let _guard = span.enter();
-        trace!("header_by_num:get");
+        let block = rpc_call::<
+            _,
+            Option<<alloy_network::Ethereum as alloy_network::Network>::BlockResponse>,
+        >(&self.ipc_provider, "eth_getBlockByNumber", (num, false))?
+        .map(|b| b.header.inner);
 
-        let block = self
-            .ipc_provider
-            .call::<_, Option<<alloy_network::Ethereum as alloy_network::Network>::BlockResponse>>(
-                "eth_getBlockByNumber",
-                (num, false),
-            )
-            .map_err(ipc_to_provider_error)?
-            .map(|b| b.header.inner);
-
-        trace!("header_by_num: got");
         Ok(block)
     }
 
     /// Gets block number of latest known block
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {
-        let span = trace_span!("last_block_num", id = rand::random::<u64>());
-        let _guard = span.enter();
-        trace!("last_block_num:get");
-
-        let block_num = self
-            .ipc_provider
-            .call::<_, U64>("eth_blockNumber", ())
-            .map_err(ipc_to_provider_error)?
-            .to::<u64>();
-
-        trace!("last_block_num: got");
-        Ok(block_num)
+        Ok(rpc_call::<_, U64>(&self.ipc_provider, "eth_blockNumber", ())?.to::<u64>())
     }
 
     /// Creates new root hasher - struct responsible for calculating root hash
@@ -277,33 +243,20 @@ impl StateProvider for IpcStateProvider {
         account: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
-        let span = trace_span!("storage", id = rand::random::<u64>());
-        let _guard = span.enter();
-        trace!("storage:get");
-
         if let Some(storage) = self.storage_cache.get(&(account, storage_key)) {
             return Ok(*storage);
         }
 
         let key: U256 = storage_key.into();
-        let storage = self
-            .ipc_provider
-            .call::<_, Option<StorageValue>>("eth_getStorageAt", (account, key))
-            .map_err(ipc_to_provider_error)?;
-
+        let storage = rpc_call(&self.ipc_provider, "eth_getStorageAt", (account, key))?;
         self.storage_cache.insert((account, storage_key), storage);
 
-        trace!("got storage");
         Ok(storage)
     }
 
     /// Get account code by its hash
     /// IMPORTANT: Assumes remote provider (node) has RPC call:"rbuilder_getCodeByHash"
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
-        let span = trace_span!("bytecode", id = rand::random::<u64>());
-        let _guard = span.enter();
-        trace!("bytecode:get");
-
         let empty_hash = code_hash.is_zero() || *code_hash == KECCAK_EMPTY;
         if empty_hash {
             return Ok(None);
@@ -313,17 +266,17 @@ impl StateProvider for IpcStateProvider {
             return Ok(Some(bytecode.clone()));
         }
 
-        let bytecode = self
-            .ipc_provider
-            .call::<_, Option<Bytes>>("rbuilder_getCodeByHash", (code_hash,))
-            .map_err(ipc_to_provider_error)?
-            .map(|b| {
-                let bytecode = Bytecode::new_raw(b);
-                self.code_cache.insert(*code_hash, bytecode.clone());
-                bytecode
-            });
+        let bytecode = rpc_call::<_, Option<Bytes>>(
+            &self.ipc_provider,
+            "rbuilder_getCodeByHash",
+            (code_hash,),
+        )?
+        .map(|b| {
+            let bytecode = Bytecode::new_raw(b);
+            self.code_cache.insert(*code_hash, bytecode.clone());
+            bytecode
+        });
 
-        trace!("bytecode: got");
         Ok(bytecode)
     }
 }
@@ -332,24 +285,20 @@ impl BlockHashReader for IpcStateProvider {
     /// Get the hash of the block with the given number. Returns `None` if no block with this number exists
     /// IMPORTANT: Assumes IPC provider (node) has RPC call:"rbuilder_getBlockHash"
     fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
-        let span = trace_span!("block_hash provider", id = rand::random::<u64>());
-        let _guard = span.enter();
-        trace!("block_hash: get");
-
         if let Some(hash) = self.block_hash_cache.get(&number) {
             return Ok(Some(*hash));
         }
 
-        let block_hash = self
-            .ipc_provider
-            .call::<_, Option<B256>>("rbuilder_getBlockHash", (BlockNumberOrTag::Number(number),))
-            .map_err(ipc_to_provider_error)?;
+        let block_hash = rpc_call::<_, Option<B256>>(
+            &self.ipc_provider,
+            "rbuilder_getBlockHash",
+            (BlockNumberOrTag::Number(number),),
+        )?;
 
         if let Some(bh) = block_hash {
             self.block_hash_cache.insert(number, bh);
         }
 
-        trace!("block_hash provider: got");
         Ok(block_hash)
     }
 
@@ -367,31 +316,26 @@ impl AccountReader for IpcStateProvider {
     /// IMPORTANT: Assumes IPC provider (node) has RPC call:"rbuilder_getAccount"
     /// Returns `None` if the account doesn't exist.
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
-        let span = trace_span!(
-            "account",
-            id = rand::random::<u64>(),
-            address = address.to_string()
-        );
-        let _guard = span.enter();
-        trace!("account: get");
-
         if let Some(account) = self.account_cache.get(address) {
             return Ok(*account);
         }
 
-        let account = self
-            .ipc_provider
-            .call::<_, Option<AccountState>>("rbuilder_getAccount", (*address, self.block_id))
-            .map_err(ipc_to_provider_error)?
-            .map(|a| Account {
-                nonce: a.nonce.try_into().unwrap(),
-                bytecode_hash: a.code_hash.into(),
-                balance: a.balance,
-            });
+        let account = rpc_call::<_, Option<AccountState>>(
+            &self.ipc_provider,
+            "rbuilder_getAccount",
+            (*address, self.block_id),
+        )?
+        .map(|a| Account {
+            nonce: a
+                .nonce
+                .try_into()
+                .expect("Nonce received from RPC should fit u64"),
+            bytecode_hash: a.code_hash.into(),
+            balance: a.balance,
+        });
 
         self.account_cache.insert(*address, account);
 
-        trace!("account: got");
         Ok(account)
     }
 }
@@ -502,14 +446,6 @@ impl RootHasher for StatRootHashCalculator {
         &self,
         outcome: &reth_provider::ExecutionOutcome,
     ) -> Result<B256, crate::roothash::RootHashError> {
-        let span = trace_span!(
-            "state_root",
-            id = rand::random::<u64>(),
-            block = outcome.first_block
-        );
-        let _guard = span.enter();
-        trace!("state_root: get");
-
         let account_diff: HashMap<Address, AccountDiff> = outcome
             .bundle
             .state
@@ -517,15 +453,13 @@ impl RootHasher for StatRootHashCalculator {
             .map(|(address, diff)| (*address, diff.clone().into()))
             .collect();
 
-        let hash = self
-            .remote_provider
-            .call::<_, B256>(
-                "rbuilder_calculateStateRoot",
-                (BlockId::Hash(self.parent_hash.into()), account_diff),
-            )
-            .map_err(|_| crate::roothash::RootHashError::Verification)?;
+        let hash = rpc_call::<_, B256>(
+            &self.remote_provider,
+            "rbuilder_calculateStateRoot",
+            (BlockId::Hash(self.parent_hash.into()), account_diff),
+        )
+        .map_err(|_| crate::roothash::RootHashError::RpcStateRootFailed)?;
 
-        trace!("state_root: got");
         Ok(hash)
     }
 }
@@ -573,6 +507,26 @@ impl From<BundleAccount> for AccountDiff {
             },
         }
     }
+}
+fn rpc_call<Param, Resp>(
+    ipc_provider: &RpcProvider,
+    rpc_method: impl Into<Cow<'static, str>> + tracing::Value,
+    params: Param,
+) -> ProviderResult<Resp>
+where
+    Param: RpcSend,
+    Resp: DeserializeOwned + derive_more::Debug,
+{
+    let span = trace_span!("rpc_call", rpc_method, id = rand::random::<u64>());
+    let _guard = span.enter();
+    trace!("send request");
+
+    let resp = ipc_provider
+        .call::<Param, Resp>(rpc_method, params)
+        .map_err(ipc_to_provider_error);
+
+    trace!("response received");
+    resp
 }
 
 fn ipc_to_provider_error(e: reipc::errors::RpcError) -> ProviderError {

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -72,7 +72,7 @@ impl IpcStateProviderFactory {
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields)]
 pub struct IpcProviderConfig {
-    pub(crate) request_timeout: u64,
+    pub(crate) request_timeout_ms: u64,
     pub(crate) ipc_path: PathBuf,
     pub(crate) mempool_server_url: String,
 }
@@ -80,7 +80,7 @@ pub struct IpcProviderConfig {
 impl Default for IpcProviderConfig {
     fn default() -> Self {
         Self {
-            request_timeout: DEFAULT_IPC_REQUEST_TIMEOUT_MS,
+            request_timeout_ms: DEFAULT_IPC_REQUEST_TIMEOUT_MS,
             mempool_server_url: String::new(),
             ipc_path: PathBuf::new(),
         }

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -44,7 +44,7 @@ const DEFAULT_STATE_CACHE_SIZE: usize = 128;
 
 /// Remote state provider factory allows providing state via remote RPC calls over IPC
 /// Specifically UnixDomainSockets
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IpcStateProviderFactory {
     ipc_provider: RpcProvider,
 
@@ -59,7 +59,7 @@ impl IpcStateProviderFactory {
         let ipc_provider = RpcProvider::try_connect(ipc_path, req_timeout.into())
             // there is no need to gracefully handle (or propagate) this error, if we cannot connect
             // to IPC, then rbuilder cannot work
-            .expect("Can't connect to IPC");
+            .expect("can't connect to IPC");
 
         Self {
             ipc_provider,
@@ -131,8 +131,8 @@ impl StateProviderFactory for IpcStateProviderFactory {
 
     /// Gets block header given block hash
     fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
-        let id: u64 = rand::random();
-        let span = trace_span!("header", id, block_hash = %block_hash.to_string());
+        let span =
+            trace_span!("header", id = rand::random::<u64>(), block_hash = %block_hash.to_string());
         let _guard = span.enter();
         trace!("header: get");
 
@@ -145,30 +145,27 @@ impl StateProviderFactory for IpcStateProviderFactory {
             .map_err(ipc_to_provider_error)?
             .map(|b| b.header.inner);
 
-        if header.is_none() {
-            trace!("header: got none");
-            return Ok(None);
-        }
-
         trace!("header: got");
-
         Ok(header)
     }
 
     /// Gets block hash given block number
     fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
-        let id: u64 = rand::random();
-        let span = trace_span!("block_hash provider factory", id, block_num = number);
+        let span = trace_span!(
+            "block_hash provider factory",
+            id = rand::random::<u64>(),
+            block_num = number
+        );
         let _guard = span.enter();
         trace!("block_hash:get");
 
         let block_hash = self
             .ipc_provider
-            .call::<_, B256>("rbuilder_getBlockHash", (BlockNumberOrTag::Number(number),))
+            .call::<_, Option<B256>>("rbuilder_getBlockHash", (BlockNumberOrTag::Number(number),))
             .map_err(ipc_to_provider_error)?;
 
         trace!("block_hash: got");
-        Ok(Some(block_hash))
+        Ok(block_hash)
     }
 
     /// Gets block number of latest known block
@@ -178,8 +175,11 @@ impl StateProviderFactory for IpcStateProviderFactory {
 
     /// Gets block header given block hash
     fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
-        let id: u64 = rand::random();
-        let span = trace_span!("header_by_number", id, block_num = num);
+        let span = trace_span!(
+            "header_by_number",
+            id = rand::random::<u64>(),
+            block_num = num
+        );
         let _guard = span.enter();
         trace!("header_by_num:get");
 
@@ -189,22 +189,16 @@ impl StateProviderFactory for IpcStateProviderFactory {
                 "eth_getBlockByNumber",
                 (num, false),
             )
-            .map_err(ipc_to_provider_error)?;
-
-        if block.is_none() {
-            trace!("header_by_num: got none");
-            return Ok(None);
-        }
+            .map_err(ipc_to_provider_error)?
+            .map(|b| b.header.inner);
 
         trace!("header_by_num: got");
-
-        Ok(block.map(|b| b.header.inner))
+        Ok(block)
     }
 
     /// Gets block number of latest known block
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {
-        let id: u64 = rand::random();
-        let span = trace_span!("last_block_num", id);
+        let span = trace_span!("last_block_num", id = rand::random::<u64>());
         let _guard = span.enter();
         trace!("last_block_num:get");
 
@@ -227,15 +221,18 @@ impl StateProviderFactory for IpcStateProviderFactory {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IpcStateProvider {
     ipc_provider: RpcProvider,
     block_id: BlockId,
 
-    //Per block cache
+    // Per block cache
     block_hash_cache: DashMap<u64, BlockHash>,
-    storage_cache: DashMap<(Address, StorageKey), StorageValue>,
-    account_cache: DashMap<Address, Account>,
+    // Note: It's ok to cache Account (and Storage) even in case of None, this is because StateProvider gives the
+    // state for some past block, so if account didn't exist the first time, it cannot magically
+    // appear later on
+    account_cache: DashMap<Address, Option<Account>>,
+    storage_cache: DashMap<(Address, StorageKey), Option<StorageValue>>,
 
     // Global cache (cache not related to specific block)
     code_cache: Arc<DashMap<B256, Bytecode>>,
@@ -262,6 +259,7 @@ impl IpcStateProvider {
 
     /// Crates new instance of state provider on the heap
     // Box::new(Arc::new(Self)) is required because StateProviderFactory returns Box<dyn StateProvider>
+    // Note: this is known clippy issue: https://github.com/rust-lang/rust-clippy/issues/7472
     #[allow(clippy::redundant_allocation)]
     fn into_boxed(
         ipc_provider: RpcProvider,
@@ -279,32 +277,30 @@ impl StateProvider for IpcStateProvider {
         account: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
-        let id: u64 = rand::random();
-        let span = trace_span!("storage", id);
+        let span = trace_span!("storage", id = rand::random::<u64>());
         let _guard = span.enter();
         trace!("storage:get");
 
         if let Some(storage) = self.storage_cache.get(&(account, storage_key)) {
-            return Ok(Some(*storage));
+            return Ok(*storage);
         }
 
         let key: U256 = storage_key.into();
         let storage = self
             .ipc_provider
-            .call::<_, StorageValue>("eth_getStorageAt", (account, key))
+            .call::<_, Option<StorageValue>>("eth_getStorageAt", (account, key))
             .map_err(ipc_to_provider_error)?;
 
         self.storage_cache.insert((account, storage_key), storage);
 
         trace!("got storage");
-        Ok(Some(storage))
+        Ok(storage)
     }
 
     /// Get account code by its hash
     /// IMPORTANT: Assumes remote provider (node) has RPC call:"rbuilder_getCodeByHash"
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
-        let id: u64 = rand::random();
-        let span = trace_span!("bytecode", id);
+        let span = trace_span!("bytecode", id = rand::random::<u64>());
         let _guard = span.enter();
         trace!("bytecode:get");
 
@@ -317,17 +313,18 @@ impl StateProvider for IpcStateProvider {
             return Ok(Some(bytecode.clone()));
         }
 
-        let bytes = self
+        let bytecode = self
             .ipc_provider
-            .call::<_, Bytes>("rbuilder_getCodeByHash", (code_hash,))
-            .map_err(ipc_to_provider_error)?;
+            .call::<_, Option<Bytes>>("rbuilder_getCodeByHash", (code_hash,))
+            .map_err(ipc_to_provider_error)?
+            .map(|b| {
+                let bytecode = Bytecode::new_raw(b);
+                self.code_cache.insert(*code_hash, bytecode.clone());
+                bytecode
+            });
 
-        let bytecode = Bytecode::new_raw(bytes);
-
-        self.code_cache.insert(*code_hash, bytecode.clone());
         trace!("bytecode: got");
-
-        Ok(Some(bytecode))
+        Ok(bytecode)
     }
 }
 
@@ -335,22 +332,25 @@ impl BlockHashReader for IpcStateProvider {
     /// Get the hash of the block with the given number. Returns `None` if no block with this number exists
     /// IMPORTANT: Assumes IPC provider (node) has RPC call:"rbuilder_getBlockHash"
     fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
-        let id: u64 = rand::random();
-        let span = trace_span!("block_hash provider", id);
+        let span = trace_span!("block_hash provider", id = rand::random::<u64>());
         let _guard = span.enter();
         trace!("block_hash: get");
 
         if let Some(hash) = self.block_hash_cache.get(&number) {
             return Ok(Some(*hash));
         }
+
         let block_hash = self
             .ipc_provider
-            .call::<_, B256>("rbuilder_getBlockHash", (BlockNumberOrTag::Number(number),))
+            .call::<_, Option<B256>>("rbuilder_getBlockHash", (BlockNumberOrTag::Number(number),))
             .map_err(ipc_to_provider_error)?;
 
-        self.block_hash_cache.insert(number, block_hash);
+        if let Some(bh) = block_hash {
+            self.block_hash_cache.insert(number, bh);
+        }
+
         trace!("block_hash provider: got");
-        Ok(Some(block_hash))
+        Ok(block_hash)
     }
 
     fn canonical_hashes_range(
@@ -367,30 +367,32 @@ impl AccountReader for IpcStateProvider {
     /// IMPORTANT: Assumes IPC provider (node) has RPC call:"rbuilder_getAccount"
     /// Returns `None` if the account doesn't exist.
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
-        let id: u64 = rand::random();
-        let span = trace_span!("account", id, address = address.to_string());
+        let span = trace_span!(
+            "account",
+            id = rand::random::<u64>(),
+            address = address.to_string()
+        );
         let _guard = span.enter();
         trace!("account: get");
 
         if let Some(account) = self.account_cache.get(address) {
-            return Ok(Some(*account));
+            return Ok(*account);
         }
 
         let account = self
             .ipc_provider
-            .call::<_, AccountState>("rbuilder_getAccount", (*address, self.block_id))
-            .map_err(ipc_to_provider_error)?;
-
-        let account = Account {
-            nonce: account.nonce.try_into().unwrap(),
-            bytecode_hash: account.code_hash.into(),
-            balance: account.balance,
-        };
+            .call::<_, Option<AccountState>>("rbuilder_getAccount", (*address, self.block_id))
+            .map_err(ipc_to_provider_error)?
+            .map(|a| Account {
+                nonce: a.nonce.try_into().unwrap(),
+                bytecode_hash: a.code_hash.into(),
+                balance: a.balance,
+            });
 
         self.account_cache.insert(*address, account);
 
         trace!("account: got");
-        Ok(Some(account))
+        Ok(account)
     }
 }
 
@@ -479,7 +481,7 @@ impl HashedPostStateProvider for IpcStateProvider {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct StatRootHashCalculator {
     remote_provider: RpcProvider,
     parent_hash: B256,
@@ -500,8 +502,11 @@ impl RootHasher for StatRootHashCalculator {
         &self,
         outcome: &reth_provider::ExecutionOutcome,
     ) -> Result<B256, crate::roothash::RootHashError> {
-        let id: u64 = rand::random();
-        let span = trace_span!("state_root", id, block = outcome.first_block);
+        let span = trace_span!(
+            "state_root",
+            id = rand::random::<u64>(),
+            block = outcome.first_block
+        );
         let _guard = span.enter();
         trace!("state_root: get");
 
@@ -521,14 +526,7 @@ impl RootHasher for StatRootHashCalculator {
             .map_err(|_| crate::roothash::RootHashError::Verification)?;
 
         trace!("state_root: got");
-
         Ok(hash)
-    }
-}
-
-impl derive_more::Debug for StatRootHashCalculator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("StatRootHashCalculator").finish()
     }
 }
 

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -262,6 +262,7 @@ impl IpcStateProvider {
 
     /// Crates new instance of state provider on the heap
     // Box::new(Arc::new(Self)) is required because StateProviderFactory returns Box<dyn StateProvider>
+    #[allow(clippy::redundant_allocation)]
     fn into_boxed(
         ipc_provider: RpcProvider,
         block_id: BlockId,

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -74,14 +74,14 @@ impl IpcStateProviderFactory {
 pub struct IpcProviderConfig {
     pub(crate) request_timeout: u64,
     pub(crate) ipc_path: PathBuf,
-    pub(crate) txpool_server_url: String,
+    pub(crate) mempool_server_url: String,
 }
 
 impl Default for IpcProviderConfig {
     fn default() -> Self {
         Self {
             request_timeout: DEFAULT_IPC_REQUEST_TIMEOUT_MS,
-            txpool_server_url: String::new(),
+            mempool_server_url: String::new(),
             ipc_path: PathBuf::new(),
         }
     }

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -9,12 +9,13 @@ use alloy_consensus::{constants::KECCAK_EMPTY, Header};
 use alloy_eips::{BlockId, BlockNumHash, BlockNumberOrTag};
 use alloy_primitives::{BlockHash, BlockNumber, StorageKey, StorageValue, U64};
 use dashmap::DashMap;
+use quick_cache::sync::Cache;
 use reipc::rpc_provider::RpcProvider;
 use reth_errors::{ProviderError, ProviderResult};
 use reth_primitives::{Account, Bytecode};
 use reth_provider::{
-    AccountReader, BlockHashReader, HashedPostStateProvider, StateProofProvider, StateProvider,
-    StateProviderBox, StateRootProvider, StorageRootProvider,
+    errors::any::AnyError, AccountReader, BlockHashReader, HashedPostStateProvider,
+    StateProofProvider, StateProvider, StateProviderBox, StateRootProvider, StorageRootProvider,
 };
 use reth_trie::{
     updates::TrieUpdates, AccountProof, HashedPostState, HashedStorage, MultiProof,
@@ -36,6 +37,10 @@ use super::{RootHasher, StateProviderFactory};
 /// 99.9% requests return within 50ms; using 100ms gives us error rate of ~0.03%
 /// Median response time is ~300 micro_sec.
 const DEFAULT_IPC_REQUEST_TIMEOUT_MS: u64 = 100;
+/// For how many blocks to cache state for
+/// Most CL implementations keep state for last 128 blocks in memory,
+/// We are mimicking this
+const DEFAULT_STATE_CACHE_SIZE: usize = 128;
 
 /// Remote state provider factory allows providing state via remote RPC calls over IPC
 /// Specifically UnixDomainSockets
@@ -44,11 +49,12 @@ pub struct IpcStateProviderFactory {
     ipc_provider: RpcProvider,
 
     code_cache: Arc<DashMap<B256, Bytecode>>,
-    //TODO: invalidate cache for old blocks
-    state_provider_by_hash: Arc<DashMap<BlockHash, Arc<IpcStateProvider>>>,
+    state_provider_by_hash: Arc<Cache<BlockHash, Arc<IpcStateProvider>>>,
 }
 
 impl IpcStateProviderFactory {
+    /// Crates new IPC Provider Factory by establishing connection to IPC given path to the IPC
+    /// req_timeout is the same across all requests to the IPC
     pub fn new(ipc_path: &Path, req_timeout: Duration) -> Self {
         let ipc_provider = RpcProvider::try_connect(ipc_path, req_timeout.into())
             // there is no need to gracefully handle (or propagate) this error, if we cannot connect
@@ -58,7 +64,7 @@ impl IpcStateProviderFactory {
         Self {
             ipc_provider,
             code_cache: Arc::new(DashMap::new()),
-            state_provider_by_hash: Arc::new(DashMap::new()),
+            state_provider_by_hash: Arc::new(Cache::new(DEFAULT_STATE_CACHE_SIZE)),
         }
     }
 }
@@ -82,6 +88,7 @@ impl Default for IpcProviderConfig {
 }
 
 impl StateProviderFactory for IpcStateProviderFactory {
+    /// Gets state for the latest block
     fn latest(&self) -> ProviderResult<StateProviderBox> {
         let state = IpcStateProvider::into_boxed(
             self.ipc_provider.clone(),
@@ -92,6 +99,7 @@ impl StateProviderFactory for IpcStateProviderFactory {
         Ok(state)
     }
 
+    /// Gets state at the block number
     // We are not caching state provider by block number to avoid any issues with reorgs
     // The calls to  history_by_block_number are rare and we shouldn't be loosing perf by not
     // leveraging caching here
@@ -105,9 +113,10 @@ impl StateProviderFactory for IpcStateProviderFactory {
         Ok(state)
     }
 
+    /// Gets state at the block hash
     fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
         if let Some(state) = self.state_provider_by_hash.get(&block) {
-            return Ok(Box::new(state.clone()));
+            return Ok(Box::new(state));
         }
 
         let state = IpcStateProvider::into_boxed(
@@ -120,6 +129,7 @@ impl StateProviderFactory for IpcStateProviderFactory {
         Ok(state)
     }
 
+    /// Gets block header given block hash
     fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
         let id: u64 = rand::random();
         let span = trace_span!("header", id, block_hash = %block_hash.to_string());
@@ -132,7 +142,7 @@ impl StateProviderFactory for IpcStateProviderFactory {
                 "eth_getBlockByHash",
                 (block_hash, false),
             )
-            .map_err(transport_to_provider_error)?
+            .map_err(ipc_to_provider_error)?
             .map(|b| b.header.inner);
 
         if header.is_none() {
@@ -145,6 +155,7 @@ impl StateProviderFactory for IpcStateProviderFactory {
         Ok(header)
     }
 
+    /// Gets block hash given block number
     fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
         let id: u64 = rand::random();
         let span = trace_span!("block_hash provider factory", id, block_num = number);
@@ -154,17 +165,18 @@ impl StateProviderFactory for IpcStateProviderFactory {
         let block_hash = self
             .ipc_provider
             .call::<_, B256>("rbuilder_getBlockHash", (BlockNumberOrTag::Number(number),))
-            .map_err(transport_to_provider_error)?;
+            .map_err(ipc_to_provider_error)?;
 
         trace!("block_hash: got");
         Ok(Some(block_hash))
     }
 
-    //TODO: is this correct?
+    /// Gets block number of latest known block
     fn best_block_number(&self) -> ProviderResult<BlockNumber> {
         self.last_block_number()
     }
 
+    /// Gets block header given block hash
     fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
         let id: u64 = rand::random();
         let span = trace_span!("header_by_number", id, block_num = num);
@@ -177,7 +189,7 @@ impl StateProviderFactory for IpcStateProviderFactory {
                 "eth_getBlockByNumber",
                 (num, false),
             )
-            .map_err(transport_to_provider_error)?;
+            .map_err(ipc_to_provider_error)?;
 
         if block.is_none() {
             trace!("header_by_num: got none");
@@ -189,6 +201,7 @@ impl StateProviderFactory for IpcStateProviderFactory {
         Ok(block.map(|b| b.header.inner))
     }
 
+    /// Gets block number of latest known block
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {
         let id: u64 = rand::random();
         let span = trace_span!("last_block_num", id);
@@ -198,13 +211,14 @@ impl StateProviderFactory for IpcStateProviderFactory {
         let block_num = self
             .ipc_provider
             .call::<_, U64>("eth_blockNumber", ())
-            .map_err(transport_to_provider_error)?
+            .map_err(ipc_to_provider_error)?
             .to::<u64>();
 
         trace!("last_block_num: got");
         Ok(block_num)
     }
 
+    /// Creates new root hasher - struct responsible for calculating root hash
     fn root_hasher(&self, parent_hash: BlockNumHash) -> ProviderResult<Box<dyn RootHasher>> {
         Ok(Box::new(StatRootHashCalculator {
             remote_provider: self.ipc_provider.clone(),
@@ -277,7 +291,7 @@ impl StateProvider for IpcStateProvider {
         let storage = self
             .ipc_provider
             .call::<_, StorageValue>("eth_getStorageAt", (account, key))
-            .map_err(transport_to_provider_error)?;
+            .map_err(ipc_to_provider_error)?;
 
         self.storage_cache.insert((account, storage_key), storage);
 
@@ -305,7 +319,7 @@ impl StateProvider for IpcStateProvider {
         let bytes = self
             .ipc_provider
             .call::<_, Bytes>("rbuilder_getCodeByHash", (code_hash,))
-            .map_err(transport_to_provider_error)?;
+            .map_err(ipc_to_provider_error)?;
 
         let bytecode = Bytecode::new_raw(bytes);
 
@@ -331,7 +345,7 @@ impl BlockHashReader for IpcStateProvider {
         let block_hash = self
             .ipc_provider
             .call::<_, B256>("rbuilder_getBlockHash", (BlockNumberOrTag::Number(number),))
-            .map_err(transport_to_provider_error)?;
+            .map_err(ipc_to_provider_error)?;
 
         self.block_hash_cache.insert(number, block_hash);
         trace!("block_hash provider: got");
@@ -364,7 +378,7 @@ impl AccountReader for IpcStateProvider {
         let account = self
             .ipc_provider
             .call::<_, AccountState>("rbuilder_getAccount", (*address, self.block_id))
-            .map_err(transport_to_provider_error)?;
+            .map_err(ipc_to_provider_error)?;
 
         let account = Account {
             nonce: account.nonce.try_into().unwrap(),
@@ -562,7 +576,6 @@ impl From<BundleAccount> for AccountDiff {
     }
 }
 
-//TODO: this is temp hack, fix it properly
-fn transport_to_provider_error(e: reipc::errors::RpcError) -> ProviderError {
-    ProviderError::Database(reth_db::DatabaseError::Other(format!("IPC ERROR: {e}")))
+fn ipc_to_provider_error(e: reipc::errors::RpcError) -> ProviderError {
+    ProviderError::Other(AnyError::new(e))
 }

--- a/crates/rbuilder/src/provider/mod.rs
+++ b/crates/rbuilder/src/provider/mod.rs
@@ -9,6 +9,7 @@ use reth_provider::StateProviderBox;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
+pub mod ipc_state_provider;
 pub mod reth_prov;
 pub mod state_provider_factory_from_provider_factory;
 

--- a/crates/rbuilder/src/provider/mod.rs
+++ b/crates/rbuilder/src/provider/mod.rs
@@ -1,10 +1,16 @@
-use crate::live_builder::simulation::SimulatedOrderCommand;
+use std::sync::Arc;
+
 use crate::roothash::RootHashError;
+use crate::{live_builder::simulation::SimulatedOrderCommand, utils::ProviderFactoryReopener};
 use alloy_consensus::Header;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockHash, BlockNumber, B256};
+use ipc_state_provider::IpcStateProviderFactory;
 use reth::providers::ExecutionOutcome;
+use reth_db::DatabaseEnv;
 use reth_errors::ProviderResult;
+use reth_node_api::NodeTypesWithDBAdapter;
+use reth_node_ethereum::EthereumNode;
 use reth_provider::StateProviderBox;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -51,4 +57,76 @@ pub trait RootHasher: std::fmt::Debug + Send + Sync {
 
     /// State root for changes outcome on top of parent block.
     fn state_root(&self, outcome: &ExecutionOutcome) -> Result<B256, RootHashError>;
+}
+
+/// All supported state provider factories
+#[derive(Clone)]
+pub enum StateProviderFactories {
+    Reth(ProviderFactoryReopener<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>),
+    Ipc(IpcStateProviderFactory),
+}
+
+impl StateProviderFactory for StateProviderFactories {
+    fn latest(&self) -> ProviderResult<StateProviderBox> {
+        match self {
+            StateProviderFactories::Reth(factory) => factory.latest(),
+            StateProviderFactories::Ipc(factory) => factory.latest(),
+        }
+    }
+
+    fn history_by_block_number(&self, block: BlockNumber) -> ProviderResult<StateProviderBox> {
+        match self {
+            StateProviderFactories::Reth(factory) => factory.history_by_block_number(block),
+            StateProviderFactories::Ipc(factory) => factory.history_by_block_number(block),
+        }
+    }
+
+    fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
+        match self {
+            StateProviderFactories::Reth(factory) => factory.history_by_block_hash(block),
+            StateProviderFactories::Ipc(factory) => factory.history_by_block_hash(block),
+        }
+    }
+
+    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
+        match self {
+            StateProviderFactories::Reth(factory) => factory.header(block_hash),
+            StateProviderFactories::Ipc(factory) => factory.header(block_hash),
+        }
+    }
+
+    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
+        match self {
+            StateProviderFactories::Reth(factory) => factory.block_hash(number),
+            StateProviderFactories::Ipc(factory) => factory.block_hash(number),
+        }
+    }
+
+    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
+        match self {
+            StateProviderFactories::Reth(factory) => factory.best_block_number(),
+            StateProviderFactories::Ipc(factory) => factory.best_block_number(),
+        }
+    }
+
+    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
+        match self {
+            StateProviderFactories::Reth(factory) => factory.header_by_number(num),
+            StateProviderFactories::Ipc(factory) => factory.header_by_number(num),
+        }
+    }
+
+    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
+        match self {
+            StateProviderFactories::Reth(factory) => factory.last_block_number(),
+            StateProviderFactories::Ipc(factory) => factory.last_block_number(),
+        }
+    }
+
+    fn root_hasher(&self, parent_num_hash: BlockNumHash) -> ProviderResult<Box<dyn RootHasher>> {
+        match self {
+            StateProviderFactories::Reth(factory) => factory.root_hasher(parent_num_hash),
+            StateProviderFactories::Ipc(factory) => factory.root_hasher(parent_num_hash),
+        }
+    }
 }

--- a/crates/rbuilder/src/provider/mod.rs
+++ b/crates/rbuilder/src/provider/mod.rs
@@ -1,16 +1,10 @@
-use std::sync::Arc;
-
+use crate::live_builder::simulation::SimulatedOrderCommand;
 use crate::roothash::RootHashError;
-use crate::{live_builder::simulation::SimulatedOrderCommand, utils::ProviderFactoryReopener};
 use alloy_consensus::Header;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockHash, BlockNumber, B256};
-use ipc_state_provider::IpcStateProviderFactory;
 use reth::providers::ExecutionOutcome;
-use reth_db::DatabaseEnv;
 use reth_errors::ProviderResult;
-use reth_node_api::NodeTypesWithDBAdapter;
-use reth_node_ethereum::EthereumNode;
 use reth_provider::StateProviderBox;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -57,76 +51,4 @@ pub trait RootHasher: std::fmt::Debug + Send + Sync {
 
     /// State root for changes outcome on top of parent block.
     fn state_root(&self, outcome: &ExecutionOutcome) -> Result<B256, RootHashError>;
-}
-
-/// All supported state provider factories
-#[derive(Clone)]
-pub enum StateProviderFactories {
-    Reth(ProviderFactoryReopener<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>),
-    Ipc(IpcStateProviderFactory),
-}
-
-impl StateProviderFactory for StateProviderFactories {
-    fn latest(&self) -> ProviderResult<StateProviderBox> {
-        match self {
-            StateProviderFactories::Reth(factory) => factory.latest(),
-            StateProviderFactories::Ipc(factory) => factory.latest(),
-        }
-    }
-
-    fn history_by_block_number(&self, block: BlockNumber) -> ProviderResult<StateProviderBox> {
-        match self {
-            StateProviderFactories::Reth(factory) => factory.history_by_block_number(block),
-            StateProviderFactories::Ipc(factory) => factory.history_by_block_number(block),
-        }
-    }
-
-    fn history_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
-        match self {
-            StateProviderFactories::Reth(factory) => factory.history_by_block_hash(block),
-            StateProviderFactories::Ipc(factory) => factory.history_by_block_hash(block),
-        }
-    }
-
-    fn header(&self, block_hash: &BlockHash) -> ProviderResult<Option<Header>> {
-        match self {
-            StateProviderFactories::Reth(factory) => factory.header(block_hash),
-            StateProviderFactories::Ipc(factory) => factory.header(block_hash),
-        }
-    }
-
-    fn block_hash(&self, number: BlockNumber) -> ProviderResult<Option<B256>> {
-        match self {
-            StateProviderFactories::Reth(factory) => factory.block_hash(number),
-            StateProviderFactories::Ipc(factory) => factory.block_hash(number),
-        }
-    }
-
-    fn best_block_number(&self) -> ProviderResult<BlockNumber> {
-        match self {
-            StateProviderFactories::Reth(factory) => factory.best_block_number(),
-            StateProviderFactories::Ipc(factory) => factory.best_block_number(),
-        }
-    }
-
-    fn header_by_number(&self, num: u64) -> ProviderResult<Option<Header>> {
-        match self {
-            StateProviderFactories::Reth(factory) => factory.header_by_number(num),
-            StateProviderFactories::Ipc(factory) => factory.header_by_number(num),
-        }
-    }
-
-    fn last_block_number(&self) -> ProviderResult<BlockNumber> {
-        match self {
-            StateProviderFactories::Reth(factory) => factory.last_block_number(),
-            StateProviderFactories::Ipc(factory) => factory.last_block_number(),
-        }
-    }
-
-    fn root_hasher(&self, parent_num_hash: BlockNumHash) -> ProviderResult<Box<dyn RootHasher>> {
-        match self {
-            StateProviderFactories::Reth(factory) => factory.root_hasher(parent_num_hash),
-            StateProviderFactories::Ipc(factory) => factory.root_hasher(parent_num_hash),
-        }
-    }
 }

--- a/crates/rbuilder/src/roothash/mod.rs
+++ b/crates/rbuilder/src/roothash/mod.rs
@@ -38,6 +38,8 @@ pub enum RootHashError {
     SparseStateRoot(#[from] SparseTrieError),
     #[error("State root verification error")]
     Verification,
+    #[error("State root calculation via RPC failed")]
+    RpcStateRootFailed,
 }
 
 impl RootHashError {


### PR DESCRIPTION
## 📝 Summary

`rbuilder` can now work with _any node_ via IPC. 
This means that any node can provide the state for `rbuilder`,  `revm` is still used as the EVM. 
Node requirements are that it exposes the following RPC calls: 

Calls not available in the [ETH JSON RPC spec:](https://ethereum.github.io/execution-apis/api-documentation/) 
1. `rbuilder_calculateStateRoot` for state root calculation
2. `rbuilder_getCodeByHash` given Bytecode hash, returns Bytecode

Calls optimised for `rbuilder`, but have a counterpart in the ETH  JSON RPC spec: 

3. `rbuilder_getBlockHash` gets the block hash  given block number (similar to `eth_getBlockByNumber`, but just returns block hash)
4. `rbuilder_getAccount` gets account info (similar to `eth_getProof`, but w/o _proof stuff_)

To use `rbuilder` with node via IPC,  the `config.toml` must have the following config (example):

```TOML
[ipc_provider]
ipc_path = "/root/execution-data/nethermind.ipc"
mempool_server_url = "ws://localhost:8546"
request_timeout_ms = 75
```

## Implementation details

### IPC

This implementation was initially intended to introduce a _remote state provider_. By remote, I mean that the idea was that state could be provided via HTTP/WS/IPC. Unfortunately, due to implementation issues/constraints, I've decided only to implement state provisioning via IPC.
I don't think this has any practical downside, especially since the state provider must be fast. There is a non-trivial number of calls to read state (~300/s), meaning it would be unrealistic to use this over the network and have near disk read latency. 

Code-wise, issues above and constraints stem mainly from the fact that the traits to read state are `sync`. Initially, I relied on tokio and alloy.rs to fetch this remote state, but this implementation had many issues.  
Firstly, each call to fetch any data (e.g. fetching account or Bytecode) had to be wrapped in a function call like this:

```Rust
    /// Runs fututre in sync context
    // StateProvider(Factory) traits require sync context, but calls to remote provider are async
    // What's more, rbuilder is executed in async context, so we have a situation
    // async -> sync -> async
    // This helper function allows execution in such environment
    fn run<F, R>(&self, f: F) -> R
    where
        F: Future<Output = R>,
    {
        tokio::task::block_in_place(|| self.runtime_handle.block_on(f))
    }
```

This adds additional overhead on Tokio runtime and doesn't play well with some parts of the codebase, specifically mutex locking. Not to go too deep into explaining issues around this in the PR description, but we would end up in scenarios where the whole Tokio runtime I/O would be blocked or we would dead-lock parking-lot mutexes (in some scenarios).

The solutions (_[monitoring thread](https://github.com/tokio-rs/tokio/issues/4730)_ + async mutex) seemed hacky and suboptimal. 
This is why, in the end, I reached for sync (but concurrent) IPC solution, which I implemented from scratch [here. It's called REIPC (coming from request/response IPC)](https://github.com/NethermindEth/reipc). 

This solution was tested using Nethermind node, and while [Nethermind will do some improvements](https://github.com/NethermindEth/nethermind/issues/8258#issue-2875081273) on IPC to reduce latency and increase throughput, here are the initial request&response latencies: 

![CleanShot 2025-03-01 at 11 44 11@2x](https://github.com/user-attachments/assets/4de4e0ca-2bca-4490-bf9c-5426afcc80af)

### Dashmap & QuickCache in IPC provider
We need caches because otherwise the number of IPC calls would be pretty high (in thousands per sec). 
I also reached for concurrent caches because both `StateProviderFactory` and `StateProvider` need to be `Send + Sync`.

QuickCache is used so that I don't have to implement concurrent-cache invalidation by hand :) 
[Here](https://github.com/moka-rs/moka?tab=readme-ov-file#choosing-the-right-cache-for-your-use-case) is some info on QuickCache vs Moka (other popular caching crate), TL;DR; for our simple case QuickCache seems a better fit.

### On `enum StateProviderFactories`
~The reason `cli.rs` passes `StateProviderFactories` enum to `config.new_builder` is because I wanted the state provider for `rbuilder` to be chosen via config at the runtime.~
~This is why, AFAIK, static dispatch is not an option.  So I was left with the choice of refactoring to dynamic dispatch (akin to `StateProviderBox`) OR the `enum` solution.~
~I chose the `enum` solution for following reasons:~
~1. It seemed to me that code diff would be smaller (smaller change to implement)~
~2. AFIAK it's faster. Enum matching will compile to `JMP` vs `CALL` (in case of dynamic dispatch), which compiler will be able to optimize better (especially in this scenario), and given branch predicitoning I guess that it'll be almost free (+ no need for vtable/pointer loading).]~

UPDATE: this was properly handled [in this commit](https://github.com/flashbots/rbuilder/pull/489/commits/2dc4f41e7f77e605502ce9da1148d8b912bd0de0) thanks to suggestions from @ZanCorDX 

### On `MempoolSource` enum

The reason I chose to use WebSockets for streaming transactions when `rbuilder` uses IPC state provider is because, currently, REIPC doesn't support ETH subscriptions/streams.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
