### PR TITLE
Fixed grammatical errors for improved readability

### DIFF
--- a/crates/op-rbuilder/src/args.rs
+++ b/crates/op-rbuilder/src/args.rs
@@ -49,7 +49,7 @@ pub struct OpRbuilderArgs {
         help = "Safety level to pass to supervisor, values: finalized, safe, local-safe, cross-unsafe, unsafe, invalid"
     )]
     pub supervisor_safety_level: Option<String>,
-    /// Signals whether to log pool transactions events
+    /// Signals whether to log pool transaction events
     #[arg(long = "builder.log-pool-transactions", default_value = "false")]
     pub log_pool_transactions: bool,
 }

--- a/docs/REORG_LOSSES.md
+++ b/docs/REORG_LOSSES.md
@@ -1,10 +1,10 @@
 # Reorg losses
 
 
-From time to time, the Ethereum network forks for a short time (you can check that on https://etherscan.io/blocks_forked), causing block reorganizations (reorgs). When a reorg happens, all the transactions from the losing fork go to the mempool. This includes any private transactions, particularly any builder-generated transactions, such as the ones we add at the end of the block to pay the validator.
+From time to time, the Ethereum network forks for a short time (you can check that at https://etherscan.io/blocks_forked), causing block reorganizations (reorgs). When a reorg happens, all the transactions from the losing fork go to the mempool. This includes any private transactions, particularly any builder-generated transactions, such as the ones we add at the end of the block to pay the validator.
 
 
-If this happens, the builder ends up paying the bid to a random validator without winning any block! Notice that **this happens even if this transaction gives no tip to the block**, probably because, for some builders, when all paying transactions are included in the block they are building (and some gas is left), they include free transactions.
+If this happens, the builder ends up paying the bid to a random validator without winning a block! Notice that **this happens even if this transaction gives no tip to the block**, probably because, for some builders, when all paying transactions are included in the block they are building (and some gas is left), they include free transactions.
 
 
 This is a rare event but occurs from time to time and **causes losses to the builder**. As soon as the builder wins a real (non-reorged) block, the nonce changes, the old reorged transaction gets invalidated, and we are safe again.


### PR DESCRIPTION
Corrected grammar: "transactions events" → "transaction events" for proper noun-adjective agreement.


Preposition correction: "on" → "at" for referring to a website link properly.
Corrected article usage: "any" → "a" for clarity.