### PR TITLE
Order sorting using types.

### DIFF
--- a/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
@@ -56,7 +56,7 @@ where
     );
 
     let state_provider = provider.history_by_block_hash(ctx.attributes.parent)?;
-    let mut partial_block = PartialBlock::new(true, None);
+    let mut partial_block = PartialBlock::new(true);
     let mut state = BlockState::new(state_provider);
 
     partial_block

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -89,7 +89,7 @@ async fn main() -> eyre::Result<()> {
         let state_provider = state_provider.clone();
         let (new_cached_reads, build_time, finalize_time) =
             tokio::task::spawn_blocking(move || -> eyre::Result<_> {
-                let partial_block = PartialBlock::new(true, None);
+                let partial_block = PartialBlock::new(true);
                 let mut state = BlockState::new_arc(state_provider)
                     .with_cached_reads(cached_reads.unwrap_or_default());
 

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -216,13 +216,12 @@ impl DummyBuildingAlgorithm {
             None,
             BUILDER_NAME.to_string(),
             false,
-            None,
             CancellationToken::new(),
         )?;
 
         for order in orders {
             // don't care about the result
-            let _ = block_building_helper.commit_order(&order)?;
+            let _ = block_building_helper.commit_order(&order, &|_| Ok(()))?;
         }
         Ok(Box::new(block_building_helper))
     }

--- a/crates/rbuilder/src/building/block_orders/mod.rs
+++ b/crates/rbuilder/src/building/block_orders/mod.rs
@@ -4,13 +4,13 @@ mod share_bundle_merger;
 
 #[cfg(test)]
 mod order_dumper;
+pub mod order_priority;
 #[cfg(test)]
 mod test_context;
 mod test_data_generator;
 use std::sync::Arc;
 
 use crate::{
-    building::Sorting,
     live_builder::simulation::SimulatedOrderCommand,
     primitives::{AccountNonce, OrderId, SimulatedOrder},
 };
@@ -18,6 +18,7 @@ use ahash::HashMap;
 use reth_errors::ProviderResult;
 use reth_provider::StateProviderBox;
 
+pub use order_priority::OrderPriority;
 pub use prioritized_order_store::PrioritizedOrderStore;
 pub use test_data_generator::TestDataGenerator;
 
@@ -101,11 +102,10 @@ impl SimulatedOrderSink for SimulatedOrderStore {
 }
 
 /// Create block orders struct from simulated orders. Used in the backtest, not practical while live.
-pub fn block_orders_from_sim_orders(
+pub fn block_orders_from_sim_orders<OrderPriorityType: OrderPriority>(
     sim_orders: &[Arc<SimulatedOrder>],
-    sorting: Sorting,
     state_provider: &StateProviderBox,
-) -> ProviderResult<PrioritizedOrderStore> {
+) -> ProviderResult<PrioritizedOrderStore<OrderPriorityType>> {
     let mut onchain_nonces = vec![];
     for order in sim_orders {
         for nonce in order.order.nonces() {
@@ -118,7 +118,7 @@ pub fn block_orders_from_sim_orders(
             });
         }
     }
-    let mut block_orders = PrioritizedOrderStore::new(sorting, onchain_nonces);
+    let mut block_orders = PrioritizedOrderStore::<OrderPriorityType>::new(onchain_nonces);
 
     for order in sim_orders.iter().cloned() {
         block_orders.insert_order(order);
@@ -131,24 +131,24 @@ pub fn block_orders_from_sim_orders(
 mod test {
     use crate::primitives::BundledTxInfo;
 
-    use super::*;
+    use super::{order_priority::OrderMaxProfitPriority, *};
     /// Helper struct for common PrioritizedOrderStore test operations
     /// Works hardcoded on Sorting::MaxProfit since it changes nothing on internal logic
     struct TestContext {
         pub data_gen: TestDataGenerator,
-        pub order_pool: PrioritizedOrderStore,
+        pub order_pool: PrioritizedOrderStore<OrderMaxProfitPriority>,
     }
 
     impl TestContext {
         /// Context with 1 account to send txs from
-        pub fn new_1_account(nonce: u64) -> (AccountNonce, TestContext) {
+        pub fn new_1_account(nonce: u64) -> (AccountNonce, Self) {
             let mut data_gen = TestDataGenerator::default();
             let nonce = data_gen.create_account_nonce(nonce);
             (
                 nonce.clone(),
                 TestContext {
                     data_gen,
-                    order_pool: PrioritizedOrderStore::new(Sorting::MaxProfit, vec![nonce]),
+                    order_pool: PrioritizedOrderStore::<OrderMaxProfitPriority>::new(vec![nonce]),
                 },
             )
         }
@@ -166,10 +166,9 @@ mod test {
                 nonce_2.clone(),
                 TestContext {
                     data_gen,
-                    order_pool: PrioritizedOrderStore::new(
-                        Sorting::MaxProfit,
-                        vec![nonce_1, nonce_2],
-                    ),
+                    order_pool: PrioritizedOrderStore::<OrderMaxProfitPriority>::new(vec![
+                        nonce_1, nonce_2,
+                    ]),
                 },
             )
         }

--- a/crates/rbuilder/src/building/block_orders/order_priority.rs
+++ b/crates/rbuilder/src/building/block_orders/order_priority.rs
@@ -1,0 +1,128 @@
+use std::{cmp::Ordering, sync::Arc};
+
+use revm_primitives::U256;
+
+use crate::primitives::{SimValue, SimulatedOrder};
+
+/// Trait to specify how we prioritize orders (eg: which we try first when are building blocks)
+pub trait OrderPriority: Ord + Clone + std::fmt::Debug + Send + Sync {
+    fn new(order: Arc<SimulatedOrder>) -> Self;
+    /// Compares a new execution new_sim_value against the original_sim_value. Returns if it's considered a "good" execution or the profit (or any specific criteria) was too low.
+    fn simulation_too_low(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool;
+}
+
+/// Any execution giving less that this might be rejected.
+const MIN_SIM_RESULT_PERCENTAGE: u64 = 95;
+
+/// Generic func for gas price or profit. May change in the future.
+fn new_sim_value_too_low(original_sim: U256, new_sim: U256) -> bool {
+    new_sim * U256::from(100) < (original_sim * U256::from(MIN_SIM_RESULT_PERCENTAGE))
+}
+
+// @TODO: Make macro!
+
+///////////////////////////////
+/// MevGasPrice
+///////////////////////////////
+
+#[derive(Debug, Clone)]
+pub struct OrderMevGasPricePriority {
+    order: Arc<SimulatedOrder>,
+}
+
+impl OrderPriority for OrderMevGasPricePriority {
+    fn new(order: Arc<SimulatedOrder>) -> Self {
+        Self { order }
+    }
+
+    fn simulation_too_low(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool {
+        new_sim_value_too_low(
+            original_sim_value.mev_gas_price,
+            new_sim_value.mev_gas_price,
+        )
+    }
+}
+
+#[inline]
+fn mev_gas_price_eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
+    a.sim_value.mev_gas_price == b.sim_value.mev_gas_price
+}
+
+#[inline]
+fn mev_gas_price_cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
+    a.sim_value.mev_gas_price.cmp(&b.sim_value.mev_gas_price)
+}
+
+impl PartialEq for OrderMevGasPricePriority {
+    fn eq(&self, other: &Self) -> bool {
+        mev_gas_price_eq(&self.order, &other.order)
+    }
+}
+
+impl Eq for OrderMevGasPricePriority {}
+
+impl PartialOrd for OrderMevGasPricePriority {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OrderMevGasPricePriority {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        mev_gas_price_cmp(&self.order, &other.order)
+    }
+}
+
+///////////////////////////////
+/// MaxProfit
+///////////////////////////////
+
+#[derive(Debug, Clone)]
+pub struct OrderMaxProfitPriority {
+    order: Arc<SimulatedOrder>,
+}
+
+impl OrderPriority for OrderMaxProfitPriority {
+    fn new(order: Arc<SimulatedOrder>) -> Self {
+        Self { order }
+    }
+
+    fn simulation_too_low(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool {
+        new_sim_value_too_low(
+            original_sim_value.coinbase_profit,
+            new_sim_value.coinbase_profit,
+        )
+    }
+}
+
+#[inline]
+fn max_profit_eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
+    a.sim_value.coinbase_profit == b.sim_value.coinbase_profit
+}
+
+#[inline]
+fn max_profit_cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
+    a.sim_value
+        .coinbase_profit
+        .cmp(&b.sim_value.coinbase_profit)
+}
+
+impl PartialEq for OrderMaxProfitPriority {
+    fn eq(&self, other: &Self) -> bool {
+        max_profit_eq(&self.order, &other.order)
+    }
+}
+
+impl Eq for OrderMaxProfitPriority {}
+
+impl PartialOrd for OrderMaxProfitPriority {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OrderMaxProfitPriority {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        max_profit_cmp(&self.order, &other.order)
+    }
+}

--- a/crates/rbuilder/src/building/block_orders/prioritized_order_store.rs
+++ b/crates/rbuilder/src/building/block_orders/prioritized_order_store.rs
@@ -1,36 +1,15 @@
-use std::{cmp::Ordering, collections::hash_map::Entry, sync::Arc};
+use std::{collections::hash_map::Entry, sync::Arc};
 
 use ahash::{HashMap, HashSet};
 use alloy_primitives::Address;
 use priority_queue::PriorityQueue;
 
 use crate::{
-    building::Sorting,
     primitives::{AccountNonce, Nonce, OrderId, SimulatedOrder},
     telemetry::mark_order_not_ready_for_immediate_inclusion,
 };
 
-use super::SimulatedOrderSink;
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct OrderPriority {
-    pub order_id: OrderId,
-    pub priority: u128,
-}
-
-impl PartialOrd for OrderPriority {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for OrderPriority {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.priority
-            .cmp(&other.priority)
-            .then_with(|| self.order_id.cmp(&other.order_id))
-    }
-}
+use super::{OrderPriority, SimulatedOrderSink};
 
 /// Block store that checks the nonces and priorities of the orders so we can easily get the best by calling pop_order()
 /// Not orders are ready to be executed due to nonce dependencies.
@@ -44,9 +23,9 @@ impl Ord for OrderPriority {
 ///     if the order is executed call update_onchain_nonces to update all the changed nonces.
 /// - Remove orders: remove_orders. This is useful if we think this orders are no really good (failed to execute to often)
 #[derive(Debug, Clone)]
-pub struct PrioritizedOrderStore {
+pub struct PrioritizedOrderStore<OrderPriorityType> {
     /// Ready (all nonce matching (or not matched but optional)) to execute orders sorted
-    main_queue: PriorityQueue<OrderId, OrderPriority>,
+    main_queue: PriorityQueue<OrderId, OrderPriorityType>,
     /// For each account we store all the orders from main_queue which contain a tx from this account.
     /// Since the orders belong to main_queue these are orders ready to execute.
     /// As soon as we execute an order from main_queue all orders for all the accounts the order used (order.nonces()) could get invalidated (if tx is not optional).
@@ -60,16 +39,10 @@ pub struct PrioritizedOrderStore {
     pending_orders: HashMap<AccountNonce, Vec<OrderId>>,
     /// Id -> order for all orders we manage. Carefully maintained by remove/insert
     orders: HashMap<OrderId, Arc<SimulatedOrder>>,
-
-    /// defines what orders are popped first
-    priority: Sorting,
 }
 
-impl PrioritizedOrderStore {
-    pub fn new(
-        priority: Sorting,
-        initial_onchain_nonces: impl IntoIterator<Item = AccountNonce>,
-    ) -> Self {
+impl<OrderPriorityType: OrderPriority> PrioritizedOrderStore<OrderPriorityType> {
+    pub fn new(initial_onchain_nonces: impl IntoIterator<Item = AccountNonce>) -> Self {
         let mut onchain_nonces = HashMap::default();
         for onchain_nonce in initial_onchain_nonces {
             onchain_nonces.insert(onchain_nonce.account, onchain_nonce.nonce);
@@ -80,7 +53,6 @@ impl PrioritizedOrderStore {
             onchain_nonces,
             pending_orders: HashMap::default(),
             orders: HashMap::default(),
-            priority,
         }
     }
 
@@ -177,7 +149,9 @@ impl PrioritizedOrderStore {
     }
 }
 
-impl SimulatedOrderSink for PrioritizedOrderStore {
+impl<OrderPriorityType: OrderPriority> SimulatedOrderSink
+    for PrioritizedOrderStore<OrderPriorityType>
+{
     fn insert_order(&mut self, sim_order: Arc<SimulatedOrder>) {
         if self.orders.contains_key(&sim_order.id()) {
             return;
@@ -206,16 +180,8 @@ impl SimulatedOrderSink for PrioritizedOrderStore {
             }
         }
         if pending_nonces.is_empty() {
-            self.main_queue.push(
-                sim_order.id(),
-                OrderPriority {
-                    priority: self
-                        .priority
-                        .sorting_value(&sim_order.sim_value)
-                        .to::<u128>(),
-                    order_id: sim_order.id(),
-                },
-            );
+            self.main_queue
+                .push(sim_order.id(), OrderPriorityType::new(sim_order.clone()));
             for nonce in sim_order.nonces() {
                 self.main_queue_nonces
                     .entry(nonce.address)

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -15,9 +15,9 @@ use crate::{
         estimate_payout_gas_limit, tracers::GasUsedSimulationTracer, BlockBuildingContext,
         BlockState, BuiltBlockTrace, BuiltBlockTraceError, CriticalCommitOrderError,
         EstimatePayoutGasErr, ExecutionError, ExecutionResult, FinalizeError, FinalizeResult,
-        PartialBlock, Sorting,
+        PartialBlock,
     },
-    primitives::SimulatedOrder,
+    primitives::{SimValue, SimulatedOrder},
     telemetry::{self, add_block_fill_time, add_order_simulation_time},
     utils::{check_block_hash_reader_health, HistoricalBlockError},
 };
@@ -36,9 +36,11 @@ pub trait BlockBuildingHelper: Send + Sync {
 
     /// Tries to add an order to the end of the block.
     /// Block state changes only on Ok(Ok)
+    /// See [PartialBlock::commit_order]
     fn commit_order(
         &mut self,
         order: &SimulatedOrder,
+        result_filter: &dyn Fn(&SimValue) -> Result<(), ExecutionError>,
     ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError>;
 
     /// Call set the trace fill_time (we still have to review this)
@@ -197,7 +199,6 @@ impl BlockBuildingHelperFromProvider {
         cached_reads: Option<CachedReads>,
         builder_name: String,
         discard_txs: bool,
-        enforce_sorting: Option<Sorting>,
         cancel_on_fatal_error: CancellationToken,
     ) -> Result<Self, BlockBuildingHelperError> {
         let last_committed_block = building_ctx.block() - 1;
@@ -206,8 +207,8 @@ impl BlockBuildingHelperFromProvider {
         let fee_recipient_balance_start = state_provider
             .account_balance(&building_ctx.attributes.suggested_fee_recipient)?
             .unwrap_or_default();
-        let mut partial_block = PartialBlock::new(discard_txs, enforce_sorting)
-            .with_tracer(GasUsedSimulationTracer::default());
+        let mut partial_block =
+            PartialBlock::new(discard_txs).with_tracer(GasUsedSimulationTracer::default());
         let mut block_state =
             BlockState::new_arc(state_provider).with_cached_reads(cached_reads.unwrap_or_default());
         partial_block
@@ -337,11 +338,15 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
     fn commit_order(
         &mut self,
         order: &SimulatedOrder,
+        result_filter: &dyn Fn(&SimValue) -> Result<(), ExecutionError>,
     ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
         let start = Instant::now();
-        let result =
-            self.partial_block
-                .commit_order(order, &self.building_ctx, &mut self.block_state);
+        let result = self.partial_block.commit_order(
+            order,
+            &self.building_ctx,
+            &mut self.block_state,
+            result_filter,
+        );
         let sim_time = start.elapsed();
         let (result, sim_ok) = match result {
             Ok(ok_result) => match ok_result {

--- a/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
@@ -1,4 +1,5 @@
 use crate::live_builder::simulation::SimulatedOrderCommand;
+use crate::primitives::SimValue;
 use crate::provider::RootHasher;
 use crate::roothash::RootHashError;
 use crate::{
@@ -66,6 +67,7 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
     fn commit_order(
         &mut self,
         _order: &SimulatedOrder,
+        _result_filter: &dyn Fn(&SimValue) -> Result<(), ExecutionError>,
     ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
         unimplemented!()
     }

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -5,7 +5,7 @@ pub mod ordering_builder;
 pub mod parallel_builder;
 
 use crate::{
-    building::{BlockBuildingContext, BuiltBlockTrace, SimulatedOrderSink, Sorting},
+    building::{BlockBuildingContext, BuiltBlockTrace, SimulatedOrderSink},
     live_builder::{
         payload_events::{InternalPayloadId, MevBoostSlotData},
         simulation::SimulatedOrderCommand,
@@ -27,7 +27,7 @@ use tokio::sync::{
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
-use super::{simulated_order_command_to_sink, PrioritizedOrderStore};
+use super::{simulated_order_command_to_sink, OrderPriority, PrioritizedOrderStore};
 
 /// Block we built
 #[derive(Debug, Clone)]
@@ -114,25 +114,21 @@ impl OrderConsumer {
 }
 
 #[derive(Debug)]
-pub struct OrderIntakeConsumer {
+pub struct OrderIntakeConsumer<OrderPriorityType> {
     nonces: NonceCache,
 
-    block_orders: PrioritizedOrderStore,
+    block_orders: PrioritizedOrderStore<OrderPriorityType>,
     onchain_nonces_updated: HashSet<Address>,
 
     order_consumer: OrderConsumer,
 }
 
-impl OrderIntakeConsumer {
+impl<OrderPriorityType: OrderPriority> OrderIntakeConsumer<OrderPriorityType> {
     /// See [`ShareBundleMerger`] for sbundle_merger_selected_signers
-    pub fn new(
-        nonces: NonceCache,
-        orders: broadcast::Receiver<SimulatedOrderCommand>,
-        sorting: Sorting,
-    ) -> Self {
+    pub fn new(nonces: NonceCache, orders: broadcast::Receiver<SimulatedOrderCommand>) -> Self {
         Self {
             nonces,
-            block_orders: PrioritizedOrderStore::new(sorting, vec![]),
+            block_orders: PrioritizedOrderStore::new(vec![]),
             onchain_nonces_updated: HashSet::default(),
             order_consumer: OrderConsumer::new(orders),
         }
@@ -181,7 +177,7 @@ impl OrderIntakeConsumer {
         Ok(true)
     }
 
-    pub fn current_block_orders(&self) -> PrioritizedOrderStore {
+    pub fn current_block_orders(&self) -> PrioritizedOrderStore<OrderPriorityType> {
         self.block_orders.clone()
     }
 

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -11,9 +11,10 @@ use crate::{
         builders::{
             block_building_helper::BlockBuildingHelper, LiveBuilderInput, OrderIntakeConsumer,
         },
-        BlockBuildingContext, ExecutionError, PrioritizedOrderStore, SimulatedOrderSink, Sorting,
+        BlockBuildingContext, ExecutionError, OrderPriority, PrioritizedOrderStore,
+        SimulatedOrderSink, Sorting,
     },
-    primitives::{AccountNonce, OrderId},
+    primitives::{AccountNonce, OrderId, SimValue},
     provider::StateProviderFactory,
     telemetry::mark_builder_considers_order,
     utils::NonceCache,
@@ -24,6 +25,7 @@ use reth::revm::cached::CachedReads;
 use reth_provider::StateProvider;
 use serde::Deserialize;
 use std::{
+    marker::PhantomData,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -64,9 +66,12 @@ impl OrderingBuilderConfig {
     }
 }
 
-pub fn run_ordering_builder<P>(input: LiveBuilderInput<P>, config: &OrderingBuilderConfig)
-where
+pub fn run_ordering_builder<P, OrderPriorityType>(
+    input: LiveBuilderInput<P>,
+    config: &OrderingBuilderConfig,
+) where
     P: StateProviderFactory + Clone + 'static,
+    OrderPriorityType: OrderPriority,
 {
     let payload_id = input.ctx.payload_id;
 
@@ -88,7 +93,8 @@ where
 
     let nonces = NonceCache::new(block_state.clone());
 
-    let mut order_intake_consumer = OrderIntakeConsumer::new(nonces, input.input, config.sorting);
+    let mut order_intake_consumer =
+        OrderIntakeConsumer::<OrderPriorityType>::new(nonces, input.input);
 
     let mut builder = OrderingBuilderContext::new(
         block_state.clone(),
@@ -145,7 +151,7 @@ where
     }
 }
 
-pub fn backtest_simulate_block<P>(
+pub fn backtest_simulate_block<P, OrderPriorityType: OrderPriority>(
     ordering_config: OrderingBuilderConfig,
     input: BacktestSimulateBlockInput<'_, P>,
 ) -> eyre::Result<(Block, CachedReads)>
@@ -157,7 +163,7 @@ where
         .provider
         .history_by_block_number(input.ctx.evm_env.block_env.number.to::<u64>() - 1)?;
     let block_orders =
-        block_orders_from_sim_orders(input.sim_orders, ordering_config.sorting, &state_provider)?;
+        block_orders_from_sim_orders::<OrderPriorityType>(input.sim_orders, &state_provider)?;
     let mut builder = OrderingBuilderContext::new(
         Arc::from(state_provider),
         input.builder_name,
@@ -232,9 +238,9 @@ impl OrderingBuilderContext {
     /// use_suggested_fee_recipient_as_coinbase: all the mev profit goes directly to the slot suggested_fee_recipient so we avoid the payout tx.
     ///     This mode disables mev-share orders since the builder has to receive the mev profit to give some portion back to the mev-share user.
     /// !use_suggested_fee_recipient_as_coinbase: all the mev profit goes to the builder and at the end of the block we pay to the suggested_fee_recipient.
-    pub fn build_block(
+    pub fn build_block<OrderPriorityType: OrderPriority>(
         &mut self,
-        block_orders: PrioritizedOrderStore,
+        block_orders: PrioritizedOrderStore<OrderPriorityType>,
         use_suggested_fee_recipient_as_coinbase: bool,
         cancel_block: CancellationToken,
     ) -> eyre::Result<Box<dyn BlockBuildingHelper>> {
@@ -258,7 +264,6 @@ impl OrderingBuilderContext {
             self.cached_reads.take(),
             self.builder_name.clone(),
             self.config.discard_txs,
-            self.config.sorting.into(),
             cancel_block,
         )?;
 
@@ -268,10 +273,10 @@ impl OrderingBuilderContext {
         Ok(Box::new(block_building_helper))
     }
 
-    fn fill_orders(
+    fn fill_orders<OrderPriorityType: OrderPriority>(
         &mut self,
         block_building_helper: &mut dyn BlockBuildingHelper,
-        mut block_orders: PrioritizedOrderStore,
+        mut block_orders: PrioritizedOrderStore<OrderPriorityType>,
         build_start: Instant,
     ) -> eyre::Result<()> {
         let mut order_attempts: HashMap<OrderId, usize> = HashMap::default();
@@ -288,7 +293,9 @@ impl OrderingBuilderContext {
                 block_building_helper.builder_name(),
             );
             let start_time = Instant::now();
-            let commit_result = block_building_helper.commit_order(&sim_order)?;
+            let commit_result = block_building_helper.commit_order(&sim_order, &|sim_result| {
+                simulation_too_low::<OrderPriorityType>(&sim_order.sim_value, sim_result)
+            })?;
             let order_commit_time = start_time.elapsed();
             let mut gas_used = 0;
             let mut execution_error = None;
@@ -341,20 +348,28 @@ impl OrderingBuilderContext {
 }
 
 #[derive(Debug)]
-pub struct OrderingBuildingAlgorithm {
+pub struct OrderingBuildingAlgorithm<OrderPriorityType> {
     config: OrderingBuilderConfig,
     name: String,
+    /// The ordering priority type used to sort simulated orders.
+    order_priority: PhantomData<OrderPriorityType>,
 }
 
-impl OrderingBuildingAlgorithm {
+impl<OrderPriorityType> OrderingBuildingAlgorithm<OrderPriorityType> {
     pub fn new(config: OrderingBuilderConfig, name: String) -> Self {
-        Self { config, name }
+        Self {
+            config,
+            name,
+            order_priority: PhantomData,
+        }
     }
 }
 
-impl<P> BlockBuildingAlgorithm<P> for OrderingBuildingAlgorithm
+impl<P, OrderPriorityType> BlockBuildingAlgorithm<P>
+    for OrderingBuildingAlgorithm<OrderPriorityType>
 where
     P: StateProviderFactory + Clone + 'static,
+    OrderPriorityType: OrderPriority,
 {
     fn name(&self) -> String {
         self.name.clone()
@@ -369,6 +384,114 @@ where
             builder_name: self.name.clone(),
             cancel: input.cancel,
         };
-        run_ordering_builder(live_input, &self.config);
+        run_ordering_builder::<P, OrderPriorityType>(live_input, &self.config);
+    }
+}
+
+// Check that new simulation results during block building are not much lower (defined by OrderPriority) than the top-of-block simulation results
+// @Opt is large err OK here
+#[allow(clippy::result_large_err)]
+fn simulation_too_low<OrderPriorityType: OrderPriority>(
+    original_sim_result: &SimValue,
+    new_sim_result: &SimValue,
+) -> Result<(), ExecutionError> {
+    if OrderPriorityType::simulation_too_low(original_sim_result, new_sim_result) {
+        Err(ExecutionError::LowerInsertedValue {
+            before: original_sim_result.clone(),
+            inplace: new_sim_result.clone(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use revm_primitives::U256;
+
+    use crate::building::order_priority::{OrderMaxProfitPriority, OrderMevGasPricePriority};
+
+    use super::*;
+
+    #[test]
+    fn test_simulation_too_low_max_profit() {
+        let sim_result = &SimValue {
+            coinbase_profit: U256::from(100),
+            mev_gas_price: U256::from(0),
+            ..Default::default()
+        };
+        let inplace_sim_result = &SimValue {
+            coinbase_profit: U256::from(94),
+            mev_gas_price: U256::from(0),
+            ..Default::default()
+        };
+
+        // Lower than 95% of the original value
+        assert!(
+            simulation_too_low::<OrderMaxProfitPriority>(sim_result, inplace_sim_result).is_err()
+        );
+
+        // Equal to original value
+        let inplace_sim_result = &SimValue {
+            coinbase_profit: U256::from(100),
+            mev_gas_price: U256::from(0),
+            ..Default::default()
+        };
+        assert!(
+            simulation_too_low::<OrderMaxProfitPriority>(sim_result, inplace_sim_result).is_ok()
+        );
+
+        // Higher than original value
+        let inplace_sim_result = &SimValue {
+            coinbase_profit: U256::from(105),
+            mev_gas_price: U256::from(0),
+            ..Default::default()
+        };
+        assert!(
+            simulation_too_low::<OrderMaxProfitPriority>(sim_result, inplace_sim_result).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_simulation_too_low_mev_gas_price() {
+        let sim_result = &SimValue {
+            coinbase_profit: U256::from(0),
+            mev_gas_price: U256::from(100),
+            gas_used: 100,
+            ..Default::default()
+        };
+
+        // Lower than 95% of the original value
+        let inplace_sim_result = &SimValue {
+            coinbase_profit: U256::from(0),
+            mev_gas_price: U256::from(94),
+            gas_used: 94,
+            ..Default::default()
+        };
+        assert!(
+            simulation_too_low::<OrderMevGasPricePriority>(sim_result, inplace_sim_result).is_err()
+        );
+
+        // Equal to original value
+        let inplace_sim_result = &SimValue {
+            coinbase_profit: U256::from(0),
+            mev_gas_price: U256::from(100),
+            gas_used: 105,
+            ..Default::default()
+        };
+        assert!(
+            simulation_too_low::<OrderMevGasPricePriority>(sim_result, inplace_sim_result).is_ok()
+        );
+
+        // Higher than original value
+        let inplace_sim_result = &SimValue {
+            coinbase_profit: U256::from(0),
+            mev_gas_price: U256::from(105),
+            gas_used: 105,
+            ..Default::default()
+        };
+        assert!(
+            simulation_too_low::<OrderMevGasPricePriority>(sim_result, inplace_sim_result).is_ok()
+        );
     }
 }

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -200,7 +200,6 @@ impl BlockBuildingResultAssembler {
             self.cached_reads.clone(),
             self.builder_name.clone(),
             self.discard_txs,
-            None,
             self.cancellation_token.clone(),
         )?;
         block_building_helper.set_trace_orders_closed_at(orders_closed_at);
@@ -231,7 +230,7 @@ impl BlockBuildingResultAssembler {
                     block_building_helper.builder_name(),
                 );
                 let start_time = Instant::now();
-                let commit_result = block_building_helper.commit_order(sim_order)?;
+                let commit_result = block_building_helper.commit_order(sim_order, &|_| Ok(()))?;
                 let order_commit_time = start_time.elapsed();
 
                 let mut gas_used = 0;
@@ -272,7 +271,6 @@ impl BlockBuildingResultAssembler {
             None, // No cached reads for backtest start
             String::from("backtest_builder"),
             self.discard_txs,
-            None,
             CancellationToken::new(),
         )?;
 
@@ -301,7 +299,7 @@ impl BlockBuildingResultAssembler {
             for (order_idx, _) in sequence_of_orders.sequence_of_orders.iter() {
                 let sim_order = &order_group.orders[*order_idx];
 
-                let commit_result = block_building_helper.commit_order(sim_order)?;
+                let commit_result = block_building_helper.commit_order(sim_order, &|_| Ok(()))?;
 
                 match commit_result {
                     Ok(res) => {

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
@@ -142,7 +142,7 @@ impl ResolverContext {
             .get_cached_state(&full_sequence_of_orders);
 
         // Initialize state and partial block
-        let mut partial_block = PartialBlock::new(true, None);
+        let mut partial_block = PartialBlock::new(true);
         let mut state = self.initialize_block_state(&cached_state_option, state_provider);
         partial_block.pre_block_call(&self.ctx, &mut state)?;
 
@@ -171,7 +171,7 @@ impl ResolverContext {
             }
 
             let sim_order = &task.group.orders[order_idx];
-            match partial_block.commit_order(sim_order, &self.ctx, &mut state)? {
+            match partial_block.commit_order(sim_order, &self.ctx, &mut state, &|_| Ok(()))? {
                 Ok(res) => self.handle_successful_commit(
                     res,
                     sim_order,

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -315,22 +315,16 @@ pub enum Sorting {
     MaxProfit,
 }
 
-impl Sorting {
-    pub fn sorting_value(&self, sim_value: &SimValue) -> U256 {
-        match self {
-            Sorting::MevGasPrice => sim_value.mev_gas_price,
-            Sorting::MaxProfit => sim_value.coinbase_profit,
-        }
-    }
-}
+const MEV_GAS_PRICE_NAME: &str = "mev_gas_price";
+const MAX_PROFIT_NAME: &str = "max_profit";
 
 impl FromStr for Sorting {
     type Err = eyre::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "mev_gas_price" => Ok(Self::MevGasPrice),
-            "max_profit" => Ok(Self::MaxProfit),
+            MEV_GAS_PRICE_NAME => Ok(Self::MevGasPrice),
+            MAX_PROFIT_NAME => Ok(Self::MaxProfit),
             _ => eyre::bail!("Invalid algorithm"),
         }
     }
@@ -338,8 +332,8 @@ impl FromStr for Sorting {
 impl std::fmt::Display for Sorting {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Sorting::MevGasPrice => write!(f, "mev_gas_price"),
-            Sorting::MaxProfit => write!(f, "max_profit"),
+            Sorting::MevGasPrice => write!(f, "{}", MEV_GAS_PRICE_NAME),
+            Sorting::MaxProfit => write!(f, "{}", MAX_PROFIT_NAME),
         }
     }
 }
@@ -348,8 +342,6 @@ impl std::fmt::Display for Sorting {
 pub struct PartialBlock<Tracer: SimulationTracer> {
     /// Value used as allow_tx_skip on calls to [`PartialBlockFork`]
     pub discard_txs: bool,
-    /// If some [`enforce_inplace_sim_result`] is called after each tx to check the profit.
-    pub enforce_sorting: Option<Sorting>,
     pub gas_used: u64,
     /// Reserved gas for later use (usually final payout tx). When simulating we subtract this from the block gas limit.
     pub gas_reserved: u64,
@@ -468,7 +460,6 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
     ) -> PartialBlock<NewTracer> {
         PartialBlock {
             discard_txs: self.discard_txs,
-            enforce_sorting: self.enforce_sorting,
             gas_used: self.gas_used,
             gas_reserved: self.gas_reserved,
             blob_gas_used: self.blob_gas_used,
@@ -487,11 +478,15 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         self.gas_reserved = 0;
     }
 
+    /// result_filter: little hack to allow "cancel" the execution depending no the SimValue result. Ideally it would be nicer to split commit_order
+    ///     in 2 parts, one that executes but does not apply (returns state changes) and then another one that applies the changes.
+    ///     You can always pass &|_| Ok(()) if you don't need the filter.
     pub fn commit_order(
         &mut self,
         order: &SimulatedOrder,
         ctx: &BlockBuildingContext,
         state: &mut BlockState,
+        result_filter: &dyn Fn(&SimValue) -> Result<(), ExecutionError>,
     ) -> Result<Result<ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
         if ctx.builder_signer.is_none() && !order.sim_value.paid_kickbacks.is_empty() {
             // Return here to avoid wasting time on a call to fork.commit_order that 99% will fail
@@ -523,14 +518,12 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             ok_result.blob_gas_used,
             ok_result.paid_kickbacks.clone(),
         );
-        if let Some(enforce_sorting) = self.enforce_sorting {
-            match enforce_inplace_sim_result(enforce_sorting, &order.sim_value, &inplace_sim_result)
-            {
-                Ok(()) => {}
-                Err(err) => {
-                    fork.rollback(rollback);
-                    return Ok(Err(err));
-                }
+
+        match result_filter(&inplace_sim_result) {
+            Ok(()) => {}
+            Err(err) => {
+                fork.rollback(rollback);
+                return Ok(Err(err));
             }
         }
 
@@ -804,10 +797,9 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
 }
 
 impl PartialBlock<()> {
-    pub fn new(discard_txs: bool, enforce_sorting: Option<Sorting>) -> Self {
+    pub fn new(discard_txs: bool) -> Self {
         Self {
             discard_txs,
-            enforce_sorting,
             gas_used: 0,
             gas_reserved: 0,
             blob_gas_used: 0,
@@ -829,103 +821,4 @@ pub enum FillOrdersError {
     CriticalCommitOrderError(#[from] CriticalCommitOrderError),
     #[error("Payout tx error: {0}")]
     PayoutTxErr(#[from] InsertPayoutTxErr),
-}
-
-// Enforces that 'inplace' simulation results during block building are not lower than 95% of the top-of-block simulation results
-// @Opt is large err OK here
-#[allow(clippy::result_large_err)]
-fn enforce_inplace_sim_result(
-    sort: Sorting,
-    sim_result: &SimValue,
-    inplace_sim_result: &SimValue,
-) -> Result<(), ExecutionError> {
-    let (sim_value, inplace_value) = (
-        sort.sorting_value(sim_result),
-        sort.sorting_value(inplace_sim_result),
-    );
-    if (inplace_value * U256::from(100)) < (sim_value * U256::from(95)) {
-        Err(ExecutionError::LowerInsertedValue {
-            before: sim_result.clone(),
-            inplace: inplace_sim_result.clone(),
-        })
-    } else {
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_enforce_inplace_sim_result_max_profit() {
-        let sort = Sorting::MaxProfit;
-        let sim_result = &SimValue {
-            coinbase_profit: U256::from(100),
-            mev_gas_price: U256::from(0),
-            ..Default::default()
-        };
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(94),
-            mev_gas_price: U256::from(0),
-            ..Default::default()
-        };
-
-        // Lower than 95% of the original value
-        assert!(enforce_inplace_sim_result(sort, sim_result, inplace_sim_result).is_err());
-
-        // Equal to original value
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(100),
-            mev_gas_price: U256::from(0),
-            ..Default::default()
-        };
-        assert!(enforce_inplace_sim_result(sort, sim_result, inplace_sim_result).is_ok());
-
-        // Higher than original value
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(105),
-            mev_gas_price: U256::from(0),
-            ..Default::default()
-        };
-        assert!(enforce_inplace_sim_result(sort, sim_result, inplace_sim_result).is_ok());
-    }
-
-    #[test]
-    fn test_enforce_inplace_sim_result_mev_gas_price() {
-        let sort = Sorting::MevGasPrice;
-        let sim_result = &SimValue {
-            coinbase_profit: U256::from(0),
-            mev_gas_price: U256::from(100),
-            gas_used: 100,
-            ..Default::default()
-        };
-
-        // Lower than 95% of the original value
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(0),
-            mev_gas_price: U256::from(94),
-            gas_used: 94,
-            ..Default::default()
-        };
-        assert!(enforce_inplace_sim_result(sort, sim_result, inplace_sim_result).is_err());
-
-        // Equal to original value
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(0),
-            mev_gas_price: U256::from(100),
-            gas_used: 105,
-            ..Default::default()
-        };
-        assert!(enforce_inplace_sim_result(sort, sim_result, inplace_sim_result).is_ok());
-
-        // Higher than original value
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(0),
-            mev_gas_price: U256::from(105),
-            gas_used: 105,
-            ..Default::default()
-        };
-        assert!(enforce_inplace_sim_result(sort, sim_result, inplace_sim_result).is_ok());
-    }
 }

--- a/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
@@ -35,7 +35,7 @@ pub struct TestSetup {
 impl TestSetup {
     pub fn gen_test_setup(block_args: BlockArgs) -> eyre::Result<Self> {
         Ok(Self {
-            partial_block: PartialBlock::new(true, None),
+            partial_block: PartialBlock::new(true),
             order_builder: OrderBuilder::None,
             bundle_state: None,
             cached_reads: None,
@@ -225,6 +225,7 @@ impl TestSetup {
             &sim_order,
             self.test_chain.block_building_context(),
             &mut block_state,
+            &|_| Ok(()),
         )?;
 
         let (cached_reads, bundle_state, _) = block_state.into_parts();

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -24,6 +24,7 @@ use crate::{
             },
             BacktestSimulateBlockInput, Block, BlockBuildingAlgorithm,
         },
+        order_priority::{OrderMaxProfitPriority, OrderMevGasPricePriority},
         Sorting,
     },
     live_builder::{
@@ -407,9 +408,20 @@ impl LiveBuilderConfig for Config {
     {
         let builder_cfg = self.builder(building_algorithm_name)?;
         match builder_cfg.builder {
-            SpecificBuilderConfig::OrderingBuilder(config) => {
-                crate::building::builders::ordering_builder::backtest_simulate_block(config, input)
-            }
+            SpecificBuilderConfig::OrderingBuilder(config) => match config.sorting {
+                Sorting::MevGasPrice => {
+                    crate::building::builders::ordering_builder::backtest_simulate_block::<
+                        P,
+                        OrderMevGasPricePriority,
+                    >(config, input)
+                }
+                Sorting::MaxProfit => {
+                    crate::building::builders::ordering_builder::backtest_simulate_block::<
+                        P,
+                        OrderMaxProfitPriority,
+                    >(config, input)
+                }
+            },
             SpecificBuilderConfig::ParallelBuilder(config) => {
                 parallel_build_backtest::<P>(input, config)
             }
@@ -571,9 +583,14 @@ where
     P: StateProviderFactory + Clone + 'static,
 {
     match cfg.builder {
-        SpecificBuilderConfig::OrderingBuilder(order_cfg) => {
-            Arc::new(OrderingBuildingAlgorithm::new(order_cfg, cfg.name))
-        }
+        SpecificBuilderConfig::OrderingBuilder(order_cfg) => match order_cfg.sorting {
+            Sorting::MevGasPrice => Arc::new(
+                OrderingBuildingAlgorithm::<OrderMevGasPricePriority>::new(order_cfg, cfg.name),
+            ),
+            Sorting::MaxProfit => Arc::new(
+                OrderingBuildingAlgorithm::<OrderMaxProfitPriority>::new(order_cfg, cfg.name),
+            ),
+        },
         SpecificBuilderConfig::ParallelBuilder(parallel_cfg) => {
             Arc::new(ParallelBuildingAlgorithm::new(parallel_cfg, cfg.name))
         }


### PR DESCRIPTION
## 📝 Summary

This is a refactoring PR, completely backwards compatible.
Order sorting was based on the ability to express the sorting as a number (Sorting::sorting_value) and this is way too rigid.
Sorting::sorting_value was replaced for type system (implementing OrderPriority). Now we can create new sorting criteria by adding new types.
I also added a patch to remove the internally hardcoded check for "enforce_inplace_sim_result". Now it's explicit and configurable (we'll need it in the future)

## 💡 Motivation and Context

This allows to easily add new sorting criteria and more advanced handling for the "enforce_inplace_sim_result".

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
