### PR TITLE
Abstract state trait, leaving only used functions

### DIFF
--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -28,6 +28,7 @@ mod primitives;
 mod tester;
 mod tx_signer;
 use monitor_tx_pool::monitor_tx_pool;
+mod provider;
 
 fn main() {
     Cli::<OpChainSpecParser, args::OpRbuilderArgs>::parse()

--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -50,9 +50,7 @@ use reth_primitives_traits::Block as _;
 use reth_primitives_traits::SignedTransaction;
 use reth_provider::CanonStateSubscriptions;
 use reth_provider::StorageRootProvider;
-use reth_provider::{
-    HashedPostStateProvider, ProviderError, StateProviderFactory, StateRootProvider,
-};
+use reth_provider::{HashedPostStateProvider, ProviderError};
 use reth_revm::database::StateProviderDatabase;
 use reth_transaction_pool::PoolTransaction;
 use reth_transaction_pool::{BestTransactionsAttributes, TransactionPool};
@@ -77,6 +75,7 @@ use tokio_tungstenite::accept_async;
 use tokio_tungstenite::WebSocketStream;
 use url::Url;
 
+use crate::provider::{BuilderStateProviderFactory, BuilderStateRootProvider};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -312,7 +311,7 @@ impl<Pool, Client, EvmConfig, N: NodePrimitives> OpPayloadBuilder<Pool, Client, 
 impl<Pool, Client, EvmConfig, N> OpPayloadBuilder<Pool, Client, EvmConfig, N>
 where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>,
+    Client: BuilderStateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>,
     N: OpPayloadPrimitives<_TX = OpTransactionSigned>,
     EvmConfig: ConfigureEvmFor<N>,
 {
@@ -463,7 +462,9 @@ where
 
 impl<EvmConfig, Pool, Client, N> PayloadBuilder for OpPayloadBuilder<Pool, Client, EvmConfig, N>
 where
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
+    Client: BuilderStateProviderFactory
+        + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>
+        + Clone,
     N: OpPayloadPrimitives<_TX = OpTransactionSigned>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
     EvmConfig: ConfigureEvmFor<N>,
@@ -490,7 +491,7 @@ where
     ChainSpec: EthChainSpec + OpHardforks,
     N: OpPayloadPrimitives<_TX = OpTransactionSigned>,
     DB: Database<Error = ProviderError> + AsRef<P>,
-    P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
+    P: BuilderStateRootProvider + HashedPostStateProvider + StorageRootProvider,
 {
     let withdrawals_root = ctx.commit_withdrawals(&mut state)?;
 

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -63,7 +63,7 @@ use reth_primitives_traits::RecoveredBlock;
 use reth_primitives_traits::SignedTransaction;
 use reth_provider::CanonStateSubscriptions;
 use reth_provider::{
-    HashedPostStateProvider, ProviderError, StateProviderFactory, StateRootProvider,
+    HashedPostStateProvider, ProviderError, StateRootProvider,
     StorageRootProvider,
 };
 use reth_revm::database::StateProviderDatabase;
@@ -80,6 +80,7 @@ use std::{fmt::Display, sync::Arc, time::Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, trace, warn};
 use url::Url;
+use crate::provider::BuilderStateProviderFactory;
 
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
@@ -316,7 +317,7 @@ impl<Pool, Client, EvmConfig, N: NodePrimitives>
 impl<EvmConfig, Pool, Client, N, Txs> PayloadBuilder
     for OpPayloadBuilderVanilla<Pool, Client, EvmConfig, N, Txs>
 where
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
+    Client: BuilderStateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
     N: OpPayloadPrimitives<_TX = OpTransactionSigned>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
     EvmConfig: ConfigureEvmFor<N>,
@@ -375,7 +376,7 @@ where
 impl<Pool, Client, EvmConfig, N, T> OpPayloadBuilderVanilla<Pool, Client, EvmConfig, N, T>
 where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>,
+    Client: BuilderStateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>,
     N: OpPayloadPrimitives<_TX = OpTransactionSigned>,
     EvmConfig: ConfigureEvmFor<N>,
 {

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -1,3 +1,4 @@
+use crate::provider::{BuilderStateProviderFactory, BuilderStateRootProvider};
 use crate::{
     generator::{BlockCell, BlockPayloadJobGenerator, BuildArguments, PayloadBuilder},
     metrics::OpRBuilderMetrics,
@@ -62,10 +63,7 @@ use reth_primitives_traits::Block;
 use reth_primitives_traits::RecoveredBlock;
 use reth_primitives_traits::SignedTransaction;
 use reth_provider::CanonStateSubscriptions;
-use reth_provider::{
-    HashedPostStateProvider, ProviderError, StateRootProvider,
-    StorageRootProvider,
-};
+use reth_provider::{HashedPostStateProvider, ProviderError, StorageRootProvider};
 use reth_revm::database::StateProviderDatabase;
 use reth_transaction_pool::BestTransactionsAttributes;
 use reth_transaction_pool::PoolTransaction;
@@ -80,7 +78,6 @@ use std::{fmt::Display, sync::Arc, time::Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, trace, warn};
 use url::Url;
-use crate::provider::BuilderStateProviderFactory;
 
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
@@ -317,7 +314,9 @@ impl<Pool, Client, EvmConfig, N: NodePrimitives>
 impl<EvmConfig, Pool, Client, N, Txs> PayloadBuilder
     for OpPayloadBuilderVanilla<Pool, Client, EvmConfig, N, Txs>
 where
-    Client: BuilderStateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
+    Client: BuilderStateProviderFactory
+        + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>
+        + Clone,
     N: OpPayloadPrimitives<_TX = OpTransactionSigned>,
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
     EvmConfig: ConfigureEvmFor<N>,
@@ -632,7 +631,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         N: OpPayloadPrimitives<_TX = OpTransactionSigned>,
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
         DB: Database<Error = ProviderError> + AsRef<P>,
-        P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
+        P: BuilderStateRootProvider + HashedPostStateProvider + StorageRootProvider,
     {
         let ExecutedPayload {
             info,

--- a/crates/op-rbuilder/src/provider/mod.rs
+++ b/crates/op-rbuilder/src/provider/mod.rs
@@ -1,0 +1,18 @@
+use alloy_primitives::BlockHash;
+use reth_provider::{ProviderResult, StateProviderBox, StateProviderFactory};
+
+/// Main trait to interact with the chain data.
+/// Allows to create different backends for chain data access without implementing lots of interfaces as would happen with reth_provider::StateProviderFactory
+/// since it only asks for what we really use.
+pub trait BuilderStateProviderFactory: Send + Sync {
+    /// Returns _any_ [StateProvider] with matching block hash.
+    ///
+    /// This will return a [StateProvider] for either a historical or pending block.
+    fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox>;
+}
+
+impl <T: StateProviderFactory> BuilderStateProviderFactory for T {
+    fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
+        StateProviderFactory::state_by_block_hash(self, block)
+    }
+}

--- a/crates/op-rbuilder/src/provider/mod.rs
+++ b/crates/op-rbuilder/src/provider/mod.rs
@@ -1,5 +1,7 @@
-use alloy_primitives::BlockHash;
-use reth_provider::{ProviderResult, StateProviderBox, StateProviderFactory};
+use alloy_primitives::{BlockHash, B256};
+use reth_provider::{ProviderResult, StateProviderBox, StateProviderFactory, StateRootProvider};
+use reth_trie::updates::TrieUpdates;
+use reth_trie::HashedPostState;
 
 /// Main trait to interact with the chain data.
 /// Allows to create different backends for chain data access without implementing lots of interfaces as would happen with reth_provider::StateProviderFactory
@@ -11,8 +13,26 @@ pub trait BuilderStateProviderFactory: Send + Sync {
     fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox>;
 }
 
-impl <T: StateProviderFactory> BuilderStateProviderFactory for T {
+impl<T: StateProviderFactory> BuilderStateProviderFactory for T {
     fn state_by_block_hash(&self, block: BlockHash) -> ProviderResult<StateProviderBox> {
         StateProviderFactory::state_by_block_hash(self, block)
+    }
+}
+
+pub trait BuilderStateRootProvider: Send + Sync {
+    /// Returns the state root of the `HashedPostState` on top of the current state with trie
+    /// updates to be committed to the database.
+    fn state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)>;
+}
+
+impl<T: StateRootProvider> BuilderStateRootProvider for T {
+    fn state_root_with_updates(
+        &self,
+        hashed_state: HashedPostState,
+    ) -> ProviderResult<(B256, TrieUpdates)> {
+        StateRootProvider::state_root_with_updates(self, hashed_state)
     }
 }


### PR DESCRIPTION
## 📝 Summary

In this PR we take control of the state provider, removing all extra traits

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
