### PR TITLE
Demote relay error

### DIFF
--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -44,6 +44,7 @@ const SIM_FAILED_NON_CRITICAL_ERRORS: &[&str] = &[
     "unknown ancestor",
     "missing trie node",
     "parent block not found", // Generated from time to time from agnostic relay "simulation failed: parent block not found"
+    "block is too old, outside validation window", // Generated from time to time from agnostic relay in the end of the slot
 ];
 
 // @Org consolidate with primitives::mev_boost


### PR DESCRIPTION
## 📝 Summary

Does not really affect since it happens at the end of the slot (cancels the slot) but we demoted this to keep logs cleaner.

## ✅ I have completed the following steps:

* [x ] Run `make lint`
* [x ] Run `make test`
* [ ] Added tests (if applicable)
