### PR TITLE
chore: fix realpath usage by removing unsupported `-s` flag

### DIFF
--- a/scripts/ci/criterion-prettify-report.sh
+++ b/scripts/ci/criterion-prettify-report.sh
@@ -10,8 +10,8 @@ if [ "$#" -ne 2 ]; then
 fi
 
 script_dir=$( dirname -- "$0"; )
-criterion_dir=$( realpath -s $1 )
-output_dir=$( realpath -s $2 )
+criterion_dir=$( realpath "$1" )
+output_dir=$( realpath "$2" )
 
 source "${script_dir}/env-vars.sh"
 


### PR DESCRIPTION
## 📝 Summary
I’ve fixed an issue with the `realpath` command in the script. The `-s` flag was causing errors on certain systems as it is not universally supported. I’ve removed the `-s` flag to ensure better compatibility, now using `realpath "$1"` and `realpath "$2"` for absolute paths.

## 💡 Motivation and Context
The `-s` flag was unsupported in some systems, causing errors. This change improves the script’s robustness and ensures it works properly across different environments.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
