### PR TITLE
continue processing orders on error

### DIFF
--- a/crates/rbuilder/src/live_builder/simulation/simulation_job.rs
+++ b/crates/rbuilder/src/live_builder/simulation/simulation_job.rs
@@ -271,11 +271,12 @@ impl SimulationJob {
         for new_commnad in new_commands {
             match new_commnad {
                 OrderPoolCommand::Insert(order) => {
-                    if !self.process_new_order(order.clone()) {
-                        return false;
-                    }
+                    // This is not unrecoverable error, so if it fails, we ignore it and try processing next order
+                    let _success = self.process_new_order(order.clone());
                 }
                 OrderPoolCommand::Remove(order_id) => {
+                    // Returns false if channel is closed,
+                    // In that case there is no need to process any new orders or cancellations for this slot
                     if !self.process_order_cancellation(order_id).await {
                         return false;
                     }


### PR DESCRIPTION
## 📝 Summary
When testing #489, I noticed that when processing new orders, if one of them fails, we stop further processing. 
This PR addresses this issue.

## 💡 Motivation and Context

The effect of the above-explained behaviour, in the worst case scenario, is that the whole slot can _fail_, meaning if the processing of the new order fails for the very first order, the whole slot ends up being empty, and in non-worse scenario we loose % of transactions, depending on when the processing was stopped. 

### When processing new order fails?
The processing of the new orders will fail only if the _StateProvider_ was unable to _provide_ the Nonce, i.e. the _StateProvider_ errors.
This is edge-case, but this can happen. 

I don't see any downsides with this approach, so this is why I opened PR instead of an issue. (I'm not saying hat there aren't any, just that _I_ don't see them 🙂)

### Process new simulations
Similar argument can be made for the processing new simulations, specifically for the following:

```Rust
    pub fn submit_simulation_tasks_results(
        &mut self,
        results: Vec<SimulatedResult>,
    ) -> Result<(), ProviderError> {
        for result in results {
            // NOTE: we can refactor the following line to
            // let _ = self.process_simulation_task_result(result);
            self.process_simulation_task_result(result)?;
        }
        Ok(())
    }
```
The code above only errors in case of the _nonce issues_,  and in that scenario we are stopping processing of all simulation tasks. 
I haven't pushed this change because I wanted so se how you feel about the this, especially since simulations _seem more serious_ than orders.   

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
