### PR TITLE
Fix flashblocks receipt index

### DIFF
--- a/crates/op-rbuilder/src/integration/integration_test.rs
+++ b/crates/op-rbuilder/src/integration/integration_test.rs
@@ -465,6 +465,19 @@ mod tests {
                         "new_account_balances missing"
                     );
                     assert!(metadata.get("receipts").is_some(), "receipts missing");
+                    // also check if the length of the receipts is the same as the number of transactions
+                    assert!(
+                        metadata.get("receipts").unwrap().as_object().unwrap().len()
+                            == msg
+                                .get("diff")
+                                .unwrap()
+                                .get("transactions")
+                                .unwrap()
+                                .as_array()
+                                .unwrap()
+                                .len(),
+                        "receipts length mismatch"
+                    );
                     message_count += 1;
                 }
                 drop(messages);

--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -579,7 +579,6 @@ where
 
     // pick the new transactions from the info field and update the last flashblock index
     let new_transactions = info.executed_transactions[info.last_flashblock_index..].to_vec();
-    info.last_flashblock_index = info.executed_transactions.len();
 
     let new_transactions_encoded = new_transactions
         .clone()
@@ -588,6 +587,7 @@ where
         .collect::<Vec<_>>();
 
     let new_receipts = info.receipts[info.last_flashblock_index..].to_vec();
+    info.last_flashblock_index = info.executed_transactions.len();
     let receipts_with_hash = new_transactions
         .iter()
         .zip(new_receipts.iter())


### PR DESCRIPTION
## 📝 Summary
The index for getting the receipt is incorrect as it's using an updated index, fix it.

Added an additional assertion in integration test to test this.

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
