### PR TITLE
New sorting modes

### DIFF
--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -1066,7 +1066,7 @@ fn order_redistribution_address(order: &Order, protect_signers: &[Address]) -> O
             // 1. first address from the refund config
             // 2. origin of the first tx
 
-            if let Some(first_refund) = bundle.inner_bundle.refund_config.first() {
+            if let Some(first_refund) = bundle.inner_bundle().refund_config.first() {
                 return Some(first_refund.address);
             }
 

--- a/crates/rbuilder/src/backtest/restore_landed_orders/find_landed_orders.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/find_landed_orders.rs
@@ -45,7 +45,7 @@ impl SimplifiedOrder {
             }
             Order::ShareBundle(bundle) => SimplifiedOrder::new(
                 id,
-                OrderChunk::chunks_from_inner_share_bundle(&bundle.inner_bundle),
+                OrderChunk::chunks_from_inner_share_bundle(bundle.inner_bundle()),
             ),
         }
     }
@@ -766,11 +766,11 @@ mod tests {
 
     #[test]
     fn test_simplified_order_conversion_share_bundle() {
-        let bundle = Order::ShareBundle(ShareBundle {
-            hash: hash(0xb1),
-            block: 0,
-            max_block: 0,
-            inner_bundle: ShareBundleInner {
+        let bundle = Order::ShareBundle(ShareBundle::new_with_fake_hash(
+            hash(0xb1),
+            0,
+            0,
+            ShareBundleInner {
                 body: vec![
                     ShareBundleBody::Tx(ShareBundleTx {
                         tx: tx(0x01),
@@ -832,11 +832,11 @@ mod tests {
                 can_skip: false,
                 original_order_id: None,
             },
-            signer: None,
-            replacement_data: None,
-            original_orders: vec![],
-            metadata: Default::default(),
-        });
+            None,
+            None,
+            vec![],
+            Default::default(),
+        ));
         let expected = SimplifiedOrder::new(
             OrderId::ShareBundle(hash(0xb1)),
             vec![

--- a/crates/rbuilder/src/building/block_orders/order_priority.rs
+++ b/crates/rbuilder/src/building/block_orders/order_priority.rs
@@ -19,110 +19,164 @@ fn new_sim_value_too_low(original_sim: U256, new_sim: U256) -> bool {
     new_sim * U256::from(100) < (original_sim * U256::from(MIN_SIM_RESULT_PERCENTAGE))
 }
 
-// @TODO: Make macro!
+macro_rules! create_order_priority {
+    ($order_priority:ident($cmp:ident $( , $next_cmp:ident )*)<$new_sim_value_too_low_func:ident>) => {
+        #[derive(Debug, Clone)]
+        pub struct $order_priority {
+            order: Arc<SimulatedOrder>,
+        }
+
+        impl OrderPriority for $order_priority {
+            fn new(order: Arc<SimulatedOrder>) -> Self {
+                Self { order }
+            }
+
+            fn simulation_too_low(
+                original_sim_value: &SimValue,
+                new_sim_value: &SimValue,
+            ) -> bool {
+                $new_sim_value_too_low_func(
+                    original_sim_value,
+                    new_sim_value,
+                )
+            }
+        }
+
+        impl PartialEq for $order_priority {
+            fn eq(&self, other: &Self) -> bool {
+                $cmp::eq(&self.order, &other.order)
+            }
+        }
+
+        impl Eq for $order_priority {}
+
+        impl PartialOrd for $order_priority {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl Ord for $order_priority {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                $cmp::cmp(&self.order, &other.order)
+                    $( .then_with(|| $next_cmp::cmp(&self.order, &other.order)) )*
+            }
+        }
+    };
+}
 
 ///////////////////////////////
 /// MevGasPrice
 ///////////////////////////////
-
-#[derive(Debug, Clone)]
-pub struct OrderMevGasPricePriority {
-    order: Arc<SimulatedOrder>,
-}
-
-impl OrderPriority for OrderMevGasPricePriority {
-    fn new(order: Arc<SimulatedOrder>) -> Self {
-        Self { order }
+struct OrderMevGasPricePriorityCmp {}
+impl OrderMevGasPricePriorityCmp {
+    #[inline]
+    fn eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
+        a.sim_value.mev_gas_price == b.sim_value.mev_gas_price
     }
 
-    fn simulation_too_low(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool {
-        new_sim_value_too_low(
-            original_sim_value.mev_gas_price,
-            new_sim_value.mev_gas_price,
-        )
+    #[inline]
+    fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
+        a.sim_value.mev_gas_price.cmp(&b.sim_value.mev_gas_price)
     }
 }
-
 #[inline]
-fn mev_gas_price_eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
-    a.sim_value.mev_gas_price == b.sim_value.mev_gas_price
-}
-
-#[inline]
-fn mev_gas_price_cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
-    a.sim_value.mev_gas_price.cmp(&b.sim_value.mev_gas_price)
-}
-
-impl PartialEq for OrderMevGasPricePriority {
-    fn eq(&self, other: &Self) -> bool {
-        mev_gas_price_eq(&self.order, &other.order)
-    }
-}
-
-impl Eq for OrderMevGasPricePriority {}
-
-impl PartialOrd for OrderMevGasPricePriority {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for OrderMevGasPricePriority {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        mev_gas_price_cmp(&self.order, &other.order)
-    }
+fn simulation_too_low_gas_price(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool {
+    new_sim_value_too_low(
+        original_sim_value.mev_gas_price,
+        new_sim_value.mev_gas_price,
+    )
 }
 
 ///////////////////////////////
 /// MaxProfit
 ///////////////////////////////
 
-#[derive(Debug, Clone)]
-pub struct OrderMaxProfitPriority {
-    order: Arc<SimulatedOrder>,
-}
-
-impl OrderPriority for OrderMaxProfitPriority {
-    fn new(order: Arc<SimulatedOrder>) -> Self {
-        Self { order }
+struct OrderMaxProfitPriorityCmp {}
+impl OrderMaxProfitPriorityCmp {
+    #[inline]
+    fn eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
+        a.sim_value.coinbase_profit == b.sim_value.coinbase_profit
     }
 
-    fn simulation_too_low(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool {
-        new_sim_value_too_low(
-            original_sim_value.coinbase_profit,
-            new_sim_value.coinbase_profit,
-        )
+    #[inline]
+    fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
+        a.sim_value
+            .coinbase_profit
+            .cmp(&b.sim_value.coinbase_profit)
     }
 }
-
 #[inline]
-fn max_profit_eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
-    a.sim_value.coinbase_profit == b.sim_value.coinbase_profit
+fn simulation_too_low_profit(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool {
+    new_sim_value_too_low(
+        original_sim_value.coinbase_profit,
+        new_sim_value.coinbase_profit,
+    )
 }
 
-#[inline]
-fn max_profit_cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
-    a.sim_value
-        .coinbase_profit
-        .cmp(&b.sim_value.coinbase_profit)
-}
+///////////////////////////////
+/// OrderType
+/// Prioritizes Bundles over Mempool
+///////////////////////////////
 
-impl PartialEq for OrderMaxProfitPriority {
-    fn eq(&self, other: &Self) -> bool {
-        max_profit_eq(&self.order, &other.order)
+struct OrderTypeCmp {}
+impl OrderTypeCmp {
+    #[inline]
+    fn eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
+        a.order.is_tx() == b.order.is_tx()
+    }
+
+    #[inline]
+    fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
+        let a_is_tx = a.order.is_tx();
+        let b_is_tx = b.order.is_tx();
+        if a_is_tx == b_is_tx {
+            Ordering::Equal
+        } else if a_is_tx {
+            //*a_is_tx && !b_is_tx
+            Ordering::Less
+        } else {
+            //*!a_is_tx && b_is_tx
+            Ordering::Greater
+        }
     }
 }
 
-impl Eq for OrderMaxProfitPriority {}
+///////////////////////////////
+/// OrderType
+/// Prioritizes Bundles over Mempool
+///////////////////////////////
 
-impl PartialOrd for OrderMaxProfitPriority {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
+struct OrderLengthThreeCmp {}
+impl OrderLengthThreeCmp {
+    #[inline]
+    fn is_long(a: &SimulatedOrder) -> bool {
+        a.order.list_txs_len() >= 3
+    }
+
+    #[inline]
+    fn eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
+        Self::is_long(a) == Self::is_long(b)
+    }
+
+    #[inline]
+    fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
+        let a_is_long = Self::is_long(a);
+        let b_is_long = Self::is_long(b);
+        if a_is_long == b_is_long {
+            Ordering::Equal
+        } else if a_is_long {
+            //*a_is_long && !b_is_long
+            Ordering::Greater
+        } else {
+            //*!a_is_long && b_is_long
+            Ordering::Less
+        }
     }
 }
 
-impl Ord for OrderMaxProfitPriority {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        max_profit_cmp(&self.order, &other.order)
-    }
-}
+create_order_priority!(OrderMevGasPricePriority(OrderMevGasPricePriorityCmp)<simulation_too_low_gas_price>);
+create_order_priority!(OrderMaxProfitPriority(OrderMaxProfitPriorityCmp)<simulation_too_low_profit>);
+create_order_priority!(OrderTypePriority(OrderTypeCmp,OrderMaxProfitPriorityCmp)<simulation_too_low_profit>);
+create_order_priority!(OrderLengthThreeMaxProfitPriority(OrderLengthThreeCmp,OrderMaxProfitPriorityCmp)<simulation_too_low_profit>);
+create_order_priority!(OrderLengthThreeMevGasPricePriority(OrderLengthThreeCmp,OrderMevGasPricePriorityCmp)<simulation_too_low_profit>);

--- a/crates/rbuilder/src/building/block_orders/order_priority.rs
+++ b/crates/rbuilder/src/building/block_orders/order_priority.rs
@@ -65,9 +65,7 @@ macro_rules! create_order_priority {
     };
 }
 
-///////////////////////////////
 /// MevGasPrice
-///////////////////////////////
 struct OrderMevGasPricePriorityCmp {}
 impl OrderMevGasPricePriorityCmp {
     #[inline]
@@ -88,10 +86,7 @@ fn simulation_too_low_gas_price(original_sim_value: &SimValue, new_sim_value: &S
     )
 }
 
-///////////////////////////////
 /// MaxProfit
-///////////////////////////////
-
 struct OrderMaxProfitPriorityCmp {}
 impl OrderMaxProfitPriorityCmp {
     #[inline]
@@ -114,11 +109,8 @@ fn simulation_too_low_profit(original_sim_value: &SimValue, new_sim_value: &SimV
     )
 }
 
-///////////////////////////////
 /// OrderType
 /// Prioritizes Bundles over Mempool
-///////////////////////////////
-
 struct OrderTypeCmp {}
 impl OrderTypeCmp {
     #[inline]
@@ -142,11 +134,7 @@ impl OrderTypeCmp {
     }
 }
 
-///////////////////////////////
-/// OrderType
-/// Prioritizes Bundles over Mempool
-///////////////////////////////
-
+/// Prioritizes orders with 3 or more txs
 struct OrderLengthThreeCmp {}
 impl OrderLengthThreeCmp {
     #[inline]

--- a/crates/rbuilder/src/building/block_orders/share_bundle_merger.rs
+++ b/crates/rbuilder/src/building/block_orders/share_bundle_merger.rs
@@ -119,7 +119,7 @@ impl<SinkType: SimulatedOrderSink> MultiBackrunManager<SinkType> {
         let mut original_orders = Vec::new();
         for broken_order in self.sorted_orders.values() {
             if let Some(sbundle) = broken_order.sbundle() {
-                let mut inner_bundle = sbundle.inner_bundle.clone();
+                let mut inner_bundle = sbundle.inner_bundle().clone();
                 inner_bundle.can_skip = true;
                 inner_bundle.original_order_id = Some(broken_order.sim_order.id());
                 body.push(ShareBundleBody::Bundle(inner_bundle));
@@ -134,18 +134,16 @@ impl<SinkType: SimulatedOrderSink> MultiBackrunManager<SinkType> {
             can_skip: false,
             original_order_id: None,
         };
-        let mut sbundle = ShareBundle {
-            hash: Default::default(),
-            block: highest_payback_order_bundle.block,
-            max_block: highest_payback_order_bundle.max_block,
+        let sbundle = ShareBundle::new(
+            highest_payback_order_bundle.block,
+            highest_payback_order_bundle.max_block,
             inner_bundle,
-            signer: highest_payback_order_bundle.signer,
-            replacement_data: None, //replacement_data get lost since we merge many sbundles
+            highest_payback_order_bundle.signer,
+            None, //replacement_data get lost since we merge many sbundles
             original_orders,
             // We take parent order submission time
-            metadata: highest_payback_order.sim_order.order.metadata().clone(),
-        };
-        sbundle.hash_slow();
+            highest_payback_order.sim_order.order.metadata().clone(),
+        );
         Some(Arc::new(SimulatedOrder {
             order: Order::ShareBundle(sbundle),
             sim_value: highest_payback_order.sim_order.sim_value.clone(),
@@ -271,7 +269,7 @@ impl<SinkType: SimulatedOrderSink> ShareBundleMerger<SinkType> {
         } else {
             return None;
         };
-        let first_item = sbundle.inner_bundle.body.first().or_else(|| {
+        let first_item = sbundle.inner_bundle().body.first().or_else(|| {
             error!(?sbundle, "Empty sbundle");
             None
         })?;
@@ -288,7 +286,7 @@ impl<SinkType: SimulatedOrderSink> ShareBundleMerger<SinkType> {
         sim_order: &Arc<SimulatedOrder>,
     ) -> Option<BrokenDownShareBundle> {
         let got_bundles = sbundle
-            .inner_bundle
+            .inner_bundle()
             .body
             .iter()
             .any(|item| matches!(item, ShareBundleBody::Bundle(_)));
@@ -298,7 +296,7 @@ impl<SinkType: SimulatedOrderSink> ShareBundleMerger<SinkType> {
             );
             return None;
         }
-        if !sbundle.inner_bundle.refund.is_empty() {
+        if !sbundle.inner_bundle().refund.is_empty() {
             warn!(hash = ?sbundle.hash,
                 "sbundle for user txs should not contain refunds"
             );
@@ -336,7 +334,7 @@ impl<SinkType: SimulatedOrderSink> ShareBundleMerger<SinkType> {
     /// Checks also that it contains no refund stuff
     fn check_and_get_user_bundle_hash_from_backrun(sbundle: &ShareBundle) -> Option<B256> {
         let user_bundle = sbundle
-            .inner_bundle
+            .inner_bundle()
             .body
             .get(Self::USER_BUNDLE_INDEX)
             .or_else(|| {
@@ -368,15 +366,15 @@ impl<SinkType: SimulatedOrderSink> ShareBundleMerger<SinkType> {
 
     /// - Have a single inner_bundle.refund (user tx) with body_idx == 0
     fn check_refunds_from_backrun_ok(sbundle: &ShareBundle) -> bool {
-        if sbundle.inner_bundle.refund.len() != 1 {
+        if sbundle.inner_bundle().refund.len() != 1 {
             warn!(
                 hash = ?sbundle.hash,
                 "sbundle should have a single refund but has {}",
-                sbundle.inner_bundle.refund.len()
+                sbundle.inner_bundle().refund.len()
             );
             return false;
         }
-        let first_body_idx = sbundle.inner_bundle.refund[0].body_idx;
+        let first_body_idx = sbundle.inner_bundle().refund[0].body_idx;
         if first_body_idx != Self::USER_BUNDLE_INDEX {
             warn!(
                 hash = ?sbundle.hash,
@@ -457,11 +455,12 @@ mod test {
     /// more than a inner_bundle.refund should pass as is
     fn test_2_refunds() {
         let mut context = new_test_context();
-        let mut sbundle = context.create_sbundle_tx_br();
-        sbundle
-            .inner_bundle
+        let sbundle = context.create_sbundle_tx_br();
+        let mut new_inner_bundle = sbundle.inner_bundle().clone();
+        new_inner_bundle
             .refund
-            .push(sbundle.inner_bundle.refund[0].clone());
+            .push(sbundle.inner_bundle().refund[0].clone());
+        let sbundle = sbundle.with_inner_bundle(new_inner_bundle);
         context.assert_passes_as_is(Order::ShareBundle(sbundle));
     }
 

--- a/crates/rbuilder/src/building/block_orders/test_context.rs
+++ b/crates/rbuilder/src/building/block_orders/test_context.rs
@@ -193,18 +193,15 @@ impl<TestedSinkType: SimulatedOrderSink> TestContext<TestedSinkType> {
             can_skip: false,
             original_order_id: None,
         };
-        let mut sbundle = ShareBundle {
-            hash: B256::default(),
-            block: DONT_CARE_BLOCK,
-            max_block: DONT_CARE_BLOCK,
-            inner_bundle: inner,
+        ShareBundle::new(
+            DONT_CARE_BLOCK,
+            DONT_CARE_BLOCK,
+            inner,
             signer,
-            replacement_data: None,
-            original_orders: Vec::new(),
-            metadata: Default::default(),
-        };
-        sbundle.hash_slow();
-        sbundle
+            None,
+            Vec::new(),
+            Default::default(),
+        )
     }
 
     fn as_inner(item: &ShareBundleBody) -> &ShareBundleInner {
@@ -236,17 +233,20 @@ impl<TestedSinkType: SimulatedOrderSink> TestContext<TestedSinkType> {
         sbundles: &[Arc<SimulatedOrder>],
     ) {
         let concatenated_sbundle = Self::as_sbundle(&concatenated_order.order);
-        assert_eq!(concatenated_sbundle.inner_bundle.body.len(), sbundles.len());
-        assert!(concatenated_sbundle.inner_bundle.refund.is_empty());
-        assert!(concatenated_sbundle.inner_bundle.refund_config.is_empty());
+        assert_eq!(
+            concatenated_sbundle.inner_bundle().body.len(),
+            sbundles.len()
+        );
+        assert!(concatenated_sbundle.inner_bundle().refund.is_empty());
+        assert!(concatenated_sbundle.inner_bundle().refund_config.is_empty());
         let concatenated_sbundle_inners = concatenated_sbundle
-            .inner_bundle
+            .inner_bundle()
             .body
             .iter()
             .map(Self::as_inner);
         let sbundles_inners = sbundles
             .iter()
-            .map(|sb| &Self::as_sbundle(&sb.order).inner_bundle);
+            .map(|sb| Self::as_sbundle(&sb.order).inner_bundle());
         concatenated_sbundle_inners
             .zip(sbundles_inners)
             .for_each(|(conc_sbundle, sbundle)| {

--- a/crates/rbuilder/src/building/block_orders/test_context.rs
+++ b/crates/rbuilder/src/building/block_orders/test_context.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, U256};
 
 use crate::{
     primitives::{

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -313,10 +313,19 @@ pub enum Sorting {
     MevGasPrice,
     /// Sorts the SimulatedOrders by its absolute profit which is computed as the coinbase balance delta after executing the order
     MaxProfit,
+    /// Orders are ordered by their origin (bundle/sbundles then mempool) and then by their absolute profit.
+    TypeMaxProfit,
+    /// Orders are ordered by length 3 (orders length >= 3 first) and then by their absolute profit.
+    LengthThreeMaxProfit,
+    /// Orders are ordered by length 3 (orders length >= 3 first) and then by their mev gas price.
+    LengthThreeMevGasPrice,
 }
 
 const MEV_GAS_PRICE_NAME: &str = "mev_gas_price";
 const MAX_PROFIT_NAME: &str = "max_profit";
+const TYPE_MAX_PROFIT_NAME: &str = "type_max_profit";
+const LENGTH_THREE_MAX_PROFIT_NAME: &str = "length_three_max_profit";
+const LENGTH_THREE_MEV_GAS_PRICE_NAME: &str = "length_three_mev_gas_price";
 
 impl FromStr for Sorting {
     type Err = eyre::Error;
@@ -325,6 +334,9 @@ impl FromStr for Sorting {
         match s {
             MEV_GAS_PRICE_NAME => Ok(Self::MevGasPrice),
             MAX_PROFIT_NAME => Ok(Self::MaxProfit),
+            TYPE_MAX_PROFIT_NAME => Ok(Self::TypeMaxProfit),
+            LENGTH_THREE_MAX_PROFIT_NAME => Ok(Self::LengthThreeMaxProfit),
+            LENGTH_THREE_MEV_GAS_PRICE_NAME => Ok(Self::LengthThreeMevGasPrice),
             _ => eyre::bail!("Invalid algorithm"),
         }
     }
@@ -334,6 +346,9 @@ impl std::fmt::Display for Sorting {
         match self {
             Sorting::MevGasPrice => write!(f, "{}", MEV_GAS_PRICE_NAME),
             Sorting::MaxProfit => write!(f, "{}", MAX_PROFIT_NAME),
+            Sorting::TypeMaxProfit => write!(f, "{}", TYPE_MAX_PROFIT_NAME),
+            Sorting::LengthThreeMaxProfit => write!(f, "{}", LENGTH_THREE_MAX_PROFIT_NAME),
+            Sorting::LengthThreeMevGasPrice => write!(f, "{}", LENGTH_THREE_MEV_GAS_PRICE_NAME),
         }
     }
 }

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -787,7 +787,7 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         allow_tx_skip: bool,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
         let res = self.commit_share_bundle_inner(
-            &bundle.inner_bundle,
+            bundle.inner_bundle(),
             ctx,
             cumulative_gas_used,
             gas_reserved,

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -24,7 +24,10 @@ use crate::{
             },
             BacktestSimulateBlockInput, Block, BlockBuildingAlgorithm,
         },
-        order_priority::{OrderMaxProfitPriority, OrderMevGasPricePriority},
+        order_priority::{
+            OrderLengthThreeMaxProfitPriority, OrderLengthThreeMevGasPricePriority,
+            OrderMaxProfitPriority, OrderMevGasPricePriority, OrderTypePriority,
+        },
         Sorting,
     },
     live_builder::{
@@ -421,6 +424,24 @@ impl LiveBuilderConfig for Config {
                         OrderMaxProfitPriority,
                     >(config, input)
                 }
+                Sorting::TypeMaxProfit => {
+                    crate::building::builders::ordering_builder::backtest_simulate_block::<
+                        P,
+                        OrderTypePriority,
+                    >(config, input)
+                }
+                Sorting::LengthThreeMaxProfit => {
+                    crate::building::builders::ordering_builder::backtest_simulate_block::<
+                        P,
+                        OrderLengthThreeMaxProfitPriority,
+                    >(config, input)
+                }
+                Sorting::LengthThreeMevGasPrice => {
+                    crate::building::builders::ordering_builder::backtest_simulate_block::<
+                        P,
+                        OrderLengthThreeMevGasPricePriority,
+                    >(config, input)
+                }
             },
             SpecificBuilderConfig::ParallelBuilder(config) => {
                 parallel_build_backtest::<P>(input, config)
@@ -590,6 +611,15 @@ where
             Sorting::MaxProfit => Arc::new(
                 OrderingBuildingAlgorithm::<OrderMaxProfitPriority>::new(order_cfg, cfg.name),
             ),
+            Sorting::TypeMaxProfit => Arc::new(
+                OrderingBuildingAlgorithm::<OrderTypePriority>::new(order_cfg, cfg.name),
+            ),
+            Sorting::LengthThreeMaxProfit => Arc::new(OrderingBuildingAlgorithm::<
+                OrderLengthThreeMaxProfitPriority,
+            >::new(order_cfg, cfg.name)),
+            Sorting::LengthThreeMevGasPrice => Arc::new(OrderingBuildingAlgorithm::<
+                OrderLengthThreeMevGasPricePriority,
+            >::new(order_cfg, cfg.name)),
         },
         SpecificBuilderConfig::ParallelBuilder(parallel_cfg) => {
             Arc::new(ParallelBuildingAlgorithm::new(parallel_cfg, cfg.name))

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -171,6 +171,11 @@ impl Bundle {
             .collect()
     }
 
+    /// list_txs().len()
+    fn list_txs_len(&self) -> usize {
+        self.txs.len()
+    }
+
     /// Returns `true` if the provided transaction hash is refundable.
     /// This means that part the profit from this execution goes to the self.refund.recipient
     pub fn is_tx_refundable(&self, hash: &B256) -> bool {
@@ -335,6 +340,16 @@ impl ShareBundleInner {
             .collect()
     }
 
+    pub fn list_txs_len(&self) -> usize {
+        self.body
+            .iter()
+            .map(|b| match b {
+                ShareBundleBody::Tx(_) => 1,
+                ShareBundleBody::Bundle(bundle) => bundle.list_txs_len(),
+            })
+            .sum()
+    }
+
     /// Refunds config for the ShareBundleInner.
     /// refund_config not empty -> we use it
     /// refund_config empty:
@@ -396,7 +411,9 @@ pub struct ShareBundle {
     pub hash: B256,
     pub block: u64,
     pub max_block: u64,
-    pub inner_bundle: ShareBundleInner,
+    inner_bundle: ShareBundleInner,
+    /// Cached inner_bundle.list_txs_len()
+    list_txs_len: usize,
     pub signer: Option<Address>,
     /// data that uniquely identifies this ShareBundle for update or cancellation
     pub replacement_data: Option<ShareBundleReplacementData>,
@@ -408,12 +425,84 @@ pub struct ShareBundle {
 }
 
 impl ShareBundle {
+    pub fn new(
+        block: u64,
+        max_block: u64,
+        inner_bundle: ShareBundleInner,
+        signer: Option<Address>,
+        replacement_data: Option<ShareBundleReplacementData>,
+        original_orders: Vec<Order>,
+        metadata: Metadata,
+    ) -> Self {
+        let list_txs_len = inner_bundle.list_txs_len();
+        let mut sbundle = Self {
+            hash: B256::default(),
+            block,
+            max_block,
+            inner_bundle,
+            list_txs_len,
+            signer,
+            replacement_data,
+            original_orders,
+            metadata,
+        };
+        sbundle.hash_slow();
+        sbundle
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_fake_hash(
+        hash: B256,
+        block: u64,
+        max_block: u64,
+        inner_bundle: ShareBundleInner,
+        signer: Option<Address>,
+        replacement_data: Option<ShareBundleReplacementData>,
+        original_orders: Vec<Order>,
+        metadata: Metadata,
+    ) -> Self {
+        let list_txs_len = inner_bundle.list_txs_len();
+        Self {
+            hash,
+            block,
+            max_block,
+            inner_bundle,
+            list_txs_len,
+            signer,
+            replacement_data,
+            original_orders,
+            metadata,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_inner_bundle(self, inner_bundle: ShareBundleInner) -> Self {
+        Self::new(
+            self.block,
+            self.max_block,
+            inner_bundle,
+            self.signer,
+            self.replacement_data,
+            self.original_orders,
+            self.metadata,
+        )
+    }
+
+    pub fn inner_bundle(&self) -> &ShareBundleInner {
+        &self.inner_bundle
+    }
     pub fn can_execute_with_block_base_fee(&self, block_base_fee: u128) -> bool {
         can_execute_with_block_base_fee(self.list_txs(), block_base_fee)
     }
 
     pub fn list_txs(&self) -> Vec<(&TransactionSignedEcRecoveredWithBlobs, bool)> {
         self.inner_bundle.list_txs()
+    }
+
+    /// @Pending: optimize by caching (we need to enforce inner_bundle immutability)
+    pub fn list_txs_len(&self) -> usize {
+        self.list_txs_len
     }
 
     /// BundledTxInfo for all the child txs
@@ -426,8 +515,7 @@ impl ShareBundle {
     }
 
     // Recalculate bundle hash.
-    /// Sadly it's not perfect since it only hashes inner txs in DFS, so tree structure and all other cfg is lost.
-    pub fn hash_slow(&mut self) {
+    fn hash_slow(&mut self) {
         self.hash = self.inner_bundle.hash_slow();
     }
 
@@ -797,6 +885,15 @@ impl Order {
             Order::Bundle(bundle) => bundle.list_txs(),
             Order::Tx(tx) => vec![(&tx.tx_with_blobs, true)],
             Order::ShareBundle(bundle) => bundle.list_txs(),
+        }
+    }
+
+    /// list_txs().len()
+    pub fn list_txs_len(&self) -> usize {
+        match self {
+            Order::Bundle(bundle) => bundle.list_txs_len(),
+            Order::Tx(_) => 1,
+            Order::ShareBundle(bundle) => bundle.list_txs_len(),
         }
     }
 

--- a/crates/rbuilder/src/primitives/order_builder.rs
+++ b/crates/rbuilder/src/primitives/order_builder.rs
@@ -250,18 +250,15 @@ impl ShareBundleBuilder {
 
     fn build(mut self) -> ShareBundle {
         let inner_bundle = self.inner_bundle_stack.pop().unwrap();
-        let mut bundle = ShareBundle {
-            hash: Default::default(),
-            block: self.block,
-            max_block: self.max_block,
+        ShareBundle::new(
+            self.block,
+            self.max_block,
             inner_bundle,
-            signer: None,
-            replacement_data: None,
-            original_orders: Vec::new(),
-            metadata: Default::default(),
-        };
-        bundle.hash_slow();
-        bundle
+            None,
+            None,
+            Vec::new(),
+            Default::default(),
+        )
     }
 
     fn start_inner_bundle(&mut self, can_skip: bool) {

--- a/crates/rbuilder/src/primitives/serialize.rs
+++ b/crates/rbuilder/src/primitives/serialize.rs
@@ -506,19 +506,15 @@ impl RawShareBundle {
         }
 
         let (_, inner_bundle) = extract_inner_bundle(0, 0, self, &encoding)?;
-        let mut bundle = ShareBundle {
-            hash: Default::default(),
+        let bundle = ShareBundle::new(
             block,
             max_block,
             inner_bundle,
             signer,
             replacement_data,
-            original_orders: Vec::new(),
-            metadata: Default::default(),
-        };
-
-        bundle.hash_slow();
-
+            Vec::new(),
+            Default::default(),
+        );
         Ok(RawShareBundleDecodeResult::NewShareBundle(Box::new(bundle)))
     }
 

--- a/crates/rbuilder/src/primitives/test_data_generator.rs
+++ b/crates/rbuilder/src/primitives/test_data_generator.rs
@@ -87,18 +87,15 @@ impl TestDataGenerator {
             can_skip: true,
             original_order_id: None,
         };
-        let mut res = ShareBundle {
-            hash: Default::default(),
+        ShareBundle::new(
             block,
-            max_block: block,
+            block,
             inner_bundle,
-            signer: replacement_data.as_ref().and_then(|r| r.key.key().signer),
+            replacement_data.as_ref().and_then(|r| r.key.key().signer),
             replacement_data,
-            original_orders: Vec::new(),
-            metadata: Default::default(),
-        };
-        res.hash_slow();
-        res
+            Vec::new(),
+            Default::default(),
+        )
     }
 
     /// Creates a bundle with a multiple txs


### PR DESCRIPTION
## 📝 Summary

This PR adds 3 new experimental sorting modes for block building:

    /// Orders are ordered by their origin (bundle/sbundles then mempool) and then by their absolute profit.
    TypeMaxProfit,
    /// Orders are ordered by length 3 (orders length >= 3 first) and then by their absolute profit.
    LengthThreeMaxProfit,
    /// Orders are ordered by length 3 (orders length >= 3 first) and then by their mev gas price.
    LengthThreeMevGasPrice,

## 💡 Motivation and Context


## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
