### PR TITLE
fix: use BlockList type everywhere

### DIFF
--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -5,12 +5,11 @@ use crate::{
         sim::simulate_all_orders_with_sim_tree, BlockBuildingContext, BundleErr, OrderErr,
         SimulatedOrderSink, SimulatedOrderStore, TransactionErr,
     },
-    live_builder::cli::LiveBuilderConfig,
+    live_builder::{block_list_provider::BlockList, cli::LiveBuilderConfig},
     primitives::{OrderId, SimulatedOrder},
     provider::StateProviderFactory,
     utils::{clean_extradata, Signer},
 };
-use ahash::HashSet;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{Address, U256};
 use reth::revm::cached::CachedReads;
@@ -62,7 +61,7 @@ pub fn backtest_prepare_ctx_for_block<P>(
     block_data: BlockData,
     provider: P,
     chain_spec: Arc<ChainSpec>,
-    blocklist: HashSet<Address>,
+    blocklist: BlockList,
     sbundle_mergeabe_signers: &[Address],
     builder_signer: Signer,
 ) -> eyre::Result<BacktestBlockInput>
@@ -129,7 +128,7 @@ pub fn backtest_simulate_block<P, ConfigType>(
     chain_spec: Arc<ChainSpec>,
     builders_names: Vec<String>,
     config: &ConfigType,
-    blocklist: HashSet<Address>,
+    blocklist: BlockList,
     sbundle_mergeabe_signers: &[Address],
 ) -> eyre::Result<BlockBacktestValue>
 where

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -17,13 +17,12 @@ use reth_primitives::BlockBody;
 use reth_primitives_traits::{proofs, Block as _};
 
 use crate::{
-    live_builder::payload_events::InternalPayloadId,
+    live_builder::{block_list_provider::BlockList, payload_events::InternalPayloadId},
     primitives::{Order, OrderId, SimValue, SimulatedOrder, TransactionSignedEcRecoveredWithBlobs},
     provider::RootHasher,
     roothash::RootHashError,
-    utils::{a2r_withdrawal, timestamp_as_u64, Signer},
+    utils::{a2r_withdrawal, default_cfg_env, timestamp_as_u64, Signer},
 };
-use ahash::HashSet;
 use alloy_eips::{
     eip1559::{calculate_block_gas_limit, ETHEREUM_BLOCK_GAS_LIMIT_30M},
     eip4844::BlobTransactionSidecar,
@@ -68,7 +67,6 @@ use thiserror::Error;
 use time::OffsetDateTime;
 
 use self::tracers::SimulationTracer;
-use crate::utils::default_cfg_env;
 pub use block_orders::*;
 pub use built_block_trace::*;
 #[cfg(test)]
@@ -87,7 +85,7 @@ pub struct BlockBuildingContext {
     /// None: coinbase = attributes.suggested_fee_recipient. No payoffs allowed.
     /// Some(signer): coinbase = signer.
     pub builder_signer: Option<Signer>,
-    pub blocklist: HashSet<Address>,
+    pub blocklist: BlockList,
     pub extra_data: Vec<u8>,
     /// Excess blob gas calculated from the parent block header
     pub excess_blob_gas: Option<u64>,
@@ -106,7 +104,7 @@ impl BlockBuildingContext {
         parent: &Header,
         signer: Signer,
         chain_spec: Arc<ChainSpec>,
-        blocklist: HashSet<Address>,
+        blocklist: BlockList,
         prefer_gas_limit: Option<u64>,
         extra_data: Vec<u8>,
         spec_id: Option<SpecId>,
@@ -186,7 +184,7 @@ impl BlockBuildingContext {
         onchain_block: alloy_rpc_types::Block,
         chain_spec: Arc<ChainSpec>,
         spec_id: Option<SpecId>,
-        blocklist: HashSet<Address>,
+        blocklist: BlockList,
         coinbase: Address,
         suggested_fee_recipient: Address,
         builder_signer: Option<Signer>,

--- a/crates/rbuilder/src/building/testing/test_chain_state.rs
+++ b/crates/rbuilder/src/building/testing/test_chain_state.rs
@@ -1,8 +1,8 @@
+use crate::live_builder::block_list_provider::BlockList;
 use crate::provider::RootHasher;
 use crate::roothash::RootHashContext;
 use crate::utils::RootHasherImpl;
 use crate::{building::BlockBuildingContext, utils::Signer};
-use ahash::HashSet;
 use alloy_consensus::{Block, Header, TxEip1559};
 use alloy_primitives::{
     keccak256, utils::parse_ether, Address, BlockHash, Bytes, TxKind as TransactionKind, B256, B64,
@@ -295,7 +295,7 @@ struct TestBlockContextBuilder {
     parent_gas_used: u64,
     parent_hash: BlockHash,
     chain_spec: Arc<ChainSpec>,
-    blocklist: HashSet<Address>,
+    blocklist: BlockList,
     prefer_gas_limit: Option<u64>,
     use_suggested_fee_recipient_as_coinbase: bool,
     root_hasher: Arc<dyn RootHasher>,

--- a/crates/rbuilder/src/live_builder/block_list_provider.rs
+++ b/crates/rbuilder/src/live_builder/block_list_provider.rs
@@ -13,6 +13,7 @@ use url::Url;
 
 use crate::telemetry::update_blocklist_metrics;
 
+/// List of flagged addresses to be blocked from being included in blocks
 pub type BlockList = HashSet<Address>;
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## 📝 Summary

The type `BlockList` is defined in `live_builder/block_list_provider.rs`, consider using it everywhere for consistency.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`