### PR TITLE
Fixes a regression that made orderings non-deterministic

### DIFF
--- a/crates/rbuilder/src/building/block_orders/order_priority.rs
+++ b/crates/rbuilder/src/building/block_orders/order_priority.rs
@@ -163,8 +163,17 @@ impl OrderLengthThreeCmp {
     }
 }
 
-create_order_priority!(OrderMevGasPricePriority(OrderMevGasPricePriorityCmp)<simulation_too_low_gas_price>);
-create_order_priority!(OrderMaxProfitPriority(OrderMaxProfitPriorityCmp)<simulation_too_low_profit>);
-create_order_priority!(OrderTypePriority(OrderTypeCmp,OrderMaxProfitPriorityCmp)<simulation_too_low_profit>);
-create_order_priority!(OrderLengthThreeMaxProfitPriority(OrderLengthThreeCmp,OrderMaxProfitPriorityCmp)<simulation_too_low_profit>);
-create_order_priority!(OrderLengthThreeMevGasPricePriority(OrderLengthThreeCmp,OrderMevGasPricePriorityCmp)<simulation_too_low_profit>);
+/// Breaks ties deterministically if all other orderings gave the same result
+struct OrderIDCmp {}
+impl OrderIDCmp {
+    #[inline]
+    fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
+        a.id().cmp(&b.id())
+    }
+}
+
+create_order_priority!(OrderMevGasPricePriority(OrderMevGasPricePriorityCmp, OrderIDCmp)<simulation_too_low_gas_price>);
+create_order_priority!(OrderMaxProfitPriority(OrderMaxProfitPriorityCmp, OrderIDCmp)<simulation_too_low_profit>);
+create_order_priority!(OrderTypePriority(OrderTypeCmp,OrderMaxProfitPriorityCmp, OrderIDCmp)<simulation_too_low_profit>);
+create_order_priority!(OrderLengthThreeMaxProfitPriority(OrderLengthThreeCmp,OrderMaxProfitPriorityCmp, OrderIDCmp)<simulation_too_low_profit>);
+create_order_priority!(OrderLengthThreeMevGasPricePriority(OrderLengthThreeCmp,OrderMevGasPricePriorityCmp, OrderIDCmp)<simulation_too_low_profit>);


### PR DESCRIPTION
## 📝 Summary

Before new ordering system was introduced orderings were always deterministic because they were breaking ties using order ids and now we don't do that and that PR returns that functionality. Without this back-tests and refunds are non-deterministic which is bad for development but also makes refund less precise because live builder also does not have this level of determinism. 

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
