### PR TITLE
refactor: Block Builder Executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,17 +91,17 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.66"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e42c54af787e3521229df1787d7b8300910dc6d9d04d378eb593b26388bd11"
+checksum = "2826a55d29df2765ec264190cd1c26dd1d6232ef811825024a25cdf5eaaadbdf"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "num_enum",
  "serde",
@@ -115,7 +115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fbf458101ed6c389e9bb70a34ebc56039868ad10472540614816cdedc8f5265"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
@@ -129,18 +129,18 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafded0c1ff8f0275c4a484239058e1c01c0c2589f8a16e03669ef7094a06f9b"
+checksum = "fc982af629e511292310fe85b433427fd38cb3105147632b574abc997db44c91"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-serde",
  "serde",
@@ -148,20 +148,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.21"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555896f0b8578adb522b1453b6e6cc6704c3027bd0af20058befdde992cee8e9"
+checksum = "eb8e762aefd39a397ff485bc86df673465c4ad3ec8819cc60833a8a3ba5cdc87"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "const-hex",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.2",
+ "winnow",
 ]
 
 [[package]]
@@ -170,13 +170,13 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "arbitrary",
  "crc",
  "rand 0.8.5",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "arbitrary",
  "rand 0.8.5",
@@ -198,14 +198,14 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "arbitrary",
  "k256 0.13.4",
  "rand 0.8.5",
  "serde",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -217,7 +217,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
@@ -235,19 +235,18 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.1.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40fe575395f20dc9527c2dc65350786492e9723d2035e9f716269b65be34c9c"
+source = "git+https://github.com/avalonche/evm?rev=ccaaa18d3f45d03deaa2e8f9020aa7d695e2b471#ccaaa18d3f45d03deaa2e8f9020aa7d695e2b471"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-hardforks",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.0.1",
  "op-revm",
  "revm",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -257,7 +256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a40de6f5b53ecf5fd7756072942f41335426d9a3704cd961f77d854739933bcf"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-serde",
  "alloy-trie",
  "serde",
@@ -265,13 +264,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1692158e9d100486fa6c2429edb42680298678ee74644b058c44f8484a278fea"
+checksum = "4e61d55f42faedd980ee3e391aa9ff8ae0fc20723fa1c6d69ac06e06d08fbade"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "auto_impl",
  "dyn-clone",
  "serde",
@@ -279,11 +278,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.23"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec80745c33797e8baf547a8cfeb850e60d837fe9b9e67b3f579c1fcd26f527e9"
+checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -295,11 +294,11 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27434beae2514d4a2aa90f53832cbdf6f23e4b5e2656d95eaf15f9276e2418b6"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -314,7 +313,7 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -326,7 +325,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -337,7 +336,7 @@ checksum = "db973a7a23cbe96f2958e5687c51ce2d304b5c6d0dc5ccb3de8667ad8476f50b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-serde",
  "serde",
 ]
@@ -351,14 +350,14 @@ dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-network",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-signer",
  "alloy-signer-local",
  "k256 0.13.4",
  "rand 0.8.5",
  "serde_json",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "url",
 ]
@@ -366,14 +365,13 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.1.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed217773009445cba32f02418828a282c7bcb7721909cf4f6aaa9a263618817"
+source = "git+https://github.com/avalonche/evm?rev=ccaaa18d3f45d03deaa2e8f9020aa7d695e2b471#ccaaa18d3f45d03deaa2e8f9020aa7d695e2b471"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-op-hardforks",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "auto_impl",
  "op-alloy-consensus",
  "op-revm",
@@ -382,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-hardforks"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc1c4dadbc9b38160d19699bd8849eab195a24d40a181f8a77e9d08fbafff03"
+checksum = "8ef11121e0eab0e732d89b71f86b907eb23928d3c69ed453905f33a599ca89c0"
 dependencies = [
  "alloy-hardforks",
  "auto_impl",
@@ -400,7 +398,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "hex-literal",
  "itoa",
  "k256 0.13.4",
@@ -414,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.23"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eacedba97e65cdc7ab592f2b22ef5d3ab8d60b2056bc3a6e6363577e8270ec6f"
+checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -428,7 +426,7 @@ dependencies = [
  "foldhash",
  "getrandom 0.2.15",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "itoa",
  "k256 0.13.4",
  "keccak-asm",
@@ -437,7 +435,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "ruint",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -455,7 +453,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
@@ -473,10 +471,10 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "url",
@@ -490,7 +488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721aca709a9231815ad5903a2d284042cc77e7d9d382696451b30c9ee0950001"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-transport",
  "bimap",
  "futures",
@@ -498,7 +496,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -531,7 +529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445a3298c14fae7afb5b9f2f735dead989f3dd83020c2ab8e48ed95d7b6d1acb"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -540,12 +538,12 @@ dependencies = [
  "async-stream",
  "futures",
  "pin-project",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tracing",
  "tracing-futures",
  "url",
@@ -558,7 +556,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9157deaec6ba2ad7854f16146e4cd60280e76593eed79fdcb06e0fa8b6c60f77"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -572,7 +570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25c053dc0acbdb922d1d088b3457eae249263ccd06d459aa68c3f9dcf6962632"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "serde",
  "serde_json",
 ]
@@ -583,7 +581,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a80ee83ef97e7ffd667a81ebdb6154558dfd5e8f20d8249a10a12a1671a04b3"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -591,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd4ceea38ea27eeb26f021df34ed5b7b793704ad7a2a009f16137a19461e7ca"
+checksum = "604dea1f00fd646debe8033abe8e767c732868bf8a5ae9df6321909ccbc99c56"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -607,13 +605,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645455186916281e0b3f063fd07d007711257cf90c3499ff3569a39ffdfc9d2f"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "serde",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tree_hash",
  "tree_hash_derive",
 ]
@@ -624,7 +622,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08b113a0087d226291b9768ed331818fa0b0744cc1207ae7c150687cf3fde1bd"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "serde",
 ]
 
@@ -636,7 +634,7 @@ checksum = "874ac9d1249ece0453e262d9ba72da9dbb3b7a2866220ded5940c2e47f1aa04d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 2.0.1",
@@ -659,7 +657,7 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
@@ -668,7 +666,7 @@ dependencies = [
  "jsonrpsee-types 0.24.9",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -678,7 +676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "505d73db6217e6abcdeba4bf025fb9db79577d6b06e092d24e7c11ed0360743b"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -691,12 +689,12 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4747763aee39c1b0f5face79bde9be8932be05b2db7d8bdcebb93490f32c889c"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -705,7 +703,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70132ebdbea1eaa68c4d6f7a62c2fadf0bdce83b904f895ab90ca4ec96f63468"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -717,7 +715,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a1cd73fc054de6353c7f22ff9b846b0f0f145cd0112da07d4119e41e9959207"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "arbitrary",
  "serde",
  "serde_json",
@@ -729,13 +727,13 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96fbde54bee943cd94ebacc8a62c50b38c7dfd2552dcd79ff61aea778b1bfcc"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "async-trait",
  "auto_impl",
  "either",
  "elliptic-curve 0.13.8",
  "k256 0.13.4",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -746,19 +744,19 @@ checksum = "cc6e72002cc1801d8b41e9892165e3a6551b7bd382bd9d0414b21e90c0c62551"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-signer",
  "async-trait",
  "k256 0.13.4",
  "rand 0.8.5",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.23"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3637022e781bc73a9e300689cd91105a0e6be00391dd4e2110a71cc7e9f20a94"
+checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -770,14 +768,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.23"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9bd22d0bba90e40f40c625c33d39afb7d62b22192476a2ce1dcf8409dce880"
+checksum = "83ad5da86c127751bc607c174d6c9fe9b85ef0889a9ca0c641735d77d4f98f26"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -788,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.23"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae4646e8123ec2fd10f9c22e361ffe4365c42811431829c2eabae528546bcc"
+checksum = "ba3d30f0d3f9ba3b7686f3ff1de9ee312647aac705604417a2f40c604f409a9e"
 dependencies = [
  "const-hex",
  "dunce",
@@ -804,22 +802,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.23"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488a747fdcefeec5c1ed5aa9e08becd775106777fdeae2a35730729fc8a95910"
+checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
- "winnow 0.7.2",
+ "winnow",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.23"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767957235807b021126dca1598ac3ef477007eace07961607dc5f490550909c7"
+checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -839,9 +837,9 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -855,18 +853,18 @@ checksum = "a082c9473c6642cce8b02405a979496126a03b096997888e86229afad05db06c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
  "serde_json",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61e2b5cbf16f7588e4420848b61824f6514944773732534f4129ba6a251e059"
+checksum = "45a78cfda2cac16fa83f6b5dd8b4643caec6161433b25b67e484ce05d2194513"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -884,14 +882,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ddcf4b98b3448eb998e057dc5a27345997863d6544ee7f0f79957616768dd3"
+checksum = "ae865917bdabaae21f418010fe7e8837c6daa6611fde25f8d78a1778d6ecb523"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.1.0",
+ "http 1.3.1",
  "rustls 0.23.25",
  "serde_json",
  "tokio",
@@ -906,7 +904,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "arbitrary",
  "arrayvec",
@@ -982,11 +980,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -1235,9 +1234,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.17"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
+checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
 dependencies = [
  "brotli 7.0.0",
  "flate2",
@@ -1245,8 +1244,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "zstd 0.13.2",
- "zstd-safe 7.2.1",
+ "zstd 0.13.3",
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -1307,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.87"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1355,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "aurora-engine-modexp"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aef7712851e524f35fbbb74fa6599c5cd8692056a1c36f9ca0d2001b670e7e5"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
 dependencies = [
  "hex",
  "num",
@@ -1365,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1382,27 +1381,25 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.2"
+version = "1.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
+checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
 dependencies = [
  "aws-lc-sys",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.25.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ac4f13dad353b209b34cbec082338202cbc01c8f00336b55c750c13ac91f8f"
+checksum = "77926887776171ced7d662120a75998e444d3750c951abfe07f90da130514b1f"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "paste",
 ]
 
 [[package]]
@@ -1415,7 +1412,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -1426,8 +1423,8 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.1",
- "tower 0.5.1",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -1441,24 +1438,24 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "backon"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4fa97bb310c33c811334143cf64c5bb2b7b3c06e453db6b095d7061eff8f113"
+checksum = "970d91570c01a8a5959b36ad7dd1c30642df24b6b3068710066f6809f7033bb7"
 dependencies = [
- "fastrand 2.2.0",
+ "fastrand 2.3.0",
  "tokio",
 ]
 
@@ -1515,16 +1512,16 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
 source = "git+https://github.com/ralexstokes/ethereum-consensus/?rev=cf3c404043230559660810bc0c9d6d5a8498d819#cf3c404043230559660810bc0c9d6d5a8498d819"
 dependencies = [
- "clap 4.5.21",
+ "clap 4.5.34",
  "ethereum-consensus",
  "http 0.2.12",
  "itertools 0.10.5",
@@ -1560,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "bigdecimal"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f850665a0385e070b64c38d2354e6c104c8479c59868d1e48a0c13ee2c7a1c1"
+checksum = "7f31f3af01c5c65a07985c804d3366560e6fa7883d640a122819b14ec327482c"
 dependencies = [
  "autocfg",
  "libm",
@@ -1595,7 +1592,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1629,18 +1626,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin-io"
@@ -1688,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "b17679a8d69b6d7fd9cd9801a536cec9fa5e5970b69f9d4747f70b39b031f5e7"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1728,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
 dependencies = [
  "cc",
  "glob",
@@ -1748,9 +1745,9 @@ dependencies = [
  "boa_interner",
  "boa_macros",
  "boa_string",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "num-bigint",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -1774,7 +1771,7 @@ dependencies = [
  "fast-float2",
  "hashbrown 0.15.2",
  "icu_normalizer",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "intrusive-collections",
  "itertools 0.13.0",
  "num-bigint",
@@ -1786,7 +1783,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.8.5",
  "regress",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "ryu-js",
  "serde",
  "serde_json",
@@ -1794,7 +1791,7 @@ dependencies = [
  "static_assertions",
  "tap",
  "thin-vec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -1820,10 +1817,10 @@ dependencies = [
  "boa_gc",
  "boa_macros",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "once_cell",
- "phf 0.11.2",
- "rustc-hash 2.1.0",
+ "phf 0.11.3",
+ "rustc-hash 2.1.1",
  "static_assertions",
 ]
 
@@ -1855,7 +1852,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "regress",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -1872,7 +1869,7 @@ checksum = "7debc13fbf7997bf38bf8e9b20f1ad5e2a7d27a900e1f6039fe244ce30f589b5"
 dependencies = [
  "fast-float2",
  "paste",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "sptr",
  "static_assertions",
 ]
@@ -1905,7 +1902,7 @@ checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 4.0.1",
+ "brotli-decompressor 4.0.2",
 ]
 
 [[package]]
@@ -1920,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1945,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -1966,15 +1963,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytecount"
@@ -1984,18 +1981,18 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
+checksum = "2ff22c2722516255d1823ce3cc4bc0b154dbc9364be5c905d6baa6eccbbc8774"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2010,9 +2007,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -2029,12 +2026,11 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -2064,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -2079,7 +2075,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.23",
+ "semver 1.0.26",
  "serde",
  "serde_json",
 ]
@@ -2092,10 +2088,10 @@ checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.23",
+ "semver 1.0.26",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2159,9 +2155,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2169,7 +2165,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -2234,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2244,21 +2240,21 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.3",
+ "clap_lex 0.7.4",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2277,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
@@ -2308,21 +2304,20 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.1.3"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "crossterm",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "compact_str"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -2352,15 +2347,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.8"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width 0.1.14",
- "windows-sys 0.52.0",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2381,6 +2376,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -2446,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -2512,7 +2527,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.21",
+ "clap 4.5.34",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -2562,18 +2577,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2590,18 +2605,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -2613,7 +2628,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -2630,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
@@ -2688,7 +2703,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.2",
+ "phf 0.11.3",
  "smallvec",
 ]
 
@@ -2716,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
@@ -2833,15 +2848,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
+checksum = "9f9724adfcf41f45bf652b3995837669d73c4d49a1b5ac1ff82905ac7d9b5558"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2849,12 +2864,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
+checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2865,9 +2880,9 @@ checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
 name = "delay_map"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df941644b671f05f59433e481ba0d31ac10e3667de725236a4c0d587c496fba1"
+checksum = "88e365f083a5cb5972d50ce8b1b2c9f125dc5ec0f50c0248cfb568ae59efcf0b"
 dependencies = [
  "futures",
  "tokio",
@@ -2897,9 +2912,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
  "serde",
@@ -2971,9 +2986,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
@@ -3009,7 +3024,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "unicode-xid",
 ]
 
 [[package]]
@@ -3164,9 +3178,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dtoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 
 [[package]]
 name = "dtoa-short"
@@ -3185,9 +3199,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
@@ -3285,7 +3299,7 @@ dependencies = [
  "base16ct 0.2.0",
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff 0.13.0",
+ "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
  "pkcs8 0.10.2",
@@ -3298,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -3393,18 +3407,18 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3431,7 +3445,7 @@ dependencies = [
 name = "eth-sparse-mpt"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-trie",
  "criterion 0.4.0",
@@ -3449,7 +3463,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "revm",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -3547,7 +3561,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70cbccfccf81d67bff0ab36e591fa536c8a935b078a7b0e58c1d00d418332fc9"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "hex",
  "serde",
  "serde_derive",
@@ -3556,12 +3570,11 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfbba28f4f3f32d92c06a64f5bf6c4537b5d4e21f28c689bd2bbaecfea4e0d3e"
+checksum = "86da3096d1304f5f28476ce383005385459afeaf0eea08592b65ddbc9b258d16"
 dependencies = [
- "alloy-primitives 0.8.23",
- "derivative",
+ "alloy-primitives 0.8.25",
  "ethereum_serde_utils",
  "itertools 0.13.0",
  "serde",
@@ -3572,9 +3585,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d37845ba7c16bf4be8be4b5786f03a2ba5f2fda0d7f9e7cb2282f69cff420d7"
+checksum = "d832a5c38eba0e7ad92592f7a22d693954637fbb332b4f669590d66a5c3183e5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3627,7 +3640,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "949eb68d436415e37b7a69c49a9900d5337616b0e420377ccc48038b86261e16"
 dependencies = [
- "fastrand 2.2.0",
+ "fastrand 2.3.0",
 ]
 
 [[package]]
@@ -3669,15 +3682,26 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastrlp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
 dependencies = [
  "arrayvec",
  "auto_impl",
@@ -3706,9 +3730,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -3746,9 +3770,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3774,9 +3798,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -3810,9 +3834,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fs_extra"
@@ -4045,16 +4069,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4075,9 +4099,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
+checksum = "5220b8ba44c68a9a7f7a7659e864dd73692e417ef0211bea133c7b74e031eeb9"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
@@ -4088,9 +4112,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gloo-net"
@@ -4123,7 +4147,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 1.1.0",
+ "http 1.3.1",
  "js-sys",
  "pin-project",
  "serde",
@@ -4196,7 +4220,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -4213,7 +4237,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4222,17 +4246,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
- "indexmap 2.7.0",
+ "http 1.3.1",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4241,9 +4265,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -4380,9 +4404,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "hex"
@@ -4429,7 +4453,7 @@ dependencies = [
  "rand 0.9.0",
  "ring",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tokio",
  "tracing",
@@ -4453,7 +4477,7 @@ dependencies = [
  "resolv-conf",
  "serde",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -4499,22 +4523,22 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "hostname"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
 dependencies = [
+ "cfg-if",
  "libc",
- "match_cfg",
- "winapi",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -4544,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -4571,27 +4595,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.1.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "http-range-header"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "http-types"
@@ -4615,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -4633,9 +4657,9 @@ checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "humantime-serde"
@@ -4649,9 +4673,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4673,15 +4697,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
- "http 1.1.0",
+ "h2 0.4.8",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -4700,7 +4724,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -4710,22 +4734,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.5.0",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rustls 0.23.25",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -4734,7 +4758,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4748,7 +4772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -4762,7 +4786,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4779,9 +4803,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -4791,14 +4815,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core 0.52.0",
 ]
@@ -4853,9 +4878,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -4877,9 +4902,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -4898,9 +4923,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -4959,12 +4984,12 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78a89907582615b19f6f0da1af18abf6ff08be259395669b834b057a7ee92d8"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4996,13 +5021,13 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5043,9 +5068,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "arbitrary",
  "equivalent",
@@ -5055,9 +5080,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
  "number_prefix",
@@ -5068,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "infer"
@@ -5100,9 +5125,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -5110,13 +5135,12 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b829f37dead9dc39df40c2d3376c179fdfd2ac771f53f55d3c30dc096a3c0c6e"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
 dependencies = [
  "darling",
  "indoc",
- "pretty_assertions",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -5148,9 +5172,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.2.1"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f4e4a06d42fab3e85ab1b419ad32b09eab58b901d40c57935ff92db3287a13"
+checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -5184,15 +5208,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0f0a572e8ffe56e2ff4f769f32ffe919282c3916799f8b68688b6030063bea"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
@@ -5200,13 +5224,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5235,6 +5259,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -5253,9 +5286,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -5367,16 +5400,16 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net 0.6.0",
- "http 1.1.0",
+ "http 1.3.1",
  "jsonrpsee-core 0.24.9",
  "pin-project",
  "rustls 0.23.25",
  "rustls-pki-types",
  "rustls-platform-verifier",
- "soketto 0.8.0",
+ "soketto 0.8.1",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.2",
  "tokio-util",
  "tracing",
  "url",
@@ -5394,7 +5427,7 @@ dependencies = [
  "beef",
  "futures-timer",
  "futures-util",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "jsonrpsee-types 0.20.4",
  "parking_lot",
  "rand 0.8.5",
@@ -5418,14 +5451,14 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.1.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types 0.24.9",
  "parking_lot",
  "pin-project",
  "rand 0.8.5",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5442,7 +5475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c7b9f95208927653e7965a98525e7fc641781cab89f0e27c43fa2974405683"
 dependencies = [
  "async-trait",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "jsonrpsee-core 0.20.4",
  "jsonrpsee-types 0.20.4",
@@ -5464,8 +5497,8 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "http-body 1.0.1",
- "hyper 1.5.0",
- "hyper-rustls 0.27.3",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
  "hyper-util",
  "jsonrpsee-core 0.24.9",
  "jsonrpsee-types 0.24.9",
@@ -5500,7 +5533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e65763c942dfc9358146571911b0cd1c361c2d63e2d2305622d40d36376ca80"
 dependencies = [
  "heck 0.5.0",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -5514,7 +5547,7 @@ checksum = "a482bc4e25eebd0adb61a3468c722763c381225bd3ec46e926f709df8a8eb548"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "jsonrpsee-core 0.20.4",
  "jsonrpsee-types 0.20.4",
  "route-recognizer",
@@ -5536,10 +5569,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e363146da18e50ad2b51a0a7925fc423137a0b1371af8235b1c231a0647328"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "jsonrpsee-core 0.24.9",
  "jsonrpsee-types 0.24.9",
@@ -5547,7 +5580,7 @@ dependencies = [
  "route-recognizer",
  "serde",
  "serde_json",
- "soketto 0.8.0",
+ "soketto 0.8.1",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -5576,7 +5609,7 @@ version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a8e70baf945b6b5752fc8eb38c918a48f1234daf11355e07106d963f860089"
 dependencies = [
- "http 1.1.0",
+ "http 1.3.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5623,7 +5656,7 @@ version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b3323d890aa384f12148e8d2a1fd18eb66e9e7e825f9de4fa53bcc19b93eef"
 dependencies = [
- "http 1.1.0",
+ "http 1.3.1",
  "jsonrpsee-client-transport 0.24.9",
  "jsonrpsee-core 0.24.9",
  "jsonrpsee-types 0.24.9",
@@ -5632,11 +5665,11 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.0"
+version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "js-sys",
  "pem",
  "ring",
@@ -5693,28 +5726,28 @@ dependencies = [
 
 [[package]]
 name = "kona-genesis"
-version = "0.2.4"
-source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+version = "0.3.0"
+source = "git+https://github.com/op-rs/kona?rev=88efce85a96a0dbc98c8aab94dd18d2136498fb0#88efce85a96a0dbc98c8aab94dd18d2136498fb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-sol-types",
  "derive_more 2.0.1",
  "kona-serde",
  "serde",
  "serde_repr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "kona-interop"
-version = "0.2.4"
-source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+version = "0.3.0"
+source = "git+https://github.com/op-rs/kona?rev=88efce85a96a0dbc98c8aab94dd18d2136498fb0#88efce85a96a0dbc98c8aab94dd18d2136498fb0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-sol-types",
  "async-trait",
@@ -5723,30 +5756,30 @@ dependencies = [
  "kona-registry",
  "op-alloy-consensus",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "kona-protocol"
-version = "0.2.4"
-source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+version = "0.3.0"
+source = "git+https://github.com/op-rs/kona?rev=88efce85a96a0dbc98c8aab94dd18d2136498fb0#88efce85a96a0dbc98c8aab94dd18d2136498fb0"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
+ "alloy-rpc-types-engine",
  "alloy-serde",
  "async-trait",
  "brotli 7.0.0",
  "kona-genesis",
  "miniz_oxide",
  "op-alloy-consensus",
- "op-alloy-flz",
  "rand 0.9.0",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
  "unsigned-varint 0.8.0",
@@ -5754,45 +5787,46 @@ dependencies = [
 
 [[package]]
 name = "kona-registry"
-version = "0.2.4"
-source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+version = "0.3.0"
+source = "git+https://github.com/op-rs/kona?rev=88efce85a96a0dbc98c8aab94dd18d2136498fb0#88efce85a96a0dbc98c8aab94dd18d2136498fb0"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "kona-genesis",
  "lazy_static",
  "serde",
  "serde_json",
- "toml 0.8.19",
+ "toml 0.8.20",
 ]
 
 [[package]]
 name = "kona-rpc"
-version = "0.1.1"
-source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+version = "0.2.0"
+source = "git+https://github.com/op-rs/kona?rev=88efce85a96a0dbc98c8aab94dd18d2136498fb0#88efce85a96a0dbc98c8aab94dd18d2136498fb0"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "async-trait",
  "derive_more 2.0.1",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "jsonrpsee 0.24.9",
  "kona-genesis",
  "kona-interop",
  "kona-protocol",
+ "op-alloy-consensus",
  "op-alloy-rpc-jsonrpsee",
  "op-alloy-rpc-types-engine",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
 name = "kona-serde"
-version = "0.1.1"
-source = "git+https://github.com/op-rs/kona?rev=0493d8479e2ca9f0eb6d5c6154e2bedc61de7217#0493d8479e2ca9f0eb6d5c6154e2bedc61de7217"
+version = "0.2.0"
+source = "git+https://github.com/op-rs/kona?rev=88efce85a96a0dbc98c8aab94dd18d2136498fb0#88efce85a96a0dbc98c8aab94dd18d2136498fb0"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "serde",
  "serde_json",
 ]
@@ -5907,15 +5941,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.0+1.9.0"
+version = "0.18.1+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
+checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
 dependencies = [
  "cc",
  "libc",
@@ -5925,9 +5959,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -5941,16 +5975,16 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cca1eb2bc1fd29f099f3daaab7effd01e1a54b7c577d0ed082521034d912e8"
+checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
 dependencies = [
  "asn1_der",
  "bs58 0.5.1",
  "ed25519-dalek",
  "hkdf",
  "libsecp256k1",
- "multihash 0.19.2",
+ "multihash 0.19.3",
  "quick-protobuf",
  "sha2 0.10.8",
  "thiserror 1.0.69",
@@ -5982,12 +6016,12 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
 dependencies = [
  "arrayref",
- "base64 0.13.1",
+ "base64 0.22.1",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -6041,9 +6075,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.20"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
  "libc",
@@ -6059,9 +6093,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linked_hash_set"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
+checksum = "bae85b5be22d9843c80e5fc80e9b64c8a3b1f98f867c709956eca3efff4e92e2"
 dependencies = [
  "linked-hash-map",
  "serde",
@@ -6069,15 +6103,21 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -6092,9 +6132,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "loom"
@@ -6129,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "lz4"
-version = "1.28.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d1febb2b4a79ddd1980eede06a8f7902197960aa0383ffcfdd62fe723036725"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
 dependencies = [
  "lz4-sys",
 ]
@@ -6194,12 +6234,6 @@ dependencies = [
  "string_cache_codegen",
  "tendril",
 ]
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -6266,7 +6300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b453bd8e35ec92138b093172731fe7920cdf397f2a709e789243147a79772b9d"
 dependencies = [
  "chrono",
- "clap 4.5.21",
+ "clap 4.5.34",
  "csv",
  "eyre",
  "indicatif",
@@ -6304,19 +6338,19 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b6f8152da6d7892ff1b7a1c0fa3f435e92b5918ad67035c3bb432111d9a29b"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper 1.5.0",
- "hyper-rustls 0.27.3",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
  "hyper-util",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "ipnet",
  "metrics",
- "metrics-util 0.18.0",
+ "metrics-util 0.19.0",
  "quanta",
  "thiserror 1.0.69",
  "tokio",
@@ -6325,9 +6359,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-process"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ca8ecd85575fbb143b2678cb123bb818779391ec0f745b1c4a9dbabadde407"
+checksum = "4a82c8add4382f29a122fa64fff1891453ed0f6b2867d971e7d60cb8dfa322ff"
 dependencies = [
  "libc",
  "libproc",
@@ -6349,7 +6383,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.15.2",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "metrics",
  "ordered-float",
  "quanta",
@@ -6363,7 +6397,14 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbd4884b1dd24f7d6628274a2f5ae22465c337c5ba065ec9b6edccddf8acc673"
 dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.2",
  "metrics",
+ "quanta",
+ "rand 0.8.5",
+ "rand_xoshiro",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -6442,11 +6483,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -6573,7 +6613,7 @@ dependencies = [
  "data-encoding",
  "libp2p-identity",
  "multibase",
- "multihash 0.19.2",
+ "multihash 0.19.3",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -6607,9 +6647,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
+checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "unsigned-varint 0.8.0",
@@ -6662,9 +6702,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -6890,7 +6930,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -6927,9 +6967,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -6946,43 +6986,43 @@ dependencies = [
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "971eaae9cfc8b6aabb62cef8d7d49640d2e8e948e5aa3177788c4dea3d226452"
+checksum = "27fb241560c631ece7b17ff6390b87140bc98ecb4fb6134b53ba4836f11c35bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-serde",
  "arbitrary",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "serde",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "op-alloy-flz"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e11bd9b9382673e8c0ab4b9ff8921aba7caf3a2805f88c6840daaa50f5db2a1"
+checksum = "2ac5d966d385a50b6975b957196391536569084dd58d53c45a3fdb810cc5de10"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697a00d2d89e2e44c0ef2d1b3b7181dd529f5665c9c574bcfda5f975821a000f"
+checksum = "82bd2e3309c47886d4d8b950252f4ba44f2aa980369f3e4a9e7b2543327c5914"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "op-alloy-consensus",
@@ -6991,27 +7031,27 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-jsonrpsee"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ad24013146aecff6fb5cc5f3ed2273830b79a1b12c1bad0bdd76e2f5fe43c6"
+checksum = "14179ab38e50d1802ce267fe808abf271a608ff7ea0e0c6586b13bf613ca6c50"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "jsonrpsee 0.24.9",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398b77b1fe4a9ca83d031d59a19fa9aa4ffcc2a896a83b7861a94292c2098412"
+checksum = "12e5551cb5703c768b6f50b4f1f989aa8a272028aff16d5ac44e75613d7f659e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "op-alloy-consensus",
  "serde",
  "serde_json",
@@ -7019,21 +7059,21 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59251cd112cb10792a041ea68d9423391e0e9e3576605ee52800890fdaa483c"
+checksum = "45a49508b90f31dd968f8ba6db84b81eb074d50312501114fb2752bc12417fb9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "alloy-serde",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "ethereum_ssz",
  "op-alloy-consensus",
  "serde",
  "snap",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -7044,7 +7084,8 @@ dependencies = [
  "alloy-eips",
  "alloy-network",
  "alloy-op-evm",
- "alloy-primitives 0.8.23",
+ "alloy-op-hardforks",
+ "alloy-primitives 0.8.25",
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types-beacon",
@@ -7055,7 +7096,7 @@ dependencies = [
  "alloy-transport-http",
  "async-trait",
  "chrono",
- "clap 4.5.21",
+ "clap 4.5.34",
  "clap_builder",
  "derive_more 2.0.1",
  "eyre",
@@ -7066,6 +7107,7 @@ dependencies = [
  "metrics",
  "op-alloy-consensus",
  "op-alloy-network",
+ "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "rand 0.8.5",
@@ -7079,6 +7121,7 @@ dependencies = [
  "reth-exex",
  "reth-metrics",
  "reth-node-api",
+ "reth-node-builder",
  "reth-node-ethereum",
  "reth-optimism-chainspec",
  "reth-optimism-cli",
@@ -7107,6 +7150,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "thiserror 1.0.69",
  "tikv-jemallocator",
  "time",
  "tokio",
@@ -7164,9 +7208,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -7190,15 +7234,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -7228,9 +7272,9 @@ checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.1.0",
+ "http 1.3.1",
  "opentelemetry",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
 ]
 
 [[package]]
@@ -7241,13 +7285,13 @@ checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 1.1.0",
+ "http 1.3.1",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -7340,30 +7384,32 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arbitrary",
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
  "bytes",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7454,9 +7500,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -7479,12 +7525,12 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.14"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -7509,12 +7555,12 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared 0.11.2",
+ "phf_shared 0.11.3",
  "serde",
 ]
 
@@ -7540,22 +7586,22 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.2",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator 0.11.2",
- "phf_shared 0.11.2",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -7567,32 +7613,32 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher",
+ "siphasher 1.0.1",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7601,9 +7647,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -7644,9 +7690,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain_hasher"
@@ -7738,7 +7784,7 @@ dependencies = [
  "comfy-table",
  "either",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "num-traits",
  "once_cell",
  "polars-arrow",
@@ -7829,7 +7875,7 @@ dependencies = [
  "argminmax",
  "arrow2",
  "either",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "memchr",
  "polars-arrow",
  "polars-core",
@@ -7963,9 +8009,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -7975,11 +8021,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7990,9 +8036,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "predicates-core",
@@ -8000,15 +8046,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -8026,9 +8072,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
  "syn 2.0.100",
@@ -8059,13 +8105,13 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "2.1.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
+checksum = "ef08705fa1589a1a59aa924ad77d14722cb0cd97b67dd5004ed5f4a4873fce8d"
 dependencies = [
  "autocfg",
  "equivalent",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
 ]
 
 [[package]]
@@ -8080,9 +8126,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -8135,9 +8181,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -8153,7 +8199,7 @@ dependencies = [
  "flate2",
  "hex",
  "procfs-core",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -8184,9 +8230,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -8214,9 +8260,9 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
+checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8265,9 +8311,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -8295,37 +8341,39 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "rustls 0.23.25",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom 0.3.2",
+ "rand 0.9.0",
  "ring",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "rustls 0.23.25",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -8333,9 +8381,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.7"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -8347,12 +8395,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -8402,8 +8456,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.2",
- "zerocopy 0.8.20",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8433,7 +8487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.2",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -8456,12 +8510,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
- "zerocopy 0.8.20",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -8493,6 +8546,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8515,9 +8577,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.2.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -8555,7 +8617,7 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives",
  "alloy-node-bindings",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rlp",
@@ -8570,9 +8632,9 @@ dependencies = [
  "async-trait",
  "atoi",
  "beacon-api-client",
- "bigdecimal 0.4.6",
+ "bigdecimal 0.4.7",
  "built",
- "clap 4.5.21",
+ "clap 4.5.34",
  "criterion 0.5.1",
  "crossbeam",
  "crossbeam-queue",
@@ -8611,7 +8673,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "redis",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
  "reth",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -8648,7 +8710,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
  "tracing-subscriber",
  "tungstenite 0.23.0",
@@ -8681,9 +8743,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -8745,11 +8807,11 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "regress"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1541daf4e4ed43a0922b7969bdc2170178bcacc5dabf7e39bc508a9fa3953a7a"
+checksum = "78ef7fa9ed0256d64a688a3747d0fef7a88851c18a5e1d57f115f38ec2e09366"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "memchr",
 ]
 
@@ -8767,7 +8829,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -8797,9 +8859,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8807,12 +8869,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.6",
- "http 1.1.0",
+ "h2 0.4.8",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
- "hyper-rustls 0.27.3",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -8825,34 +8887,34 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.25",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.2",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.8",
  "windows-registry",
 ]
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+checksum = "48375394603e3dd4b2d64371f7148fd8c7baa2680e28741f2cb8d23b59e3d4c4"
 dependencies = [
  "hostname",
- "quick-error",
 ]
 
 [[package]]
@@ -8862,12 +8924,12 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types",
  "aquamarine",
  "backon",
- "clap 4.5.21",
+ "clap 4.5.34",
  "eyre",
  "futures",
  "reth-basic-payload-builder",
@@ -8935,7 +8997,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "futures-core",
  "futures-util",
  "metrics",
@@ -8959,7 +9021,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-signer",
  "alloy-signer-local",
  "derive_more 2.0.1",
@@ -8992,7 +9054,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-trie",
  "auto_impl",
  "derive_more 2.0.1",
@@ -9008,7 +9070,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-genesis",
- "clap 4.5.21",
+ "clap 4.5.34",
  "eyre",
  "reth-cli-runner",
  "reth-db",
@@ -9024,10 +9086,10 @@ dependencies = [
  "ahash",
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "backon",
- "clap 4.5.21",
+ "clap 4.5.34",
  "comfy-table",
  "crossterm",
  "eyre",
@@ -9073,7 +9135,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml 0.8.19",
+ "toml 0.8.20",
  "tracing",
 ]
 
@@ -9093,7 +9155,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "cfg-if",
  "eyre",
  "libc",
@@ -9101,7 +9163,7 @@ dependencies = [
  "reth-fs-util",
  "secp256k1",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tikv-jemallocator",
 ]
 
@@ -9113,7 +9175,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-trie",
  "arbitrary",
  "bytes",
@@ -9146,7 +9208,7 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "serde",
- "toml 0.8.19",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -9155,11 +9217,11 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9181,14 +9243,14 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-provider",
  "alloy-rpc-types-engine",
  "auto_impl",
  "derive_more 2.0.1",
  "eyre",
  "futures",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
  "reth-node-api",
  "reth-primitives-traits",
  "reth-tracing",
@@ -9202,7 +9264,7 @@ name = "reth-db"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "derive_more 2.0.1",
  "eyre",
  "metrics",
@@ -9216,11 +9278,11 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-errors",
  "reth-tracing",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "strum 0.27.1",
- "sysinfo 0.33.0",
+ "sysinfo 0.33.1",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9230,7 +9292,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
@@ -9258,7 +9320,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
@@ -9276,7 +9338,7 @@ dependencies = [
  "reth-trie-db",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -9286,7 +9348,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -9300,7 +9362,7 @@ name = "reth-discv4"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "discv5",
  "enr 0.13.0",
@@ -9315,7 +9377,7 @@ dependencies = [
  "schnellru",
  "secp256k1",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9326,7 +9388,7 @@ name = "reth-discv5"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "derive_more 2.0.1",
  "discv5",
@@ -9340,7 +9402,7 @@ dependencies = [
  "reth-metrics",
  "reth-network-peers",
  "secp256k1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -9350,7 +9412,7 @@ name = "reth-dns-discovery"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "data-encoding",
  "enr 0.13.0",
  "hickory-resolver",
@@ -9363,7 +9425,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9376,7 +9438,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "futures",
  "futures-util",
@@ -9392,7 +9454,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9405,7 +9467,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "aes",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "block-padding",
  "byteorder",
@@ -9422,7 +9484,7 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.8",
  "sha3",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9436,7 +9498,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
@@ -9467,7 +9529,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "auto_impl",
  "futures",
@@ -9481,7 +9543,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
@@ -9505,7 +9567,7 @@ dependencies = [
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9516,7 +9578,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
@@ -9548,7 +9610,7 @@ dependencies = [
  "reth-trie-sparse",
  "revm-primitives",
  "schnellru",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -9589,7 +9651,7 @@ dependencies = [
  "reth-execution-errors",
  "reth-fs-util",
  "reth-storage-errors",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9598,7 +9660,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "bytes",
  "derive_more 2.0.1",
@@ -9613,7 +9675,7 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "snap",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9628,7 +9690,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "bytes",
  "derive_more 2.0.1",
@@ -9638,7 +9700,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9658,7 +9720,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -9673,7 +9735,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -9691,11 +9753,11 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "arbitrary",
  "auto_impl",
  "once_cell",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -9705,7 +9767,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -9734,7 +9796,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-network",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -9769,7 +9831,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "auto_impl",
  "derive_more 2.0.1",
  "futures-util",
@@ -9795,7 +9857,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -9811,11 +9873,11 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-evm",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9826,7 +9888,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "derive_more 2.0.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -9843,7 +9905,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "eyre",
  "futures",
  "itertools 0.14.0",
@@ -9868,7 +9930,7 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "rmp-serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",
@@ -9880,7 +9942,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "reth-chain-state",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -9895,7 +9957,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9904,7 +9966,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "eyre",
@@ -9937,7 +9999,7 @@ dependencies = [
  "jsonrpsee 0.24.9",
  "pin-project",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9954,11 +10016,11 @@ dependencies = [
  "byteorder",
  "dashmap 6.1.0",
  "derive_more 2.0.1",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "parking_lot",
  "reth-mdbx-sys",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -9988,7 +10050,7 @@ name = "reth-net-banlist"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
 ]
 
 [[package]]
@@ -9998,9 +10060,9 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -10012,7 +10074,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -10048,12 +10110,12 @@ dependencies = [
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "schnellru",
  "secp256k1",
  "serde",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -10065,7 +10127,7 @@ name = "reth-network-api"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-admin",
  "auto_impl",
  "derive_more 2.0.1",
@@ -10078,7 +10140,7 @@ dependencies = [
  "reth-network-types",
  "reth-tokio-util",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
 ]
@@ -10090,7 +10152,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "auto_impl",
  "derive_more 2.0.1",
  "futures",
@@ -10111,12 +10173,12 @@ name = "reth-network-peers"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "enr 0.13.0",
  "secp256k1",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "url",
 ]
@@ -10147,9 +10209,9 @@ dependencies = [
  "memmap2 0.9.5",
  "reth-fs-util",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
- "zstd 0.13.2",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -10183,7 +10245,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
  "aquamarine",
@@ -10245,9 +10307,9 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
- "clap 4.5.21",
+ "clap 4.5.34",
  "derive_more 2.0.1",
  "dirs-next",
  "eyre",
@@ -10281,8 +10343,8 @@ dependencies = [
  "serde",
  "shellexpand",
  "strum 0.27.1",
- "thiserror 2.0.11",
- "toml 0.8.19",
+ "thiserror 2.0.12",
+ "toml 0.8.20",
  "tracing",
  "vergen",
  "vergen-git2",
@@ -10330,7 +10392,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "futures",
@@ -10353,7 +10415,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "eyre",
- "http 1.1.0",
+ "http 1.3.1",
  "jsonrpsee-server 0.24.9",
  "metrics",
  "metrics-exporter-prometheus",
@@ -10390,7 +10452,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "derive_more 2.0.1",
  "once_cell",
  "op-alloy-consensus",
@@ -10402,7 +10464,7 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -10412,9 +10474,9 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
- "clap 4.5.21",
+ "clap 4.5.34",
  "derive_more 2.0.1",
  "eyre",
  "futures-util",
@@ -10459,7 +10521,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-trie",
  "op-alloy-consensus",
  "reth-chainspec",
@@ -10474,7 +10536,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "revm",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -10487,7 +10549,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-op-evm",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "derive_more 2.0.1",
  "op-alloy-consensus",
  "op-revm",
@@ -10504,7 +10566,7 @@ dependencies = [
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "revm",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -10515,7 +10577,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-chains",
  "alloy-op-hardforks",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "auto_impl",
  "once_cell",
  "reth-ethereum-forks",
@@ -10529,10 +10591,10 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "clap 4.5.21",
+ "clap 4.5.34",
  "eyre",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
@@ -10581,7 +10643,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
@@ -10608,7 +10670,7 @@ dependencies = [
  "reth-transaction-pool",
  "revm",
  "sha2 0.10.8",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -10620,7 +10682,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -10648,7 +10710,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -10664,7 +10726,7 @@ dependencies = [
  "op-alloy-rpc-types-engine",
  "op-revm",
  "parking_lot",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
  "reth-chainspec",
  "reth-evm",
  "reth-network-api",
@@ -10688,7 +10750,7 @@ dependencies = [
  "reth-transaction-pool",
  "revm",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -10700,7 +10762,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "c-kzg",
  "derive_more 2.0.1",
@@ -10759,7 +10821,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "auto_impl",
  "op-alloy-rpc-types-engine",
@@ -10768,7 +10830,7 @@ dependencies = [
  "reth-errors",
  "reth-primitives-traits",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
@@ -10778,7 +10840,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "reth-transaction-pool",
 ]
 
@@ -10815,7 +10877,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-trie",
  "arbitrary",
@@ -10837,7 +10899,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_with",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -10847,7 +10909,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "auto_impl",
  "dashmap 6.1.0",
@@ -10893,7 +10955,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "itertools 0.14.0",
  "metrics",
  "rayon",
@@ -10908,8 +10970,8 @@ dependencies = [
  "reth-prune-types",
  "reth-static-file-types",
  "reth-tokio-util",
- "rustc-hash 2.1.0",
- "thiserror 2.0.11",
+ "rustc-hash 2.1.1",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -10919,13 +10981,13 @@ name = "reth-prune-types"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "arbitrary",
  "derive_more 2.0.1",
  "modular-bitfield",
  "reth-codecs",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -10933,7 +10995,7 @@ name = "reth-rbuilder"
 version = "0.1.0"
 dependencies = [
  "alloy-rlp",
- "clap 4.5.21",
+ "clap 4.5.34",
  "eyre",
  "libc",
  "rbuilder",
@@ -10953,7 +11015,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "futures",
  "reth-eth-wire",
@@ -10972,7 +11034,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "eyre",
  "futures",
  "parking_lot",
@@ -11000,7 +11062,7 @@ name = "reth-revm"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -11019,7 +11081,7 @@ dependencies = [
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
@@ -11036,9 +11098,9 @@ dependencies = [
  "async-trait",
  "derive_more 2.0.1",
  "futures",
- "http 1.1.0",
+ "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "jsonrpsee 0.24.9",
  "jsonwebtoken",
  "parking_lot",
@@ -11071,7 +11133,7 @@ dependencies = [
  "revm-primitives",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -11087,7 +11149,7 @@ dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "alloy-json-rpc",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
@@ -11112,7 +11174,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-network",
  "alloy-provider",
- "http 1.1.0",
+ "http 1.3.1",
  "jsonrpsee 0.24.9",
  "metrics",
  "pin-project",
@@ -11134,7 +11196,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tower 0.4.13",
@@ -11148,7 +11210,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "async-trait",
  "jsonrpsee-core 0.24.9",
@@ -11167,7 +11229,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -11182,7 +11244,7 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
@@ -11222,7 +11284,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "derive_more 2.0.1",
@@ -11251,7 +11313,7 @@ dependencies = [
  "revm-inspectors",
  "schnellru",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -11263,7 +11325,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-rpc-types-engine",
- "http 1.1.0",
+ "http 1.3.1",
  "jsonrpsee-http-client 0.24.9",
  "pin-project",
  "tower 0.4.13",
@@ -11277,7 +11339,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "jsonrpsee-core 0.24.9",
  "jsonrpsee-types 0.24.9",
@@ -11293,7 +11355,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "jsonrpsee-types 0.24.9",
  "reth-primitives-traits",
@@ -11307,14 +11369,14 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "bincode",
  "blake3",
  "futures-util",
  "itertools 0.14.0",
  "num-traits",
  "rayon",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
  "reth-codecs",
  "reth-config",
  "reth-consensus",
@@ -11337,7 +11399,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -11348,7 +11410,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "aquamarine",
  "auto_impl",
  "futures-util",
@@ -11364,7 +11426,7 @@ dependencies = [
  "reth-static-file",
  "reth-static-file-types",
  "reth-tokio-util",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -11374,7 +11436,7 @@ name = "reth-stages-types"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -11388,7 +11450,7 @@ name = "reth-static-file"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "parking_lot",
  "rayon",
  "reth-codecs",
@@ -11409,8 +11471,8 @@ name = "reth-static-file-types"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
- "clap 4.5.21",
+ "alloy-primitives 0.8.25",
+ "clap 4.5.34",
  "derive_more 2.0.1",
  "serde",
  "strum 0.27.1",
@@ -11423,7 +11485,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
@@ -11446,14 +11508,14 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "derive_more 2.0.1",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -11468,7 +11530,7 @@ dependencies = [
  "pin-project",
  "rayon",
  "reth-metrics",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -11482,7 +11544,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "rand 0.8.5",
  "reth-primitives",
  "reth-primitives-traits",
@@ -11504,7 +11566,7 @@ name = "reth-tracing"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "clap 4.5.21",
+ "clap 4.5.34",
  "eyre",
  "rolling-file",
  "tracing",
@@ -11521,7 +11583,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -11542,11 +11604,11 @@ dependencies = [
  "reth-tasks",
  "revm-interpreter",
  "revm-primitives",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "schnellru",
  "serde",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -11559,7 +11621,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
@@ -11583,7 +11645,7 @@ version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -11608,7 +11670,7 @@ name = "reth-trie-db"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "derive_more 2.0.1",
  "metrics",
@@ -11627,7 +11689,7 @@ name = "reth-trie-parallel"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "derive_more 2.0.1",
  "itertools 0.14.0",
@@ -11642,7 +11704,7 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "reth-trie-sparse",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -11652,7 +11714,7 @@ name = "reth-trie-sparse"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "auto_impl",
  "metrics",
@@ -11662,7 +11724,7 @@ dependencies = [
  "reth-tracing",
  "reth-trie-common",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -11670,7 +11732,7 @@ name = "reth-zstd-compressors"
 version = "1.3.4"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.4#90c514ca818a36eb8cd36866156c26a4221e9c4a"
 dependencies = [
- "zstd 0.13.2",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -11699,7 +11761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3409abfcfb2d7e111128656d38270432854ee7d428366808c11fdb1481515c2"
 dependencies = [
  "bitvec",
- "phf 0.11.2",
+ "phf 0.11.3",
  "revm-primitives",
  "serde",
 ]
@@ -11803,7 +11865,7 @@ version = "0.17.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1504e2851a11562fb350a9f408e5783351650aef11790aea0b0d0d9ab961c40"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
@@ -11814,7 +11876,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -11856,7 +11918,7 @@ version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba06ca54b13861f785e3f01da1b61dead6e41acd3ff47a1165fa082ffe984ab"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "enumn",
  "serde",
 ]
@@ -11896,15 +11958,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -11979,9 +12040,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.6"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4b84ba6e838ceb47b41de5194a60244fac43d9fe03b71dbe8c5a201081d6d1"
+checksum = "a652edd001c53df0b3f96a36a8dc93fce6866988efc16808235653c6bcac8bf2"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -12002,21 +12063,21 @@ version = "0.1.0"
 source = "git+http://github.com/flashbots/rollup-boost?rev=6b94e1037f41e0817f2bcb1f1ca5013a5359616a#6b94e1037f41e0817f2bcb1f1ca5013a5359616a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "clap 4.5.21",
+ "clap 4.5.34",
  "dotenv",
  "eyre",
  "flate2",
  "futures",
  "futures-util",
- "http 1.1.0",
+ "http 1.3.1",
  "http-body 0.4.6",
  "http-body-util",
- "hyper 1.5.0",
- "hyper-rustls 0.27.3",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
  "hyper-util",
  "jsonrpsee 0.24.9",
  "lazy_static",
@@ -12035,7 +12096,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "paste",
- "reqwest 0.12.9",
+ "reqwest 0.12.15",
  "rustls 0.23.25",
  "serde",
  "serde_json",
@@ -12058,9 +12119,9 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rsa"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
  "digest 0.10.7",
@@ -12078,22 +12139,25 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes",
- "fastrlp",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "parity-scale-codec",
  "primitive-types",
  "proptest",
  "rand 0.8.5",
+ "rand 0.9.0",
  "rlp",
  "ruint-macro",
  "serde",
@@ -12121,9 +12185,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -12149,20 +12213,33 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.23",
+ "semver 1.0.26",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12188,7 +12265,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.1",
  "subtle",
  "zeroize",
 ]
@@ -12207,15 +12284,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -12257,9 +12333,9 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.23.25",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.1",
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -12284,9 +12360,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -12314,15 +12390,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "ryu-js"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "same-file"
@@ -12335,9 +12411,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.5"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa7ffc1c0ef49b0452c6e2986abf2b07743320641ffd5fc63d552458e3b779b"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "cfg-if",
  "derive_more 1.0.0",
@@ -12347,11 +12423,11 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.5"
+version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46385cc24172cf615450267463f937c10072516359b3ff1cb24228a4a08bf951"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -12359,18 +12435,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "schnellru"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
+checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
 dependencies = [
  "ahash",
  "cfg-if",
@@ -12510,7 +12586,7 @@ checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
- "derive_more 0.99.18",
+ "derive_more 0.99.19",
  "fxhash",
  "log",
  "new_debug_unreachable",
@@ -12532,18 +12608,18 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "semver-parser"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
@@ -12562,9 +12638,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "seq-macro"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -12592,7 +12668,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "itoa",
  "memchr",
  "ryu",
@@ -12644,15 +12720,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -12662,9 +12738,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -12859,9 +12935,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -12869,9 +12945,9 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
+checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
 dependencies = [
  "console",
  "serde",
@@ -12880,13 +12956,13 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -12895,6 +12971,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skeptic"
@@ -12928,9 +13010,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "arbitrary",
  "serde",
@@ -12955,9 +13037,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -12981,14 +13063,14 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.1.0",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -13094,7 +13176,7 @@ dependencies = [
  "futures-util",
  "hashlink 0.8.4",
  "hex",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "log",
  "memchr",
  "native-tls",
@@ -13286,7 +13368,7 @@ name = "ssz_rs"
 version = "0.9.0"
 source = "git+https://github.com/ralexstokes/ssz-rs.git#ec3073e2273b4d0873fcb6df68ff4eff79588e92"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "bitvec",
  "serde",
  "sha2 0.9.9",
@@ -13348,26 +13430,25 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+checksum = "938d512196766101d333398efde81bc1f37b00cb42c2f8350e5df639f040bbbe"
 dependencies = [
  "new_debug_unreachable",
- "once_cell",
  "parking_lot",
- "phf_shared 0.10.0",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
 ]
@@ -13489,9 +13570,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.23"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d975606bae72d8aad5b07d9342465e123a2cccf53a5a735aedf81ca92a709ecb"
+checksum = "4560533fbd6914b94a8fb5cc803ed6801c3455668db3b810702c57612bac9412"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -13507,9 +13588,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
 ]
@@ -13553,9 +13634,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948512566b1895f93b1592c7574baeb2de842f224f2aab158799ecadb8ebbb46"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -13569,11 +13650,11 @@ dependencies = [
 name = "sysperf"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "num_cpus",
  "rand 0.8.5",
  "rayon",
- "sysinfo 0.33.0",
+ "sysinfo 0.33.1",
 ]
 
 [[package]]
@@ -13638,14 +13719,14 @@ checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
- "fastrand 2.2.0",
+ "fastrand 2.3.0",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -13662,9 +13743,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-relay"
@@ -13673,9 +13754,9 @@ dependencies = [
  "ahash",
  "alloy-consensus",
  "alloy-json-rpc",
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "alloy-provider",
- "clap 4.5.21",
+ "clap 4.5.34",
  "clap_builder",
  "ctor",
  "ethereum_ssz",
@@ -13711,15 +13792,15 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thin-vec"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
+checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
 
 [[package]]
 name = "thiserror"
@@ -13732,11 +13813,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -13752,9 +13833,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13813,9 +13894,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -13831,15 +13912,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -13876,9 +13957,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -13940,20 +14021,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls 0.23.25",
- "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -13986,16 +14066,16 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.2",
  "tungstenite 0.26.2",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -14017,9 +14097,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -14038,15 +14118,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.20",
+ "winnow",
 ]
 
 [[package]]
@@ -14060,11 +14140,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.6",
- "http 1.1.0",
+ "h2 0.4.8",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -14102,14 +14182,15 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.2",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -14126,7 +14207,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
@@ -14138,7 +14219,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -14216,9 +14297,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-journald"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
+checksum = "fc0b4143302cf1022dac868d521e36e8b27691f72c84b3311750d5188ebba657"
 dependencies = [
  "libc",
  "tracing-core",
@@ -14303,7 +14384,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58eb0f518840670270d90d97ffee702d8662d9c5494870c9e1e9e0fa00f668"
 dependencies = [
- "alloy-primitives 0.8.23",
+ "alloy-primitives 0.8.25",
  "ethereum_hashing",
  "ethereum_ssz",
  "smallvec",
@@ -14353,7 +14434,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -14372,7 +14453,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -14389,7 +14470,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.1.0",
+ "http 1.3.1",
  "httparse",
  "log",
  "native-tls",
@@ -14397,7 +14478,7 @@ dependencies = [
  "rustls 0.23.25",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "utf-8",
 ]
 
@@ -14413,9 +14494,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -14455,21 +14536,21 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -14568,7 +14649,7 @@ dependencies = [
  "rustls 0.23.25",
  "rustls-pki-types",
  "url",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -14615,20 +14696,20 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.2",
  "serde",
  "sha1_smol",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -14696,9 +14777,9 @@ dependencies = [
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -14739,7 +14820,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "log",
  "mime",
  "mime_guess",
@@ -14771,9 +14852,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -14812,12 +14893,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -14883,9 +14965,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -14918,9 +15000,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.6"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -14934,14 +15016,14 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
 name = "whoami"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
  "redox_syscall",
  "wasite",
@@ -14949,9 +15031,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"
@@ -14983,6 +15065,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows"
@@ -15034,7 +15126,7 @@ dependencies = [
  "windows-implement 0.58.0",
  "windows-interface 0.58.0",
  "windows-result 0.2.0",
- "windows-strings",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -15083,14 +15175,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-result 0.3.2",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -15112,6 +15210,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15119,6 +15226,15 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -15196,11 +15312,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -15222,6 +15354,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15238,6 +15376,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -15258,10 +15402,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -15282,6 +15438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15298,6 +15460,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -15318,6 +15486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15336,19 +15510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.20"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
-dependencies = [
- "memchr",
-]
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]
@@ -15365,9 +15536,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -15414,9 +15585,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yaml-rust"
@@ -15435,9 +15606,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -15447,9 +15618,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15463,17 +15634,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
  "zerocopy-derive 0.7.35",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.20"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.20",
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -15489,9 +15659,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.20"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15500,18 +15670,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15601,11 +15771,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.1",
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -15630,18 +15800,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,11 @@ members = [
     "crates/sysperf",
     "crates/test-relay",
 ]
-default-members = ["crates/rbuilder", "crates/reth-rbuilder", "crates/test-relay"]
+default-members = [
+    "crates/rbuilder",
+    "crates/reth-rbuilder",
+    "crates/test-relay",
+]
 resolver = "2"
 
 # Like release, but with full debug symbols. Useful for e.g. `perf`.
@@ -41,6 +45,7 @@ reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
 reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
 reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
 reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
 reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
 reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v1.3.4" }
@@ -115,7 +120,8 @@ alloy-genesis = { version = "0.12.6" }
 alloy-trie = { version = "0.7.9" }
 
 # optimism
-alloy-op-evm = { version = "0.1.0-alpha.2", default-features = false }
+alloy-op-evm = { version = "0.1.0-alpha.3", default-features = false }
+alloy-op-hardforks = { version = "0.1.0-alpha.2", default-features = false }
 op-alloy-rpc-types = { version = "0.11.2", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.11.2", default-features = false }
 op-alloy-rpc-jsonrpsee = { version = "0.11.2", default-features = false }
@@ -123,8 +129,8 @@ op-alloy-network = { version = "0.11.2", default-features = false }
 op-alloy-consensus = { version = "0.11.2", default-features = false }
 
 # kona
-kona-rpc = { git = "https://github.com/op-rs/kona", rev = "0493d8479e2ca9f0eb6d5c6154e2bedc61de7217", features = ["client", "interop", "jsonrpsee"] }
-kona-interop = { git = "https://github.com/op-rs/kona", rev = "0493d8479e2ca9f0eb6d5c6154e2bedc61de7217" }
+kona-rpc = { git = "https://github.com/op-rs/kona", rev = "88efce85a96a0dbc98c8aab94dd18d2136498fb0", features = ["client", "interop", "jsonrpsee"] }
+kona-interop = { git = "https://github.com/op-rs/kona", rev = "88efce85a96a0dbc98c8aab94dd18d2136498fb0" }
 
 async-trait = { version = "0.1.83" }
 clap = { version = "4.4.3", features = ["derive", "env"] }
@@ -161,4 +167,8 @@ time = { version = "0.3.36", features = ["macros", "formatting", "parsing"] }
 eth-sparse-mpt = { path = "crates/eth-sparse-mpt" }
 rbuilder = { path = "crates/rbuilder" }
 sysperf = { path = "crates/sysperf" }
-metrics_macros = { path = "crates/rbuilder/src/telemetry/metrics_macros"}
+metrics_macros = { path = "crates/rbuilder/src/telemetry/metrics_macros" }
+
+[patch.crates-io]
+alloy-op-evm = { git = "https://github.com/avalonche/evm", rev = "ccaaa18d3f45d03deaa2e8f9020aa7d695e2b471", default-features = false }
+alloy-evm = { git = "https://github.com/avalonche/evm", rev = "ccaaa18d3f45d03deaa2e8f9020aa7d695e2b471", default-features = false }

--- a/crates/eth-sparse-mpt/src/reth_sparse_trie/change_set.rs
+++ b/crates/eth-sparse-mpt/src/reth_sparse_trie/change_set.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::ChangedAccountData;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ETHTrieChangeSet {
     pub account_trie_deletes: Vec<Bytes>,
 

--- a/crates/op-rbuilder/Cargo.toml
+++ b/crates/op-rbuilder/Cargo.toml
@@ -25,6 +25,7 @@ reth-chainspec.workspace = true
 reth-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-node-api.workspace = true
+reth-node-builder.workspace = true
 reth-basic-payload-builder.workspace = true
 reth-payload-builder.workspace = true
 reth-node-ethereum.workspace = true
@@ -58,14 +59,16 @@ alloy-serde.workspace = true
 alloy-op-evm.workspace = true
 op-alloy-consensus.workspace = true
 op-alloy-rpc-types-engine.workspace = true
+op-alloy-rpc-types.workspace = true
 op-alloy-network.workspace = true
+op-revm.workspace = true
+alloy-op-hardforks.workspace = true
 
 # kona
 kona-rpc.workspace = true
 kona-interop.workspace = true
 
 revm.workspace = true
-op-revm.workspace = true
 
 tracing.workspace = true
 futures-util = "0.3.31"
@@ -83,6 +86,7 @@ derive_more.workspace = true
 metrics.workspace = true
 serde_json.workspace = true
 tokio-util.workspace = true
+thiserror.workspace = true
 
 time = { version = "0.3.36", features = ["macros", "formatting", "parsing"] }
 chrono = "0.4"

--- a/crates/op-rbuilder/README.md
+++ b/crates/op-rbuilder/README.md
@@ -14,7 +14,7 @@ To run op-rbuilder with the op-stack, you need:
 To run the op-rbuilder, run:
 
 ```bash
-cargo run -p op-rbuilder --bin op-rbuilder --features optimism -- node \
+cargo run -p op-rbuilder --bin op-rbuilder -- node \
     --chain /path/to/chain-config.json \
     --http \
     --authrpc.port 9551 \
@@ -24,7 +24,7 @@ cargo run -p op-rbuilder --bin op-rbuilder --features optimism -- node \
 To build the op-rbuilder, run:
 
 ```bash
-cargo build -p op-rbuilder --bin op-rbuilder --features optimism
+cargo build -p op-rbuilder --bin op-rbuilder
 ```
 
 ## Observability
@@ -50,13 +50,13 @@ To run the integration tests, run:
 
 ```bash
 # Generate a genesis file
-cargo run -p op-rbuilder --bin tester --features optimism -- genesis --output genesis.json
+cargo run -p op-rbuilder --bin tester -- genesis --output genesis.json
 
 # Build the op-rbuilder binary
-cargo build -p op-rbuilder --bin op-rbuilder --features optimism
+cargo build -p op-rbuilder --bin op-rbuilder
 
 # Run the integration tests
-cargo run -p op-rbuilder --bin tester --features optimism -- run
+cargo run -p op-rbuilder --bin tester -- run
 ```
 
 ## Local Devnet
@@ -86,7 +86,7 @@ make devnet-clean && make devnet-down && make devnet-up
 4. Run `op-rbuilder` in the `rbuilder` repo on port 8547:
 
 ```bash
-cargo run -p op-rbuilder --bin op-rbuilder --features optimism -- node \
+cargo run -p op-rbuilder --bin op-rbuilder -- node \
     --chain ../optimism/.devnet/genesis-l2.json \
     --http \
     --http.port 8547 \

--- a/crates/op-rbuilder/src/args.rs
+++ b/crates/op-rbuilder/src/args.rs
@@ -5,7 +5,7 @@
 //! clap [Args](clap::Args) for optimism rollup configuration
 use reth_optimism_node::args::RollupArgs;
 
-use crate::tx_signer::Signer;
+use crate::tx_signer::OpSigner;
 use alloy_transport_http::reqwest::Url;
 
 /// Parameters for rollup configuration
@@ -17,7 +17,7 @@ pub struct OpRbuilderArgs {
     pub rollup_args: RollupArgs,
     /// Builder secret key for signing last transaction in block
     #[arg(long = "rollup.builder-secret-key", env = "BUILDER_SECRET_KEY")]
-    pub builder_signer: Option<Signer>,
+    pub builder_signer: Option<OpSigner>,
     /// Websocket port for flashblock payload builder
     #[arg(
         long = "rollup.flashblocks-ws-url",

--- a/crates/op-rbuilder/src/executor.rs
+++ b/crates/op-rbuilder/src/executor.rs
@@ -1,0 +1,354 @@
+use alloy_consensus::{Eip658Value, Header, Transaction, TxReceipt};
+use alloy_eips::{Encodable2718, Typed2718};
+use alloy_op_evm::{
+    block::{receipt_builder::OpReceiptBuilder, OpAlloyReceiptBuilder},
+    OpBlockExecutionCtx, OpBlockExecutor, OpEvmFactory,
+};
+use alloy_op_hardforks::OpChainHardforks;
+use op_alloy_consensus::{EIP1559ParamError, OpDepositReceipt};
+use op_revm::{transaction::deposit::DEPOSIT_TRANSACTION_TYPE, OpSpecId, OpTransaction};
+use reth::builder::{components::ExecutorBuilder, BuilderContext};
+use reth_chainspec::EthChainSpec;
+use reth_evm::{
+    block::{
+        BlockExecutionError, BlockExecutor, BlockExecutorFactory, BlockExecutorFor,
+        BlockValidationError, StateChangeSource,
+    },
+    eth::receipt_builder::ReceiptBuilderCtx,
+    ConfigureEvm, Database, Evm, EvmEnv, EvmFactory, FromRecoveredTx, InvalidTxError, OnStateHook,
+};
+use reth_node_api::{FullNodeTypes, NodePrimitives, NodeTypes};
+use reth_node_ethereum::BasicBlockExecutorProvider;
+use reth_optimism_chainspec::OpChainSpec;
+use reth_optimism_evm::{
+    OpBlockAssembler, OpEvmConfig, OpNextBlockEnvAttributes, OpRethReceiptBuilder,
+};
+use reth_optimism_forks::OpHardforks;
+use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
+use reth_primitives::{Recovered, SealedBlock, SealedHeader};
+use reth_primitives_traits::SignedTransaction;
+use reth_provider::BlockExecutionResult;
+use reth_revm::State;
+use revm::{
+    context::{result::ResultAndState, TxEnv},
+    DatabaseCommit, Inspector,
+};
+use std::sync::Arc;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Reverting tx error: {message}")]
+struct TransactionRevertedError {
+    message: String,
+}
+
+// Implement the InvalidTxError trait for it
+impl InvalidTxError for TransactionRevertedError {
+    fn is_nonce_too_low(&self) -> bool {
+        false
+    }
+}
+
+/// A regular optimism evm and executor builder.
+#[derive(Debug, Default, Clone, Copy)]
+#[non_exhaustive]
+pub struct OpRbuilderExecutorBuilder;
+
+impl<Node> ExecutorBuilder<Node> for OpRbuilderExecutorBuilder
+where
+    Node: FullNodeTypes<Types: NodeTypes<ChainSpec = OpChainSpec, Primitives = OpPrimitives>>,
+{
+    type EVM = OpRbuilderEvmConfig;
+    type Executor = BasicBlockExecutorProvider<Self::EVM>;
+
+    async fn build_evm(
+        self,
+        ctx: &BuilderContext<Node>,
+    ) -> eyre::Result<(Self::EVM, Self::Executor)> {
+        let evm_config =
+            OpRbuilderEvmConfig::new(ctx.chain_spec(), OpRethReceiptBuilder::default());
+        let executor = BasicBlockExecutorProvider::new(evm_config.clone());
+
+        Ok((evm_config, executor))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OpRbuilderEvmConfig<
+    ChainSpec = OpChainSpec,
+    N: NodePrimitives = OpPrimitives,
+    R = OpRethReceiptBuilder,
+> {
+    pub executor_factory: OpRbuilderBlockExecutorFactory<R, Arc<ChainSpec>>,
+    inner: OpEvmConfig<ChainSpec, N, R>,
+}
+
+impl<ChainSpec, N: NodePrimitives, R> OpRbuilderEvmConfig<ChainSpec, N, R>
+where
+    R: OpReceiptBuilder<Receipt: DepositReceipt, Transaction: SignedTransaction> + Clone,
+{
+    /// Creates a new [`OpRbuilderEvmConfig`] with the given chain spec.
+    pub fn new(chain_spec: Arc<ChainSpec>, receipt_builder: R) -> Self {
+        Self {
+            inner: OpEvmConfig::new(chain_spec.clone(), receipt_builder.clone()),
+            executor_factory: OpRbuilderBlockExecutorFactory::new(
+                receipt_builder,
+                chain_spec,
+                OpEvmFactory::default(),
+            ),
+        }
+    }
+}
+
+impl<ChainSpec, N, R> ConfigureEvm for OpRbuilderEvmConfig<ChainSpec, N, R>
+where
+    ChainSpec: EthChainSpec + OpHardforks,
+    N: NodePrimitives<
+        Receipt = R::Receipt,
+        SignedTx = R::Transaction,
+        BlockHeader = Header,
+        BlockBody = alloy_consensus::BlockBody<R::Transaction>,
+        Block = alloy_consensus::Block<R::Transaction>,
+    >,
+    OpTransaction<TxEnv>: FromRecoveredTx<N::SignedTx>,
+    R: OpReceiptBuilder<Receipt: DepositReceipt, Transaction: SignedTransaction>,
+    OpEvmConfig<ChainSpec, N, R>: Send + Sync + Unpin + Clone,
+    Self: Send + Sync + Unpin + Clone + 'static,
+{
+    type Primitives = N;
+    type Error = EIP1559ParamError;
+    type NextBlockEnvCtx = OpNextBlockEnvAttributes;
+    type BlockExecutorFactory = OpRbuilderBlockExecutorFactory<R, Arc<ChainSpec>>;
+    type BlockAssembler = OpBlockAssembler<ChainSpec>;
+
+    fn block_executor_factory(&self) -> &Self::BlockExecutorFactory {
+        &self.executor_factory
+    }
+
+    fn block_assembler(&self) -> &Self::BlockAssembler {
+        self.inner.block_assembler()
+    }
+
+    fn evm_env(&self, header: &Header) -> EvmEnv<OpSpecId> {
+        self.inner.evm_env(header)
+    }
+
+    fn next_evm_env(
+        &self,
+        parent: &Header,
+        attributes: &Self::NextBlockEnvCtx,
+    ) -> Result<EvmEnv<OpSpecId>, Self::Error> {
+        self.inner.next_evm_env(parent, attributes)
+    }
+
+    fn context_for_block(&self, block: &'_ SealedBlock<N::Block>) -> OpBlockExecutionCtx {
+        self.inner.context_for_block(block)
+    }
+
+    fn context_for_next_block(
+        &self,
+        parent: &SealedHeader<N::BlockHeader>,
+        attributes: Self::NextBlockEnvCtx,
+    ) -> OpBlockExecutionCtx {
+        self.inner.context_for_next_block(parent, attributes)
+    }
+}
+
+#[derive(Debug, Clone, Default, Copy)]
+pub struct OpRbuilderBlockExecutorFactory<
+    R = OpAlloyReceiptBuilder,
+    Spec = OpChainHardforks,
+    EvmFactory = OpEvmFactory,
+> {
+    /// Receipt builder.
+    receipt_builder: R,
+    /// Chain specification.
+    spec: Spec,
+    /// EVM factory.
+    evm_factory: EvmFactory,
+}
+
+impl<R, Spec, EvmFactory> OpRbuilderBlockExecutorFactory<R, Spec, EvmFactory> {
+    /// Creates a new [`OpRbuilderBlockExecutorFactory`] with the given spec, [`EvmFactory`], and
+    /// [`OpReceiptBuilder`].
+    pub const fn new(receipt_builder: R, spec: Spec, evm_factory: EvmFactory) -> Self {
+        Self {
+            receipt_builder,
+            spec,
+            evm_factory,
+        }
+    }
+}
+
+impl<R, Spec, EvmF> BlockExecutorFactory for OpRbuilderBlockExecutorFactory<R, Spec, EvmF>
+where
+    R: OpReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt>,
+    Spec: OpHardforks,
+    EvmF: EvmFactory<Tx: FromRecoveredTx<R::Transaction>>,
+    Self: 'static,
+{
+    type EvmFactory = EvmF;
+    type ExecutionCtx<'a> = OpBlockExecutionCtx;
+    type Transaction = R::Transaction;
+    type Receipt = R::Receipt;
+
+    fn evm_factory(&self) -> &Self::EvmFactory {
+        &self.evm_factory
+    }
+
+    fn create_executor<'a, DB, I>(
+        &'a self,
+        evm: EvmF::Evm<&'a mut State<DB>, I>,
+        ctx: Self::ExecutionCtx<'a>,
+    ) -> impl BlockExecutorFor<'a, Self, DB, I>
+    where
+        DB: Database + 'a,
+        I: Inspector<EvmF::Context<&'a mut State<DB>>> + 'a,
+    {
+        OpRbuilderBlockExecutor {
+            inner: OpBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder),
+        }
+    }
+}
+
+pub struct OpRbuilderBlockExecutor<Evm, R: OpReceiptBuilder, Spec> {
+    inner: OpBlockExecutor<Evm, R, Spec>,
+}
+
+impl<'db, DB, E, R, Spec> BlockExecutor for OpRbuilderBlockExecutor<E, R, Spec>
+where
+    DB: Database + 'db,
+    E: Evm<DB = &'db mut State<DB>, Tx: FromRecoveredTx<R::Transaction>>,
+    R: OpReceiptBuilder<Transaction: Transaction + Encodable2718, Receipt: TxReceipt>,
+    Spec: OpHardforks,
+{
+    type Transaction = R::Transaction;
+    type Receipt = R::Receipt;
+    type Evm = E;
+
+    fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
+        self.inner.apply_pre_execution_changes()
+    }
+
+    fn execute_transaction_with_result_closure(
+        &mut self,
+        tx: Recovered<&Self::Transaction>,
+        f: impl FnOnce(&revm::context::result::ExecutionResult<<Self::Evm as Evm>::HaltReason>),
+    ) -> Result<u64, BlockExecutionError> {
+        let is_deposit = tx.ty() == DEPOSIT_TRANSACTION_TYPE;
+
+        // The sum of the transaction’s gas limit, Tg, and the gas utilized in this block prior,
+        // must be no greater than the block’s gasLimit.
+        let block_available_gas = self.inner.evm.block().gas_limit - self.inner.gas_used;
+        if tx.gas_limit() > block_available_gas && (self.inner.is_regolith || !is_deposit) {
+            return Err(
+                BlockValidationError::TransactionGasLimitMoreThanAvailableBlockGas {
+                    transaction_gas_limit: tx.gas_limit(),
+                    block_available_gas,
+                }
+                .into(),
+            );
+        }
+
+        // Cache the depositor account prior to the state transition for the deposit nonce.
+        //
+        // Note that this *only* needs to be done post-regolith hardfork, as deposit nonces
+        // were not introduced in Bedrock. In addition, regular transactions don't have deposit
+        // nonces, so we don't need to touch the DB for those.
+        let depositor = (self.inner.is_regolith && is_deposit)
+            .then(|| {
+                self.inner
+                    .evm
+                    .db_mut()
+                    .load_cache_account(tx.signer())
+                    .map(|acc| acc.account_info().unwrap_or_default())
+            })
+            .transpose()
+            .map_err(BlockExecutionError::other)?;
+
+        let hash = tx.trie_hash();
+
+        // Execute transaction.
+        let result_and_state = self
+            .inner
+            .evm
+            .transact(tx)
+            .map_err(move |err| BlockExecutionError::evm(err, hash))?;
+
+        if !result_and_state.result.is_success() {
+            return Err(BlockValidationError::InvalidTx {
+                hash,
+                error: Box::new(TransactionRevertedError {
+                    message: "transaction reverted".to_string(), // TODO: add more context on error
+                }),
+            }
+            .into());
+        }
+
+        self.inner.system_caller.on_state(
+            StateChangeSource::Transaction(self.inner.receipts.len()),
+            &result_and_state.state,
+        );
+        let ResultAndState { result, state } = result_and_state;
+
+        f(&result);
+
+        let gas_used = result.gas_used();
+
+        // append gas used
+        self.inner.gas_used += gas_used;
+
+        self.inner.receipts.push(
+            match self.inner.receipt_builder.build_receipt(ReceiptBuilderCtx {
+                tx: tx.inner(),
+                result,
+                cumulative_gas_used: self.inner.gas_used,
+                evm: &self.inner.evm,
+                state: &state,
+            }) {
+                Ok(receipt) => receipt,
+                Err(ctx) => {
+                    let receipt = alloy_consensus::Receipt {
+                        // Success flag was added in `EIP-658: Embedding transaction status code
+                        // in receipts`.
+                        status: Eip658Value::Eip658(ctx.result.is_success()),
+                        cumulative_gas_used: self.inner.gas_used,
+                        logs: ctx.result.into_logs(),
+                    };
+
+                    self.inner
+                        .receipt_builder
+                        .build_deposit_receipt(OpDepositReceipt {
+                            inner: receipt,
+                            deposit_nonce: depositor.map(|account| account.nonce),
+                            // The deposit receipt version was introduced in Canyon to indicate an
+                            // update to how receipt hashes should be computed
+                            // when set. The state transition process ensures
+                            // this is only set for post-Canyon deposit
+                            // transactions.
+                            deposit_receipt_version: (is_deposit
+                                && self.inner.spec.is_canyon_active_at_timestamp(
+                                    self.inner.evm.block().timestamp,
+                                ))
+                            .then_some(1),
+                        })
+                }
+            },
+        );
+
+        self.inner.evm.db_mut().commit(state);
+
+        Ok(gas_used)
+    }
+
+    fn finish(self) -> Result<(Self::Evm, BlockExecutionResult<R::Receipt>), BlockExecutionError> {
+        self.inner.finish()
+    }
+
+    fn set_state_hook(&mut self, _hook: Option<Box<dyn OnStateHook>>) {
+        self.inner.set_state_hook(_hook)
+    }
+
+    fn evm_mut(&mut self) -> &mut Self::Evm {
+        self.inner.evm_mut()
+    }
+}

--- a/crates/op-rbuilder/src/executor.rs
+++ b/crates/op-rbuilder/src/executor.rs
@@ -67,7 +67,6 @@ where
         let evm_config =
             OpRbuilderEvmConfig::new(ctx.chain_spec(), OpRethReceiptBuilder::default());
         let executor = BasicBlockExecutorProvider::new(evm_config.clone());
-
         Ok((evm_config, executor))
     }
 }
@@ -80,6 +79,13 @@ pub struct OpRbuilderEvmConfig<
 > {
     pub executor_factory: OpRbuilderBlockExecutorFactory<R, Arc<ChainSpec>>,
     inner: OpEvmConfig<ChainSpec, N, R>,
+}
+
+impl<ChainSpec> OpRbuilderEvmConfig<ChainSpec> {
+    /// Creates a new [`OpEvmConfig`] with the given chain spec for OP chains.
+    pub fn optimism(chain_spec: Arc<ChainSpec>) -> Self {
+        Self::new(chain_spec, OpRethReceiptBuilder::default())
+    }
 }
 
 impl<ChainSpec, N: NodePrimitives, R> OpRbuilderEvmConfig<ChainSpec, N, R>

--- a/crates/op-rbuilder/src/generator.rs
+++ b/crates/op-rbuilder/src/generator.rs
@@ -1,25 +1,74 @@
+use alloy_primitives::B256;
 use futures_util::Future;
 use futures_util::FutureExt;
+use reth::builder::BuilderContext;
 use reth::providers::BlockReaderIdExt;
 use reth::{providers::StateProviderFactory, tasks::TaskSpawner};
+use reth_basic_payload_builder::BasicPayloadJobGeneratorConfig;
+use reth_basic_payload_builder::BuildOutcome;
 use reth_basic_payload_builder::HeaderForPayload;
-use reth_basic_payload_builder::{BasicPayloadJobGeneratorConfig, PayloadConfig};
+use reth_basic_payload_builder::PayloadConfig;
+use reth_basic_payload_builder::PayloadState;
+use reth_basic_payload_builder::PayloadTaskGuard;
+use reth_basic_payload_builder::PendingPayload;
+use reth_basic_payload_builder::PrecachedState;
+use reth_basic_payload_builder::ResolveBestPayload;
+use reth_node_api::FullNodeTypes;
+use reth_node_api::NodeTypesWithEngine;
 use reth_node_api::PayloadBuilderAttributes;
 use reth_node_api::PayloadKind;
+use reth_node_api::PayloadTypes;
 use reth_payload_builder::PayloadJobGenerator;
 use reth_payload_builder::{KeepPayloadJobAlive, PayloadBuilderError, PayloadJob};
 use reth_payload_primitives::BuiltPayload;
 use reth_primitives_traits::HeaderTy;
 use reth_revm::cached::CachedReads;
+use reth_revm::cancelled::CancelOnDrop;
+use reth_transaction_pool::TransactionPool;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 use tokio::sync::oneshot;
 use tokio::sync::Notify;
 use tokio::time::Duration;
+use tokio::time::Instant;
+use tokio::time::Interval;
 use tokio::time::Sleep;
-use tokio_util::sync::CancellationToken;
+use tracing::debug;
 use tracing::info;
+use tracing::trace;
+
+/// A type that knows how to build a payload builder to plug into [`BasicPayloadServiceBuilder`].
+pub trait PayloadBuilderBuilder<Node: FullNodeTypes, Pool: TransactionPool>: Send + Sized {
+    /// Payload builder implementation.
+    type PayloadBuilder: PayloadBuilderFor<Node::Types> + Unpin + 'static;
+
+    /// Spawns the payload service and returns the handle to it.
+    ///
+    /// The [`BuilderContext`] is provided to allow access to the node's configuration.
+    fn build_payload_builder(
+        self,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+    ) -> impl Future<Output = eyre::Result<Self::PayloadBuilder>> + Send;
+}
+
+/// Helper trait to bound [`PayloadBuilder`] to the node's engine types.
+pub trait PayloadBuilderFor<N: NodeTypesWithEngine>:
+    PayloadBuilder<
+    Attributes = <N::Engine as PayloadTypes>::PayloadBuilderAttributes,
+    BuiltPayload = <N::Engine as PayloadTypes>::BuiltPayload,
+>
+{
+}
+
+impl<T, N: NodeTypesWithEngine> PayloadBuilderFor<N> for T where
+    T: PayloadBuilder<
+        Attributes = <N::Engine as PayloadTypes>::PayloadBuilderAttributes,
+        BuiltPayload = <N::Engine as PayloadTypes>::BuiltPayload,
+    >
+{
+}
 
 /// A trait for building payloads that encapsulate Ethereum transactions.
 ///
@@ -50,8 +99,7 @@ pub trait PayloadBuilder: Send + Sync + Clone {
     fn try_build(
         &self,
         args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
-        best_payload: BlockCell<Self::BuiltPayload>,
-    ) -> Result<(), PayloadBuilderError>;
+    ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError>;
 }
 
 /// The generator type that creates new jobs that builds empty blocks.
@@ -63,36 +111,49 @@ pub struct BlockPayloadJobGenerator<Client, Tasks, Builder> {
     executor: Tasks,
     /// The configuration for the job generator.
     _config: BasicPayloadJobGeneratorConfig,
+    /// Restricts how many generator tasks can be executed at once.
+    payload_task_guard: PayloadTaskGuard,
     /// The type responsible for building payloads.
     ///
     /// See [PayloadBuilder]
     builder: Builder,
-    /// Whether to ensure only one payload is being processed at a time
-    ensure_only_one_payload: bool,
-    /// The last payload being processed
-    last_payload: Arc<Mutex<CancellationToken>>,
+    /// Stored `cached_reads` for new payload jobs.
+    pre_cached: Option<PrecachedState>,
 }
 
 // === impl EmptyBlockPayloadJobGenerator ===
 
 impl<Client, Tasks, Builder> BlockPayloadJobGenerator<Client, Tasks, Builder> {
-    /// Creates a new [EmptyBlockPayloadJobGenerator] with the given config and custom
-    /// [PayloadBuilder]
+    /// Creates a new [`BasicPayloadJobGenerator`] with the given config and custom
+    /// [`PayloadBuilder`]
     pub fn with_builder(
         client: Client,
         executor: Tasks,
         config: BasicPayloadJobGeneratorConfig,
         builder: Builder,
-        ensure_only_one_payload: bool,
     ) -> Self {
         Self {
             client,
             executor,
+            payload_task_guard: PayloadTaskGuard::new(3), // TODO: use configured value
             _config: config,
             builder,
-            ensure_only_one_payload,
-            last_payload: Arc::new(Mutex::new(CancellationToken::new())),
+            pre_cached: None,
         }
+    }
+
+    /// Returns a reference to the tasks type
+    pub const fn tasks(&self) -> &Tasks {
+        &self.executor
+    }
+
+    /// Returns the pre-cached reads for the given parent header if it matches the cached state's
+    /// block.
+    fn maybe_pre_cached(&self, parent: B256) -> Option<CachedReads> {
+        self.pre_cached
+            .as_ref()
+            .filter(|pc| pc.block == parent)
+            .map(|pc| pc.cached.clone())
     }
 }
 
@@ -117,33 +178,17 @@ where
         &self,
         attributes: <Builder as PayloadBuilder>::Attributes,
     ) -> Result<Self::Job, PayloadBuilderError> {
-        let cancel_token = if self.ensure_only_one_payload {
-            // Cancel existing payload
-            {
-                let last_payload = self.last_payload.lock().unwrap();
-                last_payload.cancel();
-            }
-
-            // Create and set new cancellation token with a fresh lock
-            let cancel_token = CancellationToken::new();
-            {
-                let mut last_payload = self.last_payload.lock().unwrap();
-                *last_payload = cancel_token.clone();
-            }
-            cancel_token
-        } else {
-            CancellationToken::new()
-        };
-
         let parent_header = if attributes.parent().is_zero() {
             // use latest block if parent is zero: genesis block
             self.client
-                .latest_header()?
+                .latest_header()
+                .map_err(PayloadBuilderError::from)?
                 .ok_or_else(|| PayloadBuilderError::MissingParentBlock(attributes.parent()))?
         } else {
             self.client
-                .sealed_header_by_hash(attributes.parent())?
-                .ok_or_else(|| PayloadBuilderError::MissingParentBlock(attributes.parent()))?
+                .sealed_header_by_hash(attributes.parent())
+                .map_err(PayloadBuilderError::from)?
+                .ok_or_else(|| PayloadBuilderError::MissingParentHeader(attributes.parent()))?
         };
 
         info!("Spawn block building job");
@@ -155,19 +200,25 @@ where
         // Adding 0.5 seconds as wiggle room since block times are shorter here.
         // TODO: A better long-term solution would be to implement cancellation logic
         // that cancels existing jobs when receiving new block building requests.
-        let deadline = job_deadline(attributes.timestamp()) + Duration::from_millis(500);
-
-        let deadline = Box::pin(tokio::time::sleep(deadline));
         let config = PayloadConfig::new(Arc::new(parent_header.clone()), attributes);
+
+        let until = job_deadline(config.attributes.timestamp()) + Duration::from_millis(500);
+        let deadline = Box::pin(tokio::time::sleep_until(until));
+
+        let cached_reads = self.maybe_pre_cached(parent_header.hash());
 
         let mut job = BlockPayloadJob {
             executor: self.executor.clone(),
             builder: self.builder.clone(),
             config,
-            cell: BlockCell::new(),
-            cancel: cancel_token,
             deadline,
-            build_complete: None,
+            // ticks immediately
+            interval: tokio::time::interval(Duration::from_secs(1)), // TODO: use configured value
+            best_payload: PayloadState::Missing,
+            pending_block: None,
+            cached_reads,
+            payload_task_guard: self.payload_task_guard.clone(),
+            metrics: Default::default(),
         };
 
         job.spawn_build_job();
@@ -181,25 +232,38 @@ use std::{
     task::{Context, Poll},
 };
 
+use crate::metrics::PayloadBuilderMetrics;
+
 /// A [PayloadJob] that builds empty blocks.
 pub struct BlockPayloadJob<Tasks, Builder>
 where
     Builder: PayloadBuilder,
 {
     /// The configuration for how the payload will be created.
-    pub(crate) config: PayloadConfig<Builder::Attributes, HeaderForPayload<Builder::BuiltPayload>>,
+    config: PayloadConfig<Builder::Attributes, HeaderForPayload<Builder::BuiltPayload>>,
     /// How to spawn building tasks
-    pub(crate) executor: Tasks,
+    executor: Tasks,
+    /// The deadline when this job should resolve.
+    deadline: Pin<Box<Sleep>>,
+    /// The interval at which the job should build a new payload after the last.
+    interval: Interval,
+    /// The best payload so far and its state.
+    best_payload: PayloadState<Builder::BuiltPayload>,
+    /// Receiver for the block that is currently being built.
+    pending_block: Option<PendingPayload<Builder::BuiltPayload>>,
+    /// Restricts how many generator tasks can be executed at once.
+    payload_task_guard: PayloadTaskGuard,
+    /// Caches all disk reads for the state the new payloads builds on
+    ///
+    /// This is used to avoid reading the same state over and over again when new attempts are
+    /// triggered, because during the building process we'll repeatedly execute the transactions.
+    cached_reads: Option<CachedReads>,
+    /// metrics for this type
+    metrics: PayloadBuilderMetrics,
     /// The type responsible for building payloads.
     ///
-    /// See [PayloadBuilder]
-    pub(crate) builder: Builder,
-    /// The cell that holds the built payload.
-    pub(crate) cell: BlockCell<Builder::BuiltPayload>,
-    /// Cancellation token for the running job
-    pub(crate) cancel: CancellationToken,
-    pub(crate) deadline: Pin<Box<Sleep>>, // Add deadline
-    pub(crate) build_complete: Option<oneshot::Receiver<Result<(), PayloadBuilderError>>>,
+    /// See [`PayloadBuilder`]
+    builder: Builder,
 }
 
 impl<Tasks, Builder> PayloadJob for BlockPayloadJob<Tasks, Builder>
@@ -210,11 +274,22 @@ where
     Builder::BuiltPayload: Unpin + Clone,
 {
     type PayloadAttributes = Builder::Attributes;
-    type ResolvePayloadFuture = ResolvePayload<Self::BuiltPayload>;
+    type ResolvePayloadFuture = ResolveBestPayload<Self::BuiltPayload>;
     type BuiltPayload = Builder::BuiltPayload;
 
     fn best_payload(&self) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        unimplemented!()
+        if let Some(payload) = self.best_payload.payload() {
+            Ok(payload.clone())
+        } else {
+            // No payload has been built yet, but we need to return something that the CL then
+            // can deliver, so we need to return an empty payload.
+            //
+            // Note: it is assumed that this is unlikely to happen, as the payload job is
+            // started right away and the first full block should have been
+            // built by the time CL is requesting the payload.
+            self.metrics.inc_requested_empty_payload();
+            Err(PayloadBuilderError::MissingPayload)
+        }
     }
 
     fn payload_attributes(&self) -> Result<Self::PayloadAttributes, PayloadBuilderError> {
@@ -225,13 +300,26 @@ where
         &mut self,
         kind: PayloadKind,
     ) -> (Self::ResolvePayloadFuture, KeepPayloadJobAlive) {
-        tracing::info!("Resolve kind {:?}", kind);
+        let best_payload = self.best_payload.payload().cloned();
+        if best_payload.is_none() && self.pending_block.is_none() {
+            // ensure we have a job scheduled if we don't have a best payload yet and none is active
+            self.spawn_build_job();
+        }
 
-        // check if self.cell has a payload
-        self.cancel.cancel();
+        let maybe_better = self.pending_block.take();
+        let empty_payload = None;
 
-        let resolve_future = ResolvePayload::new(self.cell.wait_for_value());
-        (resolve_future, KeepPayloadJobAlive::No)
+        if best_payload.is_none() {
+            info!(target: "payload_builder", id=%self.config.payload_id(), "no best payload yet to resolve");
+        }
+
+        let fut = ResolveBestPayload {
+            best_payload,
+            maybe_better,
+            empty_payload: empty_payload.filter(|_| kind != PayloadKind::WaitForPending),
+        };
+
+        (fut, KeepPayloadJobAlive::No)
     }
 }
 
@@ -241,7 +329,9 @@ pub struct BuildArguments<Attributes, Payload: BuiltPayload> {
     /// How to configure the payload.
     pub config: PayloadConfig<Attributes, HeaderTy<Payload::Primitives>>,
     /// A marker that can be used to cancel the job.
-    pub cancel: CancellationToken,
+    pub cancel: CancelOnDrop,
+    /// The best payload achieved so far.
+    pub best_payload: Option<Payload>,
 }
 
 /// A [PayloadJob] is a future that's being polled by the `PayloadBuilderService`
@@ -253,24 +343,30 @@ where
     Builder::BuiltPayload: Unpin + Clone,
 {
     pub fn spawn_build_job(&mut self) {
-        let builder = self.builder.clone();
-        let payload_config = self.config.clone();
-        let cell = self.cell.clone();
-        let cancel = self.cancel.clone();
-
+        trace!(target: "payload_builder", id = %self.config.payload_id(), "spawn new payload build task");
         let (tx, rx) = oneshot::channel();
-        self.build_complete = Some(rx);
-
+        let cancel = CancelOnDrop::default();
+        let _cancel = cancel.clone();
+        let guard = self.payload_task_guard.clone();
+        let payload_config = self.config.clone();
+        let best_payload = self.best_payload.payload().cloned();
+        self.metrics.inc_initiated_payload_builds();
+        let cached_reads = self.cached_reads.take().unwrap_or_default();
+        let builder = self.builder.clone();
         self.executor.spawn_blocking(Box::pin(async move {
+            // acquire the permit for executing the task
+            let _permit = guard.acquire().await;
             let args = BuildArguments {
-                cached_reads: Default::default(),
+                cached_reads,
                 config: payload_config,
                 cancel,
+                best_payload,
             };
-
-            let result = builder.try_build(args, cell);
+            let result = builder.try_build(args);
             let _ = tx.send(result);
         }));
+
+        self.pending_block = Some(PendingPayload::new(_cancel, rx));
     }
 }
 
@@ -288,17 +384,54 @@ where
         tracing::trace!("Polling job");
         let this = self.get_mut();
 
-        // Check if deadline is reached
+        // check if the deadline is reached
         if this.deadline.as_mut().poll(cx).is_ready() {
-            this.cancel.cancel();
-            tracing::debug!("Deadline reached");
+            trace!(target: "payload_builder", "payload building deadline reached");
             return Poll::Ready(Ok(()));
         }
 
-        // If cancelled via resolve_kind()
-        if this.cancel.is_cancelled() {
-            tracing::debug!("Job cancelled");
-            return Poll::Ready(Ok(()));
+        // check if the interval is reached
+        while this.interval.poll_tick(cx).is_ready() {
+            // start a new job if there is no pending block, we haven't reached the deadline,
+            // and the payload isn't frozen
+            if this.pending_block.is_none() && !this.best_payload.is_frozen() {
+                this.spawn_build_job();
+            }
+        }
+
+        // poll the pending block
+        if let Some(mut fut) = this.pending_block.take() {
+            match fut.poll_unpin(cx) {
+                Poll::Ready(Ok(outcome)) => match outcome {
+                    BuildOutcome::Better {
+                        payload,
+                        cached_reads,
+                    } => {
+                        this.cached_reads = Some(cached_reads);
+                        debug!(target: "payload_builder", value = %payload.fees(), "built better payload");
+                        this.best_payload = PayloadState::Best(payload);
+                    }
+                    BuildOutcome::Freeze(payload) => {
+                        debug!(target: "payload_builder", "payload frozen, no further building will occur");
+                        this.best_payload = PayloadState::Frozen(payload);
+                    }
+                    BuildOutcome::Aborted { fees, cached_reads } => {
+                        this.cached_reads = Some(cached_reads);
+                        trace!(target: "payload_builder", worse_fees = %fees, "skipped payload build of worse block");
+                    }
+                    BuildOutcome::Cancelled => {
+                        unreachable!("the cancel signal never fired")
+                    }
+                },
+                Poll::Ready(Err(error)) => {
+                    // job failed, but we simply try again next interval
+                    debug!(target: "payload_builder", %error, "payload build attempt failed");
+                    this.metrics.inc_failed_payload_builds();
+                }
+                Poll::Pending => {
+                    this.pending_block = Some(fut);
+                }
+            }
         }
 
         Poll::Pending
@@ -389,7 +522,7 @@ impl<T: Clone> Default for BlockCell<T> {
     }
 }
 
-fn job_deadline(unix_timestamp_secs: u64) -> std::time::Duration {
+fn job_deadline(unix_timestamp_secs: u64) -> Instant {
     let unix_now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -400,9 +533,9 @@ fn job_deadline(unix_timestamp_secs: u64) -> std::time::Duration {
 
     if duration_until == 0 {
         // Enforce a minimum block time of 1 second by rounding up any duration less than 1 second
-        Duration::from_secs(1)
+        Instant::now() + Duration::from_secs(1)
     } else {
-        Duration::from_secs(duration_until)
+        Instant::now() + Duration::from_secs(duration_until)
     }
 }
 
@@ -558,14 +691,13 @@ mod tests {
         fn try_build(
             &self,
             args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
-            _best_payload: BlockCell<Self::BuiltPayload>,
-        ) -> Result<(), PayloadBuilderError> {
+        ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
             self.new_event(BlockEvent::Started);
 
             loop {
                 if args.cancel.is_cancelled() {
                     self.new_event(BlockEvent::Cancelled);
-                    return Ok(());
+                    return Ok(BuildOutcome::Cancelled);
                 }
 
                 // Small sleep to prevent tight loop
@@ -577,23 +709,28 @@ mod tests {
     #[tokio::test]
     async fn test_job_deadline() {
         // Test future deadline
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-        let future_timestamp = now + Duration::from_secs(2);
-        // 2 seconds from now
-        let deadline = job_deadline(future_timestamp.as_secs());
-        assert!(deadline <= Duration::from_secs(2));
-        assert!(deadline > Duration::from_secs(0));
+        let now = Instant::now();
+        // Get current Unix time
+        let current_unix_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // 2 seconds in the future
+        let future_unix_timestamp = current_unix_time + 2;
+        let deadline = job_deadline(future_unix_timestamp);
+        assert!(deadline <= now + Duration::from_secs(2));
+        assert!(deadline > now);
 
         // Test past deadline
-        let past_timestamp = now - Duration::from_secs(10);
-        let deadline = job_deadline(past_timestamp.as_secs());
+        let past_unix_timestamp = current_unix_time - 10;
+        let deadline = job_deadline(past_unix_timestamp);
         // Should default to 1 second when timestamp is in the past
-        assert_eq!(deadline, Duration::from_secs(1));
+        assert_eq!(deadline, now + Duration::from_secs(1));
 
         // Test current timestamp
-        let deadline = job_deadline(now.as_secs());
+        let deadline = job_deadline(current_unix_time);
         // Should use 1 second when timestamp is current
-        assert_eq!(deadline, Duration::from_secs(1));
+        assert_eq!(deadline, now + Duration::from_secs(1));
     }
 
     #[tokio::test]
@@ -622,7 +759,6 @@ mod tests {
             executor,
             config,
             builder.clone(),
-            false,
         );
 
         // this is not nice but necessary

--- a/crates/op-rbuilder/src/integration/integration_test.rs
+++ b/crates/op-rbuilder/src/integration/integration_test.rs
@@ -3,23 +3,13 @@ mod tests {
     use crate::{
         integration::{op_rbuilder::OpRbuilderConfig, op_reth::OpRethConfig, IntegrationFramework},
         tester::{BlockGenerator, EngineApi},
-        tx_signer::Signer,
     };
-    use alloy_consensus::{Transaction, TxEip1559};
+    use alloy_consensus::Transaction;
     use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718};
     use alloy_primitives::hex;
     use alloy_provider::{Identity, Provider, ProviderBuilder};
-    use alloy_rpc_types_eth::BlockTransactionsKind;
-    use futures_util::StreamExt;
-    use op_alloy_consensus::OpTypedTransaction;
     use op_alloy_network::Optimism;
-    use std::{
-        cmp::max,
-        path::PathBuf,
-        sync::{Arc, Mutex},
-        time::Duration,
-    };
-    use tokio_tungstenite::connect_async;
+    use std::{cmp::max, path::PathBuf};
     use uuid::Uuid;
 
     const BUILDER_PRIVATE_KEY: &str =
@@ -102,6 +92,10 @@ mod tests {
     async fn integration_test_revert_protection() -> eyre::Result<()> {
         // This is a simple test using the integration framework to test that the chain
         // produces blocks.
+
+        use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
+
+        use crate::tx_signer::OpSigner;
         let mut framework =
             IntegrationFramework::new("integration_test_revert_protection").unwrap();
 
@@ -150,33 +144,33 @@ mod tests {
         );
         for _ in 0..10 {
             // Get builder's address
-            let known_wallet = Signer::try_from_secret(BUILDER_PRIVATE_KEY.parse()?)?;
+            let known_wallet: OpSigner = OpSigner::try_from_secret(BUILDER_PRIVATE_KEY.parse()?)?;
             let builder_address = known_wallet.address;
             // Get current nonce from chain
             let nonce = provider.get_transaction_count(builder_address).await?;
             // Transaction from builder should succeed
-            let tx_request = OpTypedTransaction::Eip1559(TxEip1559 {
-                chain_id: 901,
-                nonce,
-                gas_limit: 210000,
-                max_fee_per_gas: base_fee.into(),
+            let tx_request = TransactionRequest {
+                chain_id: Some(901),
+                nonce: Some(nonce),
+                gas: Some(210000),
+                max_fee_per_gas: Some(base_fee.into()),
                 ..Default::default()
-            });
-            let signed_tx = known_wallet.sign_tx(tx_request)?;
+            };
+            let signed_tx = known_wallet.build_and_sign_tx(tx_request)?;
             let known_tx = provider
                 .send_raw_transaction(signed_tx.encoded_2718().as_slice())
                 .await?;
 
             // Create a reverting transaction
-            let tx_request = OpTypedTransaction::Eip1559(TxEip1559 {
-                chain_id: 901,
-                nonce: nonce + 1,
-                gas_limit: 300000,
-                max_fee_per_gas: base_fee.into(),
-                input: hex!("60006000fd").into(), // PUSH1 0x00 PUSH1 0x00 REVERT
+            let tx_request = TransactionRequest {
+                chain_id: Some(901),
+                nonce: Some(nonce + 1),
+                gas: Some(300000),
+                max_fee_per_gas: Some(base_fee.into()),
+                input: TransactionInput::new(hex!("60006000fd").into()), // PUSH1 0x00 PUSH1 0x00 REVERT
                 ..Default::default()
-            });
-            let signed_tx = known_wallet.sign_tx(tx_request)?;
+            };
+            let signed_tx = known_wallet.build_and_sign_tx(tx_request)?;
             let reverting_tx = provider
                 .send_raw_transaction(signed_tx.encoded_2718().as_slice())
                 .await?;
@@ -227,6 +221,12 @@ mod tests {
     #[cfg(not(feature = "flashblocks"))]
     async fn integration_test_fee_priority_ordering() -> eyre::Result<()> {
         // This test validates that transactions are ordered by fee priority in blocks
+
+        use alloy_rpc_types_eth::TransactionRequest;
+        use reth_optimism_primitives::OpPrimitives;
+        use reth_primitives::{Recovered, TxTy};
+
+        use crate::tx_signer::OpSigner;
         let mut framework =
             IntegrationFramework::new("integration_test_fee_priority_ordering").unwrap();
 
@@ -277,11 +277,11 @@ mod tests {
         // Create transactions with increasing fee values
         let priority_fees: [u128; 5] = [1, 3, 5, 2, 4]; // Deliberately not in order
         let signers = vec![
-            Signer::random(),
-            Signer::random(),
-            Signer::random(),
-            Signer::random(),
-            Signer::random(),
+            OpSigner::random(),
+            OpSigner::random(),
+            OpSigner::random(),
+            OpSigner::random(),
+            OpSigner::random(),
         ];
         let mut txs = Vec::new();
 
@@ -294,15 +294,16 @@ mod tests {
 
         // Send transactions in non-optimal fee order
         for (i, priority_fee) in priority_fees.iter().enumerate() {
-            let tx_request = OpTypedTransaction::Eip1559(TxEip1559 {
-                chain_id: 901,
-                nonce: 1,
-                gas_limit: 210000,
-                max_fee_per_gas: base_fee as u128 + *priority_fee,
-                max_priority_fee_per_gas: *priority_fee,
+            let tx_request = TransactionRequest {
+                chain_id: Some(901),
+                nonce: Some(1),
+                gas: Some(210000),
+                max_fee_per_gas: Some(base_fee as u128 + *priority_fee),
+                max_priority_fee_per_gas: Some(*priority_fee),
                 ..Default::default()
-            });
-            let signed_tx = signers[i].sign_tx(tx_request)?;
+            };
+            let signed_tx: Recovered<TxTy<OpPrimitives>> =
+                signers[i].build_and_sign_tx(tx_request)?;
             let tx = provider
                 .send_raw_transaction(signed_tx.encoded_2718().as_slice())
                 .await?;

--- a/crates/op-rbuilder/src/integration/integration_test.rs
+++ b/crates/op-rbuilder/src/integration/integration_test.rs
@@ -93,6 +93,7 @@ mod tests {
         // This is a simple test using the integration framework to test that the chain
         // produces blocks.
 
+        use alloy_primitives::{Address, TxKind};
         use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
 
         use crate::tx_signer::OpSigner;
@@ -154,6 +155,8 @@ mod tests {
                 nonce: Some(nonce),
                 gas: Some(210000),
                 max_fee_per_gas: Some(base_fee.into()),
+                max_priority_fee_per_gas: Some(0),
+                to: Some(TxKind::Call(Address::ZERO)),
                 ..Default::default()
             };
             let signed_tx = known_wallet.build_and_sign_tx(tx_request)?;
@@ -167,6 +170,8 @@ mod tests {
                 nonce: Some(nonce + 1),
                 gas: Some(300000),
                 max_fee_per_gas: Some(base_fee.into()),
+                max_priority_fee_per_gas: Some(0),
+                to: Some(TxKind::Create),
                 input: TransactionInput::new(hex!("60006000fd").into()), // PUSH1 0x00 PUSH1 0x00 REVERT
                 ..Default::default()
             };
@@ -198,7 +203,8 @@ mod tests {
                     .transactions
                     .hashes()
                     .any(|hash| hash == *reverting_tx.tx_hash()),
-                "reverted transaction unexpectedly included in block"
+                "reverted transaction {:?} unexpectedly included in block",
+                reverting_tx.tx_hash()
             );
             for hash in block.transactions.hashes() {
                 let receipt = provider
@@ -222,6 +228,7 @@ mod tests {
     async fn integration_test_fee_priority_ordering() -> eyre::Result<()> {
         // This test validates that transactions are ordered by fee priority in blocks
 
+        use alloy_primitives::{Address, TxKind};
         use alloy_rpc_types_eth::TransactionRequest;
         use reth_optimism_primitives::OpPrimitives;
         use reth_primitives::{Recovered, TxTy};
@@ -300,6 +307,7 @@ mod tests {
                 gas: Some(210000),
                 max_fee_per_gas: Some(base_fee as u128 + *priority_fee),
                 max_priority_fee_per_gas: Some(*priority_fee),
+                to: Some(TxKind::Call(Address::ZERO)),
                 ..Default::default()
             };
             let signed_tx: Recovered<TxTy<OpPrimitives>> =

--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use executor::OpRbuilderExecutorBuilder;
 use monitoring::Monitoring;
 use reth::providers::CanonStateSubscriptions;
 use reth_optimism_cli::{chainspec::OpChainSpecParser, Cli};
@@ -7,12 +8,12 @@ use reth_optimism_node::OpNode;
 
 #[cfg(feature = "flashblocks")]
 use payload_builder::CustomOpPayloadBuilder;
-#[cfg(not(feature = "flashblocks"))]
 use payload_builder_vanilla::CustomOpPayloadBuilder;
 use reth_transaction_pool::TransactionPool;
 
 /// CLI argument parsing.
 pub mod args;
+mod executor;
 pub mod generator;
 #[cfg(test)]
 mod integration;
@@ -37,14 +38,22 @@ fn main() {
             let op_node = OpNode::new(rollup_args.clone());
             let handle = builder
                 .with_types::<OpNode>()
-                .with_components(op_node.components().payload(CustomOpPayloadBuilder::new(
-                    builder_args.builder_signer,
-                    builder_args.flashblocks_ws_url,
-                    builder_args.chain_block_time,
-                    builder_args.flashblock_block_time,
-                    builder_args.supervisor_url,
-                    builder_args.supervisor_safety_level,
-                )))
+                .with_components(
+                    op_node
+                        .components()
+                        .payload(
+                            CustomOpPayloadBuilder::new(
+                                builder_args.builder_signer,
+                                builder_args.flashblocks_ws_url,
+                                builder_args.chain_block_time,
+                                builder_args.flashblock_block_time,
+                                builder_args.supervisor_url,
+                                builder_args.supervisor_safety_level,
+                            )
+                            .with_da_config(op_node.da_config.clone()),
+                        )
+                        .executor(OpRbuilderExecutorBuilder::default()),
+                )
                 .with_add_ons(
                     OpAddOnsBuilder::default()
                         .with_sequencer(rollup_args.sequencer_http.clone())
@@ -53,7 +62,7 @@ fn main() {
                 )
                 .on_node_started(move |ctx| {
                     let new_canonical_blocks = ctx.provider().canonical_state_stream();
-                    let builder_signer = builder_args.builder_signer;
+                    // let builder_signer = builder_args.builder_signer;
 
                     if builder_args.log_pool_transactions {
                         tracing::info!("Logging pool transactions");
@@ -68,7 +77,7 @@ fn main() {
                     ctx.task_executor.spawn_critical(
                         "monitoring",
                         Box::pin(async move {
-                            let monitoring = Monitoring::new(builder_signer);
+                            let monitoring = Monitoring::new(builder_args.builder_signer);
                             let _ = monitoring.run_with_stream(new_canonical_blocks).await;
                         }),
                     );

--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -18,8 +18,6 @@ pub struct OpRBuilderMetrics {
     pub total_block_built_duration: Histogram,
     /// Duration of fetching transactions from the pool
     pub transaction_pool_fetch_duration: Histogram,
-    /// Duration of state root calculation
-    pub state_root_calculation_duration: Histogram,
     /// Duration of sequencer transaction execution
     pub sequencer_tx_duration: Histogram,
     /// Duration of state merge transitions
@@ -93,5 +91,31 @@ impl OpRBuilderMetrics {
 
     pub fn inc_num_cross_chain_tx_server_error(&self) {
         self.num_cross_chain_tx_server_error.increment(1);
+    }
+}
+
+/// Transaction pool metrics
+#[derive(Metrics)]
+#[metrics(scope = "payloads")]
+pub(crate) struct PayloadBuilderMetrics {
+    /// Total number of times an empty payload was returned because a built one was not ready.
+    pub(crate) requested_empty_payload: Counter,
+    /// Total number of initiated payload build attempts.
+    pub(crate) initiated_payload_builds: Counter,
+    /// Total number of failed payload build attempts.
+    pub(crate) failed_payload_builds: Counter,
+}
+
+impl PayloadBuilderMetrics {
+    pub(crate) fn inc_requested_empty_payload(&self) {
+        self.requested_empty_payload.increment(1);
+    }
+
+    pub(crate) fn inc_initiated_payload_builds(&self) {
+        self.initiated_payload_builds.increment(1);
+    }
+
+    pub(crate) fn inc_failed_payload_builds(&self) {
+        self.failed_payload_builds.increment(1);
     }
 }

--- a/crates/op-rbuilder/src/monitoring.rs
+++ b/crates/op-rbuilder/src/monitoring.rs
@@ -10,18 +10,18 @@ use reth_primitives::{Block, RecoveredBlock};
 use reth_provider::{Chain, ExecutionOutcome};
 use tracing::{info, warn};
 
-use crate::{metrics::OpRBuilderMetrics, tx_signer::Signer};
+use crate::{metrics::OpRBuilderMetrics, tx_signer::OpSigner};
 
 const OP_BUILDER_TX_PREFIX: &[u8] = b"Block Number:";
 
 pub struct Monitoring {
-    builder_signer: Option<Signer>,
+    builder_signer: Option<OpSigner>,
     metrics: OpRBuilderMetrics,
     execution_outcome: ExecutionOutcome<OpReceipt>,
 }
 
 impl Monitoring {
-    pub fn new(builder_signer: Option<Signer>) -> Self {
+    pub fn new(builder_signer: Option<OpSigner>) -> Self {
         Self {
             builder_signer,
             metrics: Default::default(),
@@ -140,7 +140,7 @@ impl Monitoring {
 /// Decode chain of blocks and filter list to builder txs
 fn decode_chain_into_builder_txs(
     chain: &Chain<OpPrimitives>,
-    builder_signer: Option<Signer>,
+    builder_signer: Option<OpSigner>,
 ) -> Vec<(&RecoveredBlock<Block<OpTransactionSigned>>, bool)> {
     chain
         // Get all blocks and receipts
@@ -186,7 +186,7 @@ fn decode_chain_into_reverted_txs(chain: &Chain<OpPrimitives>) -> usize {
 /// Decode state and find the last builder balance
 fn decode_state_into_builder_balance(
     execution_outcome: &ExecutionOutcome<OpReceipt>,
-    builder_signer: Option<Signer>,
+    builder_signer: Option<OpSigner>,
 ) -> Option<U256> {
     builder_signer.and_then(|signer| {
         execution_outcome

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -1,4 +1,5 @@
 use crate::{
+    executor::OpRbuilderEvmConfig,
     generator::{BlockPayloadJobGenerator, BuildArguments, PayloadBuilder, PayloadBuilderBuilder},
     metrics::OpRBuilderMetrics,
     primitives::{reth::ExecutionInfo, supervisor::SupervisorValidator},
@@ -34,7 +35,7 @@ use reth_node_builder::{
     BuilderContext,
 };
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
+use reth_optimism_evm::OpNextBlockEnvAttributes;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::{txpool::OpPooledTx, OpEngineTypes};
 use reth_optimism_payload_builder::config::{OpBuilderConfig, OpDAConfig};
@@ -157,14 +158,14 @@ where
     Txs: OpPayloadTransactions<Pool::Transaction>,
     <Pool as TransactionPool>::Transaction: OpPooledTx,
 {
-    type PayloadBuilder = OpPayloadBuilderVanilla<Pool, Node::Provider, OpEvmConfig, Txs>;
+    type PayloadBuilder = OpPayloadBuilderVanilla<Pool, Node::Provider, OpRbuilderEvmConfig, Txs>;
 
     async fn build_payload_builder(
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
     ) -> eyre::Result<Self::PayloadBuilder> {
-        self.build(OpEvmConfig::optimism(ctx.chain_spec()), ctx, pool)
+        self.build(OpRbuilderEvmConfig::optimism(ctx.chain_spec()), ctx, pool)
     }
 }
 

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -1,120 +1,86 @@
 use crate::{
-    generator::{BlockCell, BlockPayloadJobGenerator, BuildArguments, PayloadBuilder},
+    generator::{BlockPayloadJobGenerator, BuildArguments, PayloadBuilder, PayloadBuilderBuilder},
     metrics::OpRBuilderMetrics,
-    primitives::{
-        reth::{ExecutedPayload, ExecutionInfo},
-        supervisor::SupervisorValidator,
-    },
-    tx_signer::Signer,
+    primitives::{reth::ExecutionInfo, supervisor::SupervisorValidator},
+    tx_signer::OpSigner,
 };
-use alloy_consensus::{
-    constants::EMPTY_WITHDRAWALS, transaction::Recovered, Eip658Value, Header, Transaction,
-    TxEip1559, Typed2718, EMPTY_OMMER_ROOT_HASH,
-};
-use alloy_eips::merge::BEACON_NONCE;
-use alloy_op_evm::block::receipt_builder::OpReceiptBuilder;
-use alloy_primitives::{private::alloy_rlp::Encodable, Address, Bytes, TxHash, TxKind, B256, U256};
+use alloy_consensus::transaction::Recovered;
+use alloy_consensus::{Header, Transaction, Typed2718};
+use alloy_primitives::private::alloy_rlp::Encodable;
+use alloy_primitives::{Address, Bytes, TxHash, TxKind, B256, U256};
 use alloy_rpc_types_engine::PayloadId;
-use alloy_rpc_types_eth::Withdrawals;
+use alloy_rpc_types_eth::TransactionRequest;
 use jsonrpsee::http_client::HttpClientBuilder;
 use kona_interop::{ExecutingDescriptor, SafetyLevel};
 use kona_rpc::{InteropTxValidator, InteropTxValidatorError};
-use op_alloy_consensus::{OpDepositReceipt, OpTypedTransaction};
-use op_revm::OpSpecId;
-use reth::{
-    builder::{
-        components::{PayloadBuilderBuilder, PayloadServiceBuilder},
-        node::FullNodeTypes,
-        BuilderContext,
-    },
-    core::primitives::InMemorySize,
-    payload::PayloadBuilderHandle,
-};
+use reth::builder::components::PayloadServiceBuilder;
+use reth::core::primitives::InMemorySize;
+use reth::payload::PayloadBuilderHandle;
 use reth_basic_payload_builder::{
-    BasicPayloadJobGeneratorConfig, BuildOutcome, BuildOutcomeKind, PayloadConfig,
+    is_better_payload, BasicPayloadJobGeneratorConfig, BuildOutcome, BuildOutcomeKind,
+    PayloadConfig,
 };
 use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates};
-use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::{
-    env::EvmEnv, eth::receipt_builder::ReceiptBuilderCtx, execute::BlockBuilder, ConfigureEvm,
-    Database, Evm, EvmError, InvalidTxError,
+    block::{BlockExecutionError, BlockValidationError},
+    execute::{BlockBuilder, BlockBuilderOutcome},
+    ConfigureEvm, Database, Evm,
 };
 use reth_execution_types::ExecutionOutcome;
-use reth_node_api::{NodePrimitives, NodeTypesWithEngine, TxTy};
+use reth_node_api::{NodePrimitives, PrimitivesTy, TxTy};
+use reth_node_builder::{
+    node::{FullNodeTypes, NodeTypesWithEngine},
+    BuilderContext,
+};
 use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_consensus::calculate_receipt_root_no_memo_optimism;
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_forks::OpHardforks;
-use reth_optimism_node::OpEngineTypes;
+use reth_optimism_node::{txpool::OpPooledTx, OpEngineTypes};
+use reth_optimism_payload_builder::config::{OpBuilderConfig, OpDAConfig};
+use reth_optimism_payload_builder::OpPayloadPrimitives;
 use reth_optimism_payload_builder::{
-    config::{OpBuilderConfig, OpDAConfig},
     error::OpPayloadBuilderError,
     payload::{OpBuiltPayload, OpPayloadBuilderAttributes},
-    OpPayloadPrimitives,
 };
-use reth_optimism_primitives::{
-    OpPrimitives, OpReceipt, OpTransactionSigned, ADDRESS_L2_TO_L1_MESSAGE_PASSER,
-};
-use reth_optimism_txpool::OpPooledTx;
+use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_payload_builder::PayloadBuilderService;
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::PayloadBuilderAttributes;
-use reth_payload_util::{BestPayloadTransactions, PayloadTransactions};
+use reth_payload_util::BestPayloadTransactions;
+use reth_payload_util::PayloadTransactions;
 use reth_primitives::{BlockBody, SealedHeader};
-use reth_primitives_traits::{proofs, Block as _, RecoveredBlock, SignedTransaction};
-use reth_provider::{
-    CanonStateSubscriptions, HashedPostStateProvider, ProviderError, StateProviderFactory,
-    StateRootProvider, StorageRootProvider,
-};
-use reth_revm::database::StateProviderDatabase;
-use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
-use revm::{
-    context::{result::ResultAndState, Block as _},
-    database::{states::bundle_state::BundleRetention, State},
-    DatabaseCommit,
-};
+use reth_primitives_traits::{SignedTransaction, TxTy as PrimitivesTxTy};
+use reth_provider::{CanonStateSubscriptions, StateProvider};
+use reth_provider::{ProviderError, StateProviderFactory};
+use reth_revm::{cancelled::CancelOnDrop, database::StateProviderDatabase, State};
+use reth_transaction_pool::BestTransactionsAttributes;
+use reth_transaction_pool::PoolTransaction;
+use reth_transaction_pool::TransactionPool;
+use revm::context::{Block, BlockEnv};
 use std::{sync::Arc, time::Instant};
-use tokio_util::sync::CancellationToken;
-use tracing::*;
+use tracing::{error, info, trace, warn};
 use url::Url;
 
 #[derive(Debug, Clone, Default)]
-#[non_exhaustive]
-pub struct CustomOpPayloadBuilder {
-    builder_signer: Option<Signer>,
-    #[cfg(feature = "flashblocks")]
-    flashblocks_ws_url: String,
-    #[cfg(feature = "flashblocks")]
-    chain_block_time: u64,
-    #[cfg(feature = "flashblocks")]
-    flashblock_block_time: u64,
-    supervisor_url: Option<Url>,
-    supervisor_safety_level: Option<String>,
+pub struct CustomOpPayloadBuilder<Txs = ()> {
+    /// The type responsible for yielding the best transactions for the payload if mempool
+    /// transactions are allowed.
+    pub best_transactions: Txs,
+    /// This data availability configuration specifies constraints for the payload builder
+    /// when assembling payloads
+    pub da_config: OpDAConfig,
+    /// The builder's signer key to use for an end of block tx
+    pub builder_signer: Option<OpSigner>,
+    /// The URL of the supervisor for validation
+    pub supervisor_url: Option<Url>,
+    /// The safety level for the supervisor
+    pub supervisor_safety_level: Option<String>,
 }
 
 impl CustomOpPayloadBuilder {
-    #[cfg(feature = "flashblocks")]
     pub fn new(
-        builder_signer: Option<Signer>,
-        flashblocks_ws_url: String,
-        chain_block_time: u64,
-        flashblock_block_time: u64,
-        supervisor_url: Option<Url>,
-        supervisor_safety_level: Option<String>,
-    ) -> Self {
-        Self {
-            builder_signer,
-            flashblocks_ws_url,
-            chain_block_time,
-            flashblock_block_time,
-            supervisor_url,
-            supervisor_safety_level,
-        }
-    }
-
-    #[cfg(not(feature = "flashblocks"))]
-    pub fn new(
-        builder_signer: Option<Signer>,
+        builder_signer: Option<OpSigner>,
         _flashblocks_ws_url: String,
         _chain_block_time: u64,
         _flashblock_block_time: u64,
@@ -122,14 +88,61 @@ impl CustomOpPayloadBuilder {
         supervisor_safety_level: Option<String>,
     ) -> Self {
         Self {
+            best_transactions: (),
+            da_config: OpDAConfig::default(),
             builder_signer,
             supervisor_url,
             supervisor_safety_level,
         }
     }
+
+    /// Configure the data availability configuration for the OP payload builder.
+    pub fn with_da_config(mut self, da_config: OpDAConfig) -> Self {
+        self.da_config = da_config;
+        self
+    }
 }
 
-impl<Node, Pool> PayloadBuilderBuilder<Node, Pool> for CustomOpPayloadBuilder
+impl<Txs> CustomOpPayloadBuilder<Txs> {
+    /// A helper method to initialize [`OpPayloadBuilderVanilla`] with the
+    /// given EVM config.
+    pub fn build<Node, Evm, Pool>(
+        self,
+        evm_config: Evm,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+    ) -> eyre::Result<OpPayloadBuilderVanilla<Pool, Node::Provider, Evm, Txs>>
+    where
+        Node: FullNodeTypes<
+            Types: NodeTypesWithEngine<
+                Engine = OpEngineTypes,
+                ChainSpec = OpChainSpec,
+                Primitives = OpPrimitives,
+            >,
+        >,
+        Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
+            + Unpin
+            + 'static,
+        Evm: ConfigureEvm<Primitives = PrimitivesTy<Node::Types>>,
+        Txs: OpPayloadTransactions<Pool::Transaction>,
+    {
+        let payload_builder = OpPayloadBuilderVanilla::with_builder_config(
+            evm_config,
+            self.builder_signer,
+            pool,
+            ctx.provider().clone(),
+            self.supervisor_url.clone(),
+            self.supervisor_safety_level.clone(),
+            OpBuilderConfig {
+                da_config: self.da_config.clone(),
+            },
+        )
+        .with_transactions(self.best_transactions.clone());
+        Ok(payload_builder)
+    }
+}
+
+impl<Node, Pool, Txs> PayloadBuilderBuilder<Node, Pool> for CustomOpPayloadBuilder<Txs>
 where
     Node: FullNodeTypes<
         Types: NodeTypesWithEngine<
@@ -141,23 +154,17 @@ where
     Pool: TransactionPool<Transaction: PoolTransaction<Consensus = TxTy<Node::Types>>>
         + Unpin
         + 'static,
+    Txs: OpPayloadTransactions<Pool::Transaction>,
     <Pool as TransactionPool>::Transaction: OpPooledTx,
 {
-    type PayloadBuilder = OpPayloadBuilderVanilla<Pool, Node::Provider>;
+    type PayloadBuilder = OpPayloadBuilderVanilla<Pool, Node::Provider, OpEvmConfig, Txs>;
 
     async fn build_payload_builder(
         self,
         ctx: &BuilderContext<Node>,
         pool: Pool,
     ) -> eyre::Result<Self::PayloadBuilder> {
-        Ok(OpPayloadBuilderVanilla::new(
-            OpEvmConfig::optimism(ctx.chain_spec()),
-            self.builder_signer,
-            pool,
-            ctx.provider().clone(),
-            self.supervisor_url.clone(),
-            self.supervisor_safety_level.clone(),
-        ))
+        self.build(OpEvmConfig::optimism(ctx.chain_spec()), ctx, pool)
     }
 }
 
@@ -180,7 +187,7 @@ where
         ctx: &BuilderContext<Node>,
         pool: Pool,
     ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypesWithEngine>::Engine>> {
-        tracing::info!("Spawning a custom payload builder");
+        tracing::info!("Spawning a vanilla payload builder service");
         let payload_builder = self.build_payload_builder(ctx, pool).await?;
         let payload_job_config = BasicPayloadJobGeneratorConfig::default();
 
@@ -189,7 +196,6 @@ where
             ctx.task_executor().clone(),
             payload_job_config,
             payload_builder,
-            false,
         );
 
         let (payload_service, payload_builder) =
@@ -198,47 +204,19 @@ where
         ctx.task_executor()
             .spawn_critical("custom payload builder service", Box::pin(payload_service));
 
-        tracing::info!("Custom payload service started");
+        tracing::info!("Vanilla payload builder service started");
 
         Ok(payload_builder)
     }
 }
 
-impl<Pool, Client, Txs> reth_basic_payload_builder::PayloadBuilder
-    for OpPayloadBuilderVanilla<Pool, Client, Txs>
-where
-    Pool: Clone + Send + Sync,
-    Client: Clone + Send + Sync,
-    Txs: Clone + Send + Sync,
-{
-    type Attributes = OpPayloadBuilderAttributes<OpTransactionSigned>;
-    type BuiltPayload = OpBuiltPayload;
-
-    fn try_build(
-        &self,
-        _args: reth_basic_payload_builder::BuildArguments<Self::Attributes, Self::BuiltPayload>,
-    ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
-        unimplemented!()
-    }
-
-    fn build_empty_payload(
-        &self,
-        _config: reth_basic_payload_builder::PayloadConfig<
-            Self::Attributes,
-            reth_basic_payload_builder::HeaderForPayload<Self::BuiltPayload>,
-        >,
-    ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
-        unimplemented!()
-    }
-}
-
 /// Optimism's payload builder
 #[derive(Debug, Clone)]
-pub struct OpPayloadBuilderVanilla<Pool, Client, Txs = ()> {
+pub struct OpPayloadBuilderVanilla<Pool, Client, Evm: ConfigureEvm, Txs = ()> {
     /// The type responsible for creating the evm.
-    pub evm_config: OpEvmConfig,
+    pub evm_config: Evm,
     /// The builder's signer key to use for an end of block tx
-    pub builder_signer: Option<Signer>,
+    pub builder_signer: Option<OpSigner>,
     /// The transaction pool
     pub pool: Pool,
     /// Node client
@@ -256,33 +234,16 @@ pub struct OpPayloadBuilderVanilla<Pool, Client, Txs = ()> {
     pub supervisor_safety_level: SafetyLevel,
 }
 
-impl<Pool, Client> OpPayloadBuilderVanilla<Pool, Client> {
-    /// `OpPayloadBuilder` constructor.
-    pub fn new(
-        evm_config: OpEvmConfig,
-        builder_signer: Option<Signer>,
-        pool: Pool,
-        client: Client,
-        supervisor_url: Option<Url>,
-        supervisor_safety_level: Option<String>,
-    ) -> Self {
-        Self::with_builder_config(
-            evm_config,
-            builder_signer,
-            pool,
-            client,
-            supervisor_url,
-            supervisor_safety_level,
-            Default::default(),
-        )
-    }
-
+impl<Pool, Client, Evm> OpPayloadBuilderVanilla<Pool, Client, Evm>
+where
+    Evm: ConfigureEvm<Primitives = OpPrimitives>,
+{
     // TODO: we will move supervisor_url and supervisor_safety_level into OpBuilderConfig to reduce
     // number of args
     #[allow(clippy::too_many_arguments)]
     pub fn with_builder_config(
-        evm_config: OpEvmConfig,
-        builder_signer: Option<Signer>,
+        evm_config: Evm,
+        builder_signer: Option<OpSigner>,
         pool: Pool,
         client: Client,
         supervisor_url: Option<Url>,
@@ -316,70 +277,90 @@ impl<Pool, Client> OpPayloadBuilderVanilla<Pool, Client> {
     }
 }
 
-impl<Pool, Client, Txs> PayloadBuilder for OpPayloadBuilderVanilla<Pool, Client, Txs>
+impl<Pool, Client, Evm, Txs> OpPayloadBuilderVanilla<Pool, Client, Evm, Txs>
 where
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
-    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = OpTransactionSigned>>,
-    Txs: OpPayloadTransactions<Pool::Transaction>,
+    Evm: ConfigureEvm<Primitives = OpPrimitives>,
 {
-    type Attributes = OpPayloadBuilderAttributes<OpTransactionSigned>;
-    type BuiltPayload = OpBuiltPayload;
-
-    fn try_build(
-        &self,
-        args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
-        best_payload: BlockCell<Self::BuiltPayload>,
-    ) -> Result<(), PayloadBuilderError> {
-        let pool = self.pool.clone();
-        let block_build_start_time = Instant::now();
-
-        match self.build_payload(
-            args,
-            |attrs| {
-                #[allow(clippy::unit_arg)]
-                self.best_transactions
-                    .best_transactions(pool.clone(), attrs)
-            },
-            |hashes| {
-                #[allow(clippy::unit_arg)]
-                self.best_transactions.remove_invalid(pool.clone(), hashes)
-            },
-        )? {
-            BuildOutcome::Better { payload, .. } => {
-                best_payload.set(payload);
-                self.metrics
-                    .total_block_built_duration
-                    .record(block_build_start_time.elapsed());
-                self.metrics.block_built_success.increment(1);
-                Ok(())
-            }
-            BuildOutcome::Freeze(payload) => {
-                best_payload.set(payload);
-                self.metrics
-                    .total_block_built_duration
-                    .record(block_build_start_time.elapsed());
-                Ok(())
-            }
-            BuildOutcome::Cancelled => {
-                tracing::warn!("Payload build cancelled");
-                Err(PayloadBuilderError::MissingPayload)
-            }
-            _ => {
-                tracing::warn!("No better payload found");
-                Err(PayloadBuilderError::MissingPayload)
-            }
+    /// Configures the type responsible for yielding the transactions that should be included in the
+    /// payload.
+    pub fn with_transactions<T>(
+        self,
+        best_transactions: T,
+    ) -> OpPayloadBuilderVanilla<Pool, Client, Evm, T> {
+        let Self {
+            pool,
+            client,
+            evm_config,
+            config,
+            builder_signer,
+            metrics,
+            supervisor_client,
+            supervisor_safety_level,
+            ..
+        } = self;
+        OpPayloadBuilderVanilla {
+            pool,
+            client,
+            evm_config,
+            best_transactions,
+            config,
+            builder_signer,
+            metrics,
+            supervisor_client,
+            supervisor_safety_level,
         }
     }
 }
 
-impl<Pool, Client, T> OpPayloadBuilderVanilla<Pool, Client, T>
+impl<Evm, Pool, Client, N, Txs> PayloadBuilder for OpPayloadBuilderVanilla<Pool, Client, Evm, Txs>
 where
-    Pool: TransactionPool<Transaction: PoolTransaction<Consensus = OpTransactionSigned>>,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks> + Clone,
+    N: OpPayloadPrimitives,
+    Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
+    Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm::Primitives: OpPayloadPrimitives<_TX = OpTransactionSigned>,
+    Txs: OpPayloadTransactions<Pool::Transaction>,
+{
+    type Attributes = OpPayloadBuilderAttributes<N::SignedTx>;
+    type BuiltPayload = OpBuiltPayload<N>;
+
+    fn try_build(
+        &self,
+        args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
+    ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
+        let pool = self.pool.clone();
+        let start = Instant::now();
+        self.build_payload(
+            args,
+            |attrs| {
+                self.best_transactions
+                    .best_transactions(pool.clone(), attrs)
+            },
+            |hashes| self.best_transactions.remove_invalid(pool.clone(), hashes),
+        )
+        .inspect(|_| {
+            self.metrics
+                .total_block_built_duration
+                .record(start.elapsed());
+        })
+    }
+}
+
+impl<Pool, Client, Evm, N, T> OpPayloadBuilderVanilla<Pool, Client, Evm, T>
+where
+    Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: EthChainSpec + OpHardforks>,
+    N: OpPayloadPrimitives,
+    Evm: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm::Primitives: OpPayloadPrimitives<
+        BlockHeader = Header,
+        BlockBody = BlockBody<<Evm::Primitives as NodePrimitives>::SignedTx>,
+        _TX = OpTransactionSigned,
+    >,
 {
     /// Constructs an Optimism payload from the transactions sent via the
     /// Payload attributes by the sequencer. If the `no_tx_pool` argument is passed in
-    /// the payload attributes, the transaction pool will be ignored and the only transactions
+    /// the transaction pool will be ignored and the only transactions
     /// included in the payload will be those sent through the attributes.
     ///
     /// Given build arguments including an Optimism client, transaction pool,
@@ -387,10 +368,10 @@ where
     /// a result indicating success with the payload or an error in case of failure.
     fn build_payload<'a, Txs>(
         &self,
-        args: BuildArguments<OpPayloadBuilderAttributes<OpTransactionSigned>, OpBuiltPayload>,
+        args: BuildArguments<OpPayloadBuilderAttributes<N::SignedTx>, OpBuiltPayload<N>>,
         best: impl FnOnce(BestTransactionsAttributes) -> Txs + Send + Sync + 'a,
-        remove_reverted: impl FnOnce(Vec<TxHash>),
-    ) -> Result<BuildOutcome<OpBuiltPayload>, PayloadBuilderError>
+        remove_reverted: impl FnOnce(Vec<TxHash>) + 'a,
+    ) -> Result<BuildOutcome<OpBuiltPayload<N>>, PayloadBuilderError>
     where
         Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = OpTransactionSigned>>,
     {
@@ -398,45 +379,18 @@ where
             mut cached_reads,
             config,
             cancel,
+            best_payload,
         } = args;
 
         let chain_spec = self.client.chain_spec();
-        let timestamp = config.attributes.timestamp();
-        let block_env_attributes = OpNextBlockEnvAttributes {
-            timestamp,
-            suggested_fee_recipient: config.attributes.suggested_fee_recipient(),
-            prev_randao: config.attributes.prev_randao(),
-            gas_limit: config
-                .attributes
-                .gas_limit
-                .unwrap_or(config.parent_header.gas_limit),
-            parent_beacon_block_root: config
-                .attributes
-                .payload_attributes
-                .parent_beacon_block_root,
-            extra_data: if chain_spec.is_holocene_active_at_timestamp(timestamp) {
-                config
-                    .attributes
-                    .get_holocene_extra_data(chain_spec.base_fee_params_at_timestamp(timestamp))
-                    .map_err(PayloadBuilderError::other)?
-            } else {
-                Default::default()
-            },
-        };
-
-        let evm_env = self
-            .evm_config
-            .next_evm_env(&config.parent_header, &block_env_attributes)
-            .map_err(PayloadBuilderError::other)?;
 
         let ctx = OpPayloadBuilderCtx {
             evm_config: self.evm_config.clone(),
             da_config: self.config.da_config.clone(),
             chain_spec,
             config,
-            evm_env,
-            block_env_attributes,
             cancel,
+            best_payload,
             builder_signer: self.builder_signer,
             metrics: Default::default(),
             supervisor_client: self.supervisor_client.clone(),
@@ -446,21 +400,13 @@ where
         let builder = OpBuilder::new(best, remove_reverted);
 
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
-        let state = StateProviderDatabase::new(state_provider);
+        let state = StateProviderDatabase::new(&state_provider);
 
         if ctx.attributes().no_tx_pool {
-            let db = State::builder()
-                .with_database(state)
-                .with_bundle_update()
-                .build();
-            builder.build(db, ctx)
+            builder.build(state, &state_provider, ctx)
         } else {
             // sequencer mode we can reuse cachedreads from previous runs
-            let db = State::builder()
-                .with_database(cached_reads.as_db_mut(state))
-                .with_bundle_update()
-                .build();
-            builder.build(db, ctx)
+            builder.build(cached_reads.as_db_mut(state), &state_provider, ctx)
         }
         .map(|out| out.with_cached_reads(cached_reads))
     }
@@ -503,18 +449,19 @@ impl<'a, Txs> OpBuilder<'a, Txs> {
 }
 
 impl<Txs> OpBuilder<'_, Txs> {
-    /// Executes the payload and returns the outcome.
-    pub fn execute<ChainSpec, N, DB, P>(
+    /// Builds the payload on top of the state.
+    pub fn build<EvmConfig, ChainSpec, N>(
         self,
-        state: &mut State<DB>,
-        ctx: &OpPayloadBuilderCtx<ChainSpec, N>,
-    ) -> Result<BuildOutcomeKind<ExecutedPayload<N>>, PayloadBuilderError>
+        db: impl Database<Error = ProviderError>,
+        state_provider: impl StateProvider,
+        ctx: OpPayloadBuilderCtx<EvmConfig, ChainSpec>,
+    ) -> Result<BuildOutcomeKind<OpBuiltPayload<N>>, PayloadBuilderError>
     where
-        N: OpPayloadPrimitives<_TX = OpTransactionSigned>,
-        Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
+        EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
         ChainSpec: EthChainSpec + OpHardforks,
-        DB: Database<Error = ProviderError> + AsRef<P>,
-        P: StorageRootProvider,
+        N: OpPayloadPrimitives,
+        EvmConfig::Primitives: OpPayloadPrimitives<_TX = OpTransactionSigned>,
+        Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx>>,
     {
         let Self {
             best,
@@ -522,34 +469,44 @@ impl<Txs> OpBuilder<'_, Txs> {
         } = self;
         info!(target: "payload_builder", id=%ctx.payload_id(), parent_header = ?ctx.parent().hash(), parent_number = ctx.parent().number, "building new payload");
 
+        let mut db = State::builder()
+            .with_database(db)
+            .with_bundle_update()
+            .build();
+
+        let mut builder = ctx.block_builder(&mut db)?;
+
         // 1. apply pre-execution changes
-        ctx.evm_config
-            .builder_for_next_block(state, ctx.parent(), ctx.block_env_attributes.clone())
-            .map_err(PayloadBuilderError::other)?
-            .apply_pre_execution_changes()?;
+        builder.apply_pre_execution_changes().map_err(|err| {
+            warn!(target: "payload_builder", %err, "failed to apply pre-execution changes");
+            PayloadBuilderError::Internal(err.into())
+        })?;
 
         let sequencer_tx_start_time = Instant::now();
 
-        // 3. execute sequencer transactions
-        let mut info = ctx.execute_sequencer_transactions(state)?;
+        // 2. execute sequencer transactions
+        let mut info = ctx.execute_sequencer_transactions(&mut builder)?;
 
         ctx.metrics
             .sequencer_tx_duration
             .record(sequencer_tx_start_time.elapsed());
 
-        // 4. if mem pool transactions are requested we execute them
-
-        // gas reserved for builder tx
-        let message = format!("Block Number: {}", ctx.block_number())
+        // reserve gas for builder tx
+        let message = format!("Block Number: {}", builder.evm_mut().block().number)
             .as_bytes()
             .to_vec();
         let builder_tx_gas = ctx
             .builder_signer()
             .map_or(0, |_| estimate_gas_for_builder_tx(message.clone()));
-        let block_gas_limit = ctx.block_gas_limit() - builder_tx_gas;
+        let block_gas_limit = builder.evm_mut().block().gas_limit - builder_tx_gas;
         // Save some space in the block_da_limit for builder tx
         let builder_tx_da_size = ctx
-            .estimate_builder_tx_da_size(state, builder_tx_gas, message.clone())
+            .estimate_builder_tx_da_size(
+                &state_provider,
+                builder.evm_mut().block().basefee,
+                builder_tx_gas,
+                message.clone(),
+            )
             .unwrap_or(0);
         let block_da_limit = ctx
             .da_config
@@ -564,16 +521,18 @@ impl<Txs> OpBuilder<'_, Txs> {
             );
         }
 
+        // 3. if mem pool transactions are requested we execute them
         if !ctx.attributes().no_tx_pool {
             let best_txs_start_time = Instant::now();
-            let best_txs = best(ctx.best_transaction_attributes());
+            let best_txs = best(ctx.best_transaction_attributes(builder.evm_mut().block()));
             ctx.metrics
                 .transaction_pool_fetch_duration
                 .record(best_txs_start_time.elapsed());
+
             if ctx
                 .execute_best_transactions(
                     &mut info,
-                    state,
+                    &mut builder,
                     best_txs,
                     block_gas_limit,
                     block_da_limit,
@@ -582,171 +541,58 @@ impl<Txs> OpBuilder<'_, Txs> {
             {
                 return Ok(BuildOutcomeKind::Cancelled);
             }
+
+            // check if the new payload is even more valuable
+            if !ctx.is_better_payload(info.total_fees) {
+                // can skip building the block
+                return Ok(BuildOutcomeKind::Aborted {
+                    fees: info.total_fees,
+                });
+            }
         }
 
         // Add builder tx to the block
-        ctx.add_builder_tx(&mut info, state, builder_tx_gas, message);
+        ctx.add_builder_tx(
+            &mut info,
+            &mut builder,
+            &state_provider,
+            builder_tx_gas,
+            message,
+        );
 
         let state_merge_start_time = Instant::now();
-
-        // merge all transitions into bundle state, this would apply the withdrawal balance changes
-        // and 4788 contract call
-        state.merge_transitions(BundleRetention::Reverts);
-
+        let BlockBuilderOutcome {
+            execution_result,
+            hashed_state,
+            trie_updates,
+            block,
+        } = builder.finish(state_provider)?;
         ctx.metrics
             .state_transition_merge_duration
             .record(state_merge_start_time.elapsed());
+
         ctx.metrics
             .payload_num_tx
-            .record(info.executed_transactions.len() as f64);
+            .record(execution_result.receipts.len() as f64);
 
-        let withdrawals_root = if ctx.is_isthmus_active() {
-            // withdrawals root field in block header is used for storage root of L2 predeploy
-            // `l2tol1-message-passer`
-            Some(
-                state
-                    .database
-                    .as_ref()
-                    .storage_root(ADDRESS_L2_TO_L1_MESSAGE_PASSER, Default::default())?,
-            )
-        } else if ctx.is_canyon_active() {
-            Some(EMPTY_WITHDRAWALS)
-        } else {
-            None
-        };
+        let sealed_block = Arc::new(block.sealed_block().clone());
+        info!(target: "payload_builder", id=%ctx.attributes().payload_id(), sealed_block_header = ?sealed_block.header(), "sealed built block");
 
-        remove_invalid(info.invalid_tx_hashes.iter().copied().collect());
-
-        let payload = ExecutedPayload {
-            info,
-            withdrawals_root,
-        };
-
-        Ok(BuildOutcomeKind::Better { payload })
-    }
-
-    /// Builds the payload on top of the state.
-    pub fn build<ChainSpec, DB, P>(
-        self,
-        mut state: State<DB>,
-        ctx: OpPayloadBuilderCtx<ChainSpec, OpPrimitives>,
-    ) -> Result<BuildOutcomeKind<OpBuiltPayload>, PayloadBuilderError>
-    where
-        ChainSpec: EthChainSpec + OpHardforks,
-        Txs: PayloadTransactions<Transaction: PoolTransaction<Consensus = OpTransactionSigned>>,
-        DB: Database<Error = ProviderError> + AsRef<P>,
-        P: StateRootProvider + HashedPostStateProvider + StorageRootProvider,
-    {
-        let ExecutedPayload {
-            info,
-            withdrawals_root,
-        } = match self.execute(&mut state, &ctx)? {
-            BuildOutcomeKind::Better { payload } | BuildOutcomeKind::Freeze(payload) => payload,
-            BuildOutcomeKind::Cancelled => return Ok(BuildOutcomeKind::Cancelled),
-            BuildOutcomeKind::Aborted { fees } => return Ok(BuildOutcomeKind::Aborted { fees }),
-        };
-
-        let block_number = ctx.block_number();
         let execution_outcome = ExecutionOutcome::new(
-            state.take_bundle(),
-            vec![info.receipts],
-            block_number,
+            db.take_bundle(),
+            vec![execution_result.receipts],
+            block.number,
             Vec::new(),
         );
-        let receipts_root = execution_outcome
-            .generic_receipts_root_slow(block_number, |receipts| {
-                calculate_receipt_root_no_memo_optimism(
-                    receipts,
-                    &ctx.chain_spec,
-                    ctx.attributes().timestamp(),
-                )
-            })
-            .expect("Number is in range");
-        let logs_bloom = execution_outcome
-            .block_logs_bloom(block_number)
-            .expect("Number is in range");
-
-        // calculate the state root
-        let state_root_start_time = Instant::now();
-
-        let state_provider = state.database.as_ref();
-        let hashed_state = state_provider.hashed_post_state(execution_outcome.state());
-        let (state_root, trie_output) = {
-            state
-                .database
-                .as_ref()
-                .state_root_with_updates(hashed_state.clone())
-                .inspect_err(|err| {
-                    warn!(target: "payload_builder",
-                    parent_header=%ctx.parent().hash(),
-                        %err,
-                        "failed to calculate state root for payload"
-                    );
-                })?
-        };
-
-        ctx.metrics
-            .state_root_calculation_duration
-            .record(state_root_start_time.elapsed());
-
-        // create the block header
-        let transactions_root = proofs::calculate_transaction_root(&info.executed_transactions);
-
-        // OP doesn't support blobs/EIP-4844.
-        // https://specs.optimism.io/protocol/exec-engine.html#ecotone-disable-blob-transactions
-        // Need [Some] or [None] based on hardfork to match block hash.
-        let (excess_blob_gas, blob_gas_used) = ctx.blob_fields();
-        let extra_data = ctx.extra_data()?;
-
-        let header = Header {
-            parent_hash: ctx.parent().hash(),
-            ommers_hash: EMPTY_OMMER_ROOT_HASH,
-            beneficiary: ctx.evm_env.block_env.beneficiary,
-            state_root,
-            transactions_root,
-            receipts_root,
-            withdrawals_root,
-            logs_bloom,
-            timestamp: ctx.attributes().payload_attributes.timestamp,
-            mix_hash: ctx.attributes().payload_attributes.prev_randao,
-            nonce: BEACON_NONCE.into(),
-            base_fee_per_gas: Some(ctx.base_fee()),
-            number: ctx.parent().number + 1,
-            gas_limit: ctx.block_gas_limit(),
-            difficulty: U256::ZERO,
-            gas_used: info.cumulative_gas_used,
-            extra_data,
-            parent_beacon_block_root: ctx.attributes().payload_attributes.parent_beacon_block_root,
-            blob_gas_used,
-            excess_blob_gas,
-            requests_hash: None,
-        };
-
-        // seal the block
-        let block = alloy_consensus::Block::<OpTransactionSigned>::new(
-            header,
-            BlockBody {
-                transactions: info.executed_transactions,
-                ommers: vec![],
-                withdrawals: ctx.withdrawals().cloned(),
-            },
-        );
-
-        let sealed_block = Arc::new(block.seal_slow());
-        info!(target: "payload_builder", id=%ctx.attributes().payload_id(), "sealed built block");
 
         // create the executed block data
-        let executed: ExecutedBlockWithTrieUpdates<OpPrimitives> = ExecutedBlockWithTrieUpdates {
+        let executed: ExecutedBlockWithTrieUpdates<N> = ExecutedBlockWithTrieUpdates {
             block: ExecutedBlock {
-                recovered_block: Arc::new(RecoveredBlock::<
-                    alloy_consensus::Block<OpTransactionSigned>,
-                >::new_sealed(
-                    sealed_block.as_ref().clone(), info.executed_senders
-                )),
+                recovered_block: Arc::new(block),
                 execution_output: Arc::new(execution_outcome),
                 hashed_state: Arc::new(hashed_state),
             },
-            trie: Arc::new(trie_output),
+            trie: Arc::new(trie_updates),
         };
 
         let no_tx_pool = ctx.attributes().no_tx_pool;
@@ -758,9 +604,7 @@ impl<Txs> OpBuilder<'_, Txs> {
             Some(executed),
         );
 
-        ctx.metrics
-            .payload_byte_size
-            .record(payload.block().size() as f64);
+        remove_invalid(info.invalid_tx_hashes.iter().copied().collect());
 
         if no_tx_pool {
             // if `no_tx_pool` is set only transactions from the payload attributes will be included
@@ -768,6 +612,10 @@ impl<Txs> OpBuilder<'_, Txs> {
             // freeze it once we've successfully built it.
             Ok(BuildOutcomeKind::Freeze(payload))
         } else {
+            ctx.metrics.block_built_success.increment(1);
+            ctx.metrics
+                .payload_byte_size
+                .record(payload.block().size() as f64);
             Ok(BuildOutcomeKind::Better { payload })
         }
     }
@@ -810,24 +658,22 @@ impl<T: PoolTransaction> OpPayloadTransactions<T> for () {
 }
 
 /// Container type that holds all necessities to build a new payload.
-#[derive(Debug)]
-pub struct OpPayloadBuilderCtx<ChainSpec, N: NodePrimitives> {
+// #[derive(derive_more::Debug)]
+pub struct OpPayloadBuilderCtx<Evm: ConfigureEvm, ChainSpec> {
     /// The type that knows how to perform system calls and configure the evm.
-    pub evm_config: OpEvmConfig,
+    pub evm_config: Evm,
     /// The DA config for the payload builder
     pub da_config: OpDAConfig,
     /// The chainspec
     pub chain_spec: Arc<ChainSpec>,
     /// How to build the payload.
-    pub config: PayloadConfig<OpPayloadBuilderAttributes<N::SignedTx>>,
-    /// Evm Settings
-    pub evm_env: EvmEnv<OpSpecId>,
-    /// Block env attributes for the current block.
-    pub block_env_attributes: OpNextBlockEnvAttributes,
+    pub config: PayloadConfig<OpPayloadBuilderAttributes<PrimitivesTxTy<Evm::Primitives>>>,
     /// Marker to check whether the job has been cancelled.
-    pub cancel: CancellationToken,
+    pub cancel: CancelOnDrop,
+    /// The currently best payload.
+    pub best_payload: Option<OpBuiltPayload<Evm::Primitives>>,
     /// The builder signer
-    pub builder_signer: Option<Signer>,
+    pub builder_signer: Option<OpSigner>,
     /// The metrics for the builder
     pub metrics: OpRBuilderMetrics,
     /// Client to execute supervisor validation
@@ -836,10 +682,11 @@ pub struct OpPayloadBuilderCtx<ChainSpec, N: NodePrimitives> {
     pub supervisor_safety_level: SafetyLevel,
 }
 
-impl<ChainSpec, N> OpPayloadBuilderCtx<ChainSpec, N>
+impl<Evm, ChainSpec> OpPayloadBuilderCtx<Evm, ChainSpec>
 where
+    Evm: ConfigureEvm<Primitives: OpPayloadPrimitives, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm::Primitives: OpPayloadPrimitives<_TX = OpTransactionSigned>,
     ChainSpec: EthChainSpec + OpHardforks,
-    N: NodePrimitives,
 {
     /// Returns the parent block the payload will be build on.
     pub fn parent(&self) -> &SealedHeader {
@@ -847,54 +694,8 @@ where
     }
 
     /// Returns the builder attributes.
-    pub const fn attributes(&self) -> &OpPayloadBuilderAttributes<N::SignedTx> {
+    pub const fn attributes(&self) -> &OpPayloadBuilderAttributes<PrimitivesTxTy<Evm::Primitives>> {
         &self.config.attributes
-    }
-
-    /// Returns the withdrawals if shanghai is active.
-    pub fn withdrawals(&self) -> Option<&Withdrawals> {
-        self.chain_spec
-            .is_shanghai_active_at_timestamp(self.attributes().timestamp())
-            .then(|| &self.attributes().payload_attributes.withdrawals)
-    }
-
-    /// Returns the block gas limit to target.
-    pub fn block_gas_limit(&self) -> u64 {
-        self.attributes()
-            .gas_limit
-            .unwrap_or(self.evm_env.block_env.gas_limit)
-    }
-
-    /// Returns the block number for the block.
-    pub fn block_number(&self) -> u64 {
-        self.evm_env.block_env.number
-    }
-
-    /// Returns the current base fee
-    pub fn base_fee(&self) -> u64 {
-        self.evm_env.block_env.basefee
-    }
-
-    /// Returns the current blob gas price.
-    pub fn get_blob_gasprice(&self) -> Option<u64> {
-        self.evm_env
-            .block_env
-            .blob_gasprice()
-            .map(|gasprice| gasprice as u64)
-    }
-
-    /// Returns the blob fields for the header.
-    ///
-    /// This will always return `Some(0)` after ecotone.
-    pub fn blob_fields(&self) -> (Option<u64>, Option<u64>) {
-        // OP doesn't support blobs/EIP-4844.
-        // https://specs.optimism.io/protocol/exec-engine.html#ecotone-disable-blob-transactions
-        // Need [Some] or [None] based on hardfork to match block hash.
-        if self.is_ecotone_active() {
-            (Some(0), Some(0))
-        } else {
-            (None, None)
-        }
     }
 
     /// Returns the extra data for the block.
@@ -915,31 +716,16 @@ where
     }
 
     /// Returns the current fee settings for transactions from the mempool
-    pub fn best_transaction_attributes(&self) -> BestTransactionsAttributes {
-        BestTransactionsAttributes::new(self.base_fee(), self.get_blob_gasprice())
+    pub fn best_transaction_attributes(&self, block_env: &BlockEnv) -> BestTransactionsAttributes {
+        BestTransactionsAttributes::new(
+            block_env.basefee,
+            block_env.blob_gasprice().map(|p| p as u64),
+        )
     }
 
     /// Returns the unique id for this payload job.
     pub fn payload_id(&self) -> PayloadId {
         self.attributes().payload_id()
-    }
-
-    /// Returns true if regolith is active for the payload.
-    pub fn is_regolith_active(&self) -> bool {
-        self.chain_spec
-            .is_regolith_active_at_timestamp(self.attributes().timestamp())
-    }
-
-    /// Returns true if ecotone is active for the payload.
-    pub fn is_ecotone_active(&self) -> bool {
-        self.chain_spec
-            .is_ecotone_active_at_timestamp(self.attributes().timestamp())
-    }
-
-    /// Returns true if canyon is active for the payload.
-    pub fn is_canyon_active(&self) -> bool {
-        self.chain_spec
-            .is_canyon_active_at_timestamp(self.attributes().timestamp())
     }
 
     /// Returns true if holocene is active for the payload.
@@ -948,71 +734,62 @@ where
             .is_holocene_active_at_timestamp(self.attributes().timestamp())
     }
 
-    /// Returns true if isthmus is active for the payload.
-    pub fn is_isthmus_active(&self) -> bool {
-        self.chain_spec
-            .is_isthmus_active_at_timestamp(self.attributes().timestamp())
-    }
-
     /// Returns the chain id
     pub fn chain_id(&self) -> u64 {
         self.chain_spec.chain_id()
     }
 
+    /// Returns true if the fees are higher than the previous payload.
+    pub fn is_better_payload(&self, total_fees: U256) -> bool {
+        is_better_payload(self.best_payload.as_ref(), total_fees)
+    }
+
     /// Returns the builder signer
-    pub fn builder_signer(&self) -> Option<Signer> {
+    pub fn builder_signer(&self) -> Option<OpSigner> {
         self.builder_signer
+    }
+
+    /// Prepares a [`BlockBuilder`] for the next block.
+    pub fn block_builder<'a, DB: Database>(
+        &'a self,
+        db: &'a mut State<DB>,
+    ) -> Result<impl BlockBuilder<Primitives = Evm::Primitives> + 'a, PayloadBuilderError> {
+        self.evm_config
+            .builder_for_next_block(
+                db,
+                self.parent(),
+                OpNextBlockEnvAttributes {
+                    timestamp: self.attributes().timestamp(),
+                    suggested_fee_recipient: self.attributes().suggested_fee_recipient(),
+                    prev_randao: self.attributes().prev_randao(),
+                    gas_limit: self
+                        .attributes()
+                        .gas_limit
+                        .unwrap_or(self.parent().gas_limit),
+                    parent_beacon_block_root: self.attributes().parent_beacon_block_root(),
+                    extra_data: self.extra_data()?,
+                },
+            )
+            .map_err(PayloadBuilderError::other)
     }
 }
 
-impl<ChainSpec, N> OpPayloadBuilderCtx<ChainSpec, N>
+impl<Evm, ChainSpec> OpPayloadBuilderCtx<Evm, ChainSpec>
 where
+    Evm: ConfigureEvm<Primitives: OpPayloadPrimitives, NextBlockEnvCtx = OpNextBlockEnvAttributes>,
+    Evm::Primitives: OpPayloadPrimitives<
+        BlockHeader = Header,
+        BlockBody = BlockBody<<Evm::Primitives as NodePrimitives>::SignedTx>,
+        _TX = OpTransactionSigned,
+    >,
     ChainSpec: EthChainSpec + OpHardforks,
-    N: OpPayloadPrimitives<_TX = OpTransactionSigned>,
 {
-    /// Constructs a receipt for the given transaction.
-    fn build_receipt<E: Evm>(
-        &self,
-        ctx: ReceiptBuilderCtx<'_, OpTransactionSigned, E>,
-        deposit_nonce: Option<u64>,
-    ) -> OpReceipt {
-        let receipt_builder = self.evm_config.block_executor_factory().receipt_builder();
-        match receipt_builder.build_receipt(ctx) {
-            Ok(receipt) => receipt,
-            Err(ctx) => {
-                let receipt = alloy_consensus::Receipt {
-                    // Success flag was added in `EIP-658: Embedding transaction status code
-                    // in receipts`.
-                    status: Eip658Value::Eip658(ctx.result.is_success()),
-                    cumulative_gas_used: ctx.cumulative_gas_used,
-                    logs: ctx.result.into_logs(),
-                };
-
-                receipt_builder.build_deposit_receipt(OpDepositReceipt {
-                    inner: receipt,
-                    deposit_nonce,
-                    // The deposit receipt version was introduced in Canyon to indicate an
-                    // update to how receipt hashes should be computed
-                    // when set. The state transition process ensures
-                    // this is only set for post-Canyon deposit
-                    // transactions.
-                    deposit_receipt_version: self.is_canyon_active().then_some(1),
-                })
-            }
-        }
-    }
-
     /// Executes all sequencer transactions that are included in the payload attributes.
-    pub fn execute_sequencer_transactions<DB>(
+    pub fn execute_sequencer_transactions(
         &self,
-        db: &mut State<DB>,
-    ) -> Result<ExecutionInfo<N>, PayloadBuilderError>
-    where
-        DB: Database<Error = ProviderError>,
-    {
-        let mut info = ExecutionInfo::with_capacity(self.attributes().transactions.len());
-
-        let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
+        builder: &mut impl BlockBuilder<Primitives = Evm::Primitives>,
+    ) -> Result<ExecutionInfo, PayloadBuilderError> {
+        let mut info = ExecutionInfo::new();
 
         for sequencer_tx in &self.attributes().transactions {
             // A sequencer's block should never contain blob transactions.
@@ -1022,7 +799,19 @@ where
                 ));
             }
 
-            // Convert the transaction to a [Recovered<TransactionSigned>]. This is
+            // Check transactions against supervisor if it's cross chain
+            if let (false, _) = self.is_cross_tx_valid(
+                sequencer_tx.value(),
+                self.supervisor_client.as_ref(),
+                self.supervisor_safety_level,
+                self.config.attributes.timestamp(),
+                &self.metrics,
+            ) {
+                // We skip this transaction because it's not possible to verify it's validity
+                continue;
+            }
+
+            // Convert the transaction to a [RecoveredTx]. This is
             // purely for the purposes of utilizing the `evm_config.tx_env`` function.
             // Deposit transactions do not have signatures, so if the tx is a deposit, this
             // will just pull in its `from` address.
@@ -1033,67 +822,23 @@ where
                     PayloadBuilderError::other(OpPayloadBuilderError::TransactionEcRecoverFailed)
                 })?;
 
-            // Check transactions against supervisor if it's cross chain
-            if let (false, _) = is_cross_tx_valid::<N>(
-                sequencer_tx.inner(),
-                self.supervisor_client.as_ref(),
-                self.supervisor_safety_level,
-                self.config.attributes.timestamp(),
-                &self.metrics,
-            ) {
-                // We skip this transaction because it's not possible to verify it's validity
-                continue;
-            }
-
-            // Cache the depositor account prior to the state transition for the deposit nonce.
-            //
-            // Note that this *only* needs to be done post-regolith hardfork, as deposit nonces
-            // were not introduced in Bedrock. In addition, regular transactions don't have deposit
-            // nonces, so we don't need to touch the DB for those.
-            let depositor_nonce = (self.is_regolith_active() && sequencer_tx.is_deposit())
-                .then(|| {
-                    evm.db_mut()
-                        .load_cache_account(sequencer_tx.signer())
-                        .map(|acc| acc.account_info().unwrap_or_default().nonce)
-                })
-                .transpose()
-                .map_err(|_| {
-                    PayloadBuilderError::other(OpPayloadBuilderError::AccountLoadFailed(
-                        sequencer_tx.signer(),
-                    ))
-                })?;
-
-            let ResultAndState { result, state } = match evm.transact(&sequencer_tx) {
-                Ok(res) => res,
+            let gas_used = match builder.execute_transaction(sequencer_tx.clone()) {
+                Ok(gas_used) => gas_used,
+                Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                    error,
+                    ..
+                })) => {
+                    trace!(target: "payload_builder", %error, ?sequencer_tx, "Error in sequencer transaction, skipping.");
+                    continue;
+                }
                 Err(err) => {
-                    if err.is_invalid_tx_err() {
-                        trace!(target: "payload_builder", %err, ?sequencer_tx, "Error in sequencer transaction, skipping.");
-                        continue;
-                    }
                     // this is an error that we should treat as fatal for this attempt
                     return Err(PayloadBuilderError::EvmExecutionError(Box::new(err)));
                 }
             };
 
             // add gas used by the transaction to cumulative gas used, before creating the receipt
-            let gas_used = result.gas_used();
             info.cumulative_gas_used += gas_used;
-
-            let ctx = ReceiptBuilderCtx {
-                tx: sequencer_tx.inner(),
-                evm: &evm,
-                result,
-                state: &state,
-                cumulative_gas_used: info.cumulative_gas_used,
-            };
-            info.receipts.push(self.build_receipt(ctx, depositor_nonce));
-
-            // commit changes
-            evm.db_mut().commit(state);
-
-            // append sender and transaction to the respective lists
-            info.executed_senders.push(sequencer_tx.signer());
-            info.executed_transactions.push(sequencer_tx.into_inner());
         }
 
         Ok(info)
@@ -1102,27 +847,24 @@ where
     /// Executes the given best transactions and updates the execution info.
     ///
     /// Returns `Ok(Some(())` if the job was cancelled.
-    pub fn execute_best_transactions<DB>(
+    pub fn execute_best_transactions(
         &self,
-        info: &mut ExecutionInfo<N>,
-        db: &mut State<DB>,
+        info: &mut ExecutionInfo,
+        builder: &mut impl BlockBuilder<Primitives = Evm::Primitives>,
         mut best_txs: impl PayloadTransactions<
-            Transaction: PoolTransaction<Consensus = OpTransactionSigned>,
+            Transaction: PoolTransaction<Consensus = PrimitivesTxTy<Evm::Primitives>>,
         >,
         block_gas_limit: u64,
         block_da_limit: Option<u64>,
-    ) -> Result<Option<()>, PayloadBuilderError>
-    where
-        DB: Database<Error = ProviderError>,
-    {
+    ) -> Result<Option<()>, PayloadBuilderError> {
         let execute_txs_start_time = Instant::now();
         let mut num_txs_considered = 0;
         let mut num_txs_simulated = 0;
         let mut num_txs_simulated_success = 0;
         let mut num_txs_simulated_fail = 0;
-        let base_fee = self.base_fee();
+
         let tx_da_limit = self.da_config.max_da_tx_size();
-        let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
+        let base_fee = builder.evm_mut().block().basefee;
 
         while let Some(tx) = best_txs.next(()) {
             let tx = tx.into_consensus();
@@ -1143,7 +885,7 @@ where
             }
 
             // Check transactions against supervisor if it's cross chain
-            if let (false, is_recoverable) = is_cross_tx_valid::<N>(
+            if let (false, is_recoverable) = self.is_cross_tx_valid(
                 tx.inner(),
                 self.supervisor_client.as_ref(),
                 self.supervisor_safety_level,
@@ -1166,59 +908,46 @@ where
             }
 
             let tx_simulation_start_time = Instant::now();
-            let ResultAndState { result, state } = match evm.transact(&tx) {
-                Ok(res) => res,
-                Err(err) => {
-                    if let Some(err) = err.as_invalid_tx_err() {
-                        if err.is_nonce_too_low() {
-                            // if the nonce is too low, we can skip this transaction
-                            trace!(target: "payload_builder", %err, ?tx, "skipping nonce too low transaction");
-                        } else {
-                            // if the transaction is invalid, we can skip it and all of its
-                            // descendants
-                            trace!(target: "payload_builder", %err, ?tx, "skipping invalid transaction and its descendants");
-                            best_txs.mark_invalid(tx.signer(), tx.nonce());
-                        }
 
-                        continue;
+            let gas_used = match builder.execute_transaction_with_result_closure(
+                tx.clone(),
+                |result| {
+                    if result.is_success() {
+                        num_txs_simulated_success += 1;
+                    } else {
+                        num_txs_simulated_fail += 1;
+                        trace!(target: "payload_builder", ?tx, "skipping reverted transaction");
+                        best_txs.mark_invalid(tx.signer(), tx.nonce());
+                        info.invalid_tx_hashes.insert(*tx.tx_hash());
                     }
+                },
+            ) {
+                Ok(gas_used) => gas_used,
+                Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
+                    error,
+                    ..
+                })) => {
+                    if error.is_nonce_too_low() {
+                        // if the nonce is too low, we can skip this transaction
+                        trace!(target: "payload_builder", %error, ?tx, "skipping nonce too low transaction");
+                    } else {
+                        // if the transaction is invalid, we can skip it and all of its
+                        // descendants
+                        trace!(target: "payload_builder", %error, ?tx, "skipping invalid transaction and its descendants");
+                        best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    }
+                    continue;
+                }
+                Err(err) => {
                     // this is an error that we should treat as fatal for this attempt
                     return Err(PayloadBuilderError::EvmExecutionError(Box::new(err)));
                 }
             };
 
-            self.metrics
-                .tx_simulation_duration
-                .record(tx_simulation_start_time.elapsed());
-            self.metrics.tx_byte_size.record(tx.inner().size() as f64);
-            num_txs_simulated += 1;
-            if result.is_success() {
-                num_txs_simulated_success += 1;
-            } else {
-                num_txs_simulated_fail += 1;
-                trace!(target: "payload_builder", ?tx, "skipping reverted transaction");
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
-                info.invalid_tx_hashes.insert(*tx.tx_hash());
-                continue;
-            }
-
             // add gas used by the transaction to cumulative gas used, before creating the
             // receipt
-            let gas_used = result.gas_used();
             info.cumulative_gas_used += gas_used;
-
-            // Push transaction changeset and calculate header bloom filter for receipt.
-            let ctx = ReceiptBuilderCtx {
-                tx: tx.inner(),
-                evm: &evm,
-                result,
-                state: &state,
-                cumulative_gas_used: info.cumulative_gas_used,
-            };
-            info.receipts.push(self.build_receipt(ctx, None));
-
-            // commit changes
-            evm.db_mut().commit(state);
+            info.cumulative_da_bytes_used += tx.length() as u64;
 
             // update add to total fees
             let miner_fee = tx
@@ -1226,9 +955,11 @@ where
                 .expect("fee is always valid; execution succeeded");
             info.total_fees += U256::from(miner_fee) * U256::from(gas_used);
 
-            // append sender and transaction to the respective lists
-            info.executed_senders.push(tx.signer());
-            info.executed_transactions.push(tx.into_inner());
+            self.metrics
+                .tx_simulation_duration
+                .record(tx_simulation_start_time.elapsed());
+            self.metrics.tx_byte_size.record(tx.inner().size() as f64);
+            num_txs_simulated += 1;
         }
 
         self.metrics
@@ -1250,51 +981,63 @@ where
         Ok(None)
     }
 
-    pub fn add_builder_tx<DB>(
+    /// Creates signed builder tx to Address::ZERO and specified message as input
+    pub fn signed_builder_tx(
         &self,
-        info: &mut ExecutionInfo<N>,
-        db: &mut State<DB>,
+        db: &impl StateProvider,
         builder_tx_gas: u64,
         message: Vec<u8>,
-    ) -> Option<()>
-    where
-        DB: Database<Error = ProviderError>,
-    {
+        signer: OpSigner,
+        base_fee: u64,
+        chain_id: u64,
+    ) -> Result<Recovered<PrimitivesTxTy<Evm::Primitives>>, PayloadBuilderError> {
+        // Create message with block number for the builder to sign
+        let nonce = db
+            .account_nonce(&signer.address)
+            .map_err(|_| {
+                PayloadBuilderError::other(OpPayloadBuilderError::AccountLoadFailed(signer.address))
+            })?
+            .unwrap_or_default();
+
+        let request = TransactionRequest {
+            chain_id: Some(chain_id),
+            nonce: Some(nonce),
+            gas: Some(builder_tx_gas),
+            max_fee_per_gas: Some(base_fee.into()),
+            max_priority_fee_per_gas: Some(0),
+            to: Some(TxKind::Call(Address::ZERO)),
+            input: message.into(),
+            ..Default::default()
+        };
+
+        // Sign the transaction and return directly since types match
+        signer
+            .build_and_sign_tx(request)
+            .map_err(PayloadBuilderError::other)
+    }
+
+    pub fn add_builder_tx(
+        &self,
+        info: &mut ExecutionInfo,
+        builder: &mut impl BlockBuilder<Primitives = Evm::Primitives>,
+        db: &impl StateProvider,
+        builder_tx_gas: u64,
+        message: Vec<u8>,
+    ) -> Option<()> {
         self.builder_signer()
             .map(|signer| {
-                let base_fee = self.base_fee();
+                let base_fee = builder.evm_mut().block().basefee;
                 let chain_id = self.chain_id();
-                // Create and sign the transaction
-                let builder_tx =
-                    signed_builder_tx(db, builder_tx_gas, message, signer, base_fee, chain_id)?;
-
-                let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
-
-                let ResultAndState { result, state } = evm
-                    .transact(&builder_tx)
-                    .map_err(|err| PayloadBuilderError::EvmExecutionError(Box::new(err)))?;
-
-                // Add gas used by the transaction to cumulative gas used, before creating the receipt
-                let gas_used = result.gas_used();
+                let builder_tx = self.signed_builder_tx(
+                    db,
+                    builder_tx_gas,
+                    message,
+                    signer,
+                    base_fee,
+                    chain_id,
+                )?;
+                let gas_used = builder.execute_transaction(builder_tx)?;
                 info.cumulative_gas_used += gas_used;
-
-                let ctx = ReceiptBuilderCtx {
-                    tx: builder_tx.inner(),
-                    evm: &evm,
-                    result,
-                    state: &state,
-                    cumulative_gas_used: info.cumulative_gas_used,
-                };
-                info.receipts.push(self.build_receipt(ctx, None));
-
-                // Release the db reference by dropping evm
-                drop(evm);
-                // Commit changes
-                db.commit(state);
-
-                // Append sender and transaction to the respective lists
-                info.executed_senders.push(builder_tx.signer());
-                info.executed_transactions.push(builder_tx.into_inner());
                 Ok(())
             })
             .transpose()
@@ -1305,22 +1048,25 @@ where
     }
 
     /// Calculates EIP 2718 builder transaction size
-    pub fn estimate_builder_tx_da_size<DB>(
+    pub fn estimate_builder_tx_da_size(
         &self,
-        db: &mut State<DB>,
+        db: &impl StateProvider,
+        base_fee: u64,
         builder_tx_gas: u64,
         message: Vec<u8>,
-    ) -> Option<usize>
-    where
-        DB: Database<Error = ProviderError>,
-    {
+    ) -> Option<usize> {
         self.builder_signer()
             .map(|signer| {
-                let base_fee = self.base_fee();
                 let chain_id = self.chain_id();
                 // Create and sign the transaction
-                let builder_tx =
-                    signed_builder_tx(db, builder_tx_gas, message, signer, base_fee, chain_id)?;
+                let builder_tx = self.signed_builder_tx(
+                    db,
+                    builder_tx_gas,
+                    message,
+                    signer,
+                    base_fee,
+                    chain_id,
+                )?;
                 Ok(builder_tx.length())
             })
             .transpose()
@@ -1329,44 +1075,97 @@ where
                 None
             })
     }
-}
 
-/// Creates signed builder tx to Address::ZERO and specified message as input
-pub fn signed_builder_tx<DB>(
-    db: &mut State<DB>,
-    builder_tx_gas: u64,
-    message: Vec<u8>,
-    signer: Signer,
-    base_fee: u64,
-    chain_id: u64,
-) -> Result<Recovered<OpTransactionSigned>, PayloadBuilderError>
-where
-    DB: Database<Error = ProviderError>,
-{
-    // Create message with block number for the builder to sign
-    let nonce = db
-        .load_cache_account(signer.address)
-        .map(|acc| acc.account_info().unwrap_or_default().nonce)
-        .map_err(|_| {
-            PayloadBuilderError::other(OpPayloadBuilderError::AccountLoadFailed(signer.address))
-        })?;
+    /// Extracts commitment from access list entries, pointing to 0x420..022 and validates them
+    /// against supervisor.
+    ///
+    /// If commitment present pre-interop tx rejected.
+    ///
+    /// Returns (is_valid, is_recoverable)
+    pub fn is_cross_tx_valid(
+        &self,
+        tx: &PrimitivesTxTy<Evm::Primitives>,
+        // TODO: after spec rebase we must make this field not optional
+        client: Option<&SupervisorValidator>,
+        safety_level: SafetyLevel,
+        timestamp: u64,
+        metrics: &OpRBuilderMetrics,
+    ) -> (bool, bool) {
+        if tx.access_list().is_none() {
+            return (true, true);
+        }
+        let access_list = tx.access_list().unwrap();
+        let inbox_entries = SupervisorValidator::parse_access_list(access_list)
+            .cloned()
+            .collect::<Vec<_>>();
+        if !inbox_entries.is_empty() {
+            metrics.inc_num_cross_chain_tx();
+            if client.is_none() {
+                return (false, true);
+            }
+            match self.validate_supervisor_messages(
+                inbox_entries,
+                client.unwrap(),
+                safety_level,
+                timestamp,
+            ) {
+                Ok(res) => match res {
+                    Ok(()) => (true, true),
+                    Err(err) => {
+                        match err {
+                            // TODO: we should add reconnecting to supervisor in case of disconnect
+                            InteropTxValidatorError::SupervisorServerError(err) => {
+                                warn!(target: "payload_builder", %err, ?tx, "Supervisor error, skipping.");
+                                metrics.inc_num_cross_chain_tx_server_error();
+                                (false, true)
+                            }
+                            InteropTxValidatorError::ValidationTimeout(_) => {
+                                warn!(target: "payload_builder", %err, ?tx, "Cross tx validation timed out, skipping.");
+                                metrics.inc_num_cross_chain_tx_timeout();
+                                (false, true)
+                            }
+                            err => {
+                                trace!(target: "payload_builder", %err, ?tx, "Cross tx rejected.");
+                                metrics.inc_num_cross_chain_tx_fail();
+                                // It's possible that transaction invalid now, but would be valid later.
+                                // We should keep limited queue for transactions that could become valid.
+                                // We should have the limit to ensure that builder won't get overwhelmed.
+                                (false, false)
+                            }
+                        }
+                    }
+                },
+                Err(err) => {
+                    error!(target: "payload_builder", %err, ?tx, "Client side error during cross tx validation, skipping.");
+                    (false, true)
+                }
+            }
+        } else {
+            (true, true)
+        }
+    }
 
-    // Create the EIP-1559 transaction
-    let tx = OpTypedTransaction::Eip1559(TxEip1559 {
-        chain_id,
-        nonce,
-        gas_limit: builder_tx_gas,
-        max_fee_per_gas: base_fee.into(),
-        max_priority_fee_per_gas: 0,
-        to: TxKind::Call(Address::ZERO),
-        // Include the message as part of the transaction data
-        input: message.into(),
-        ..Default::default()
-    });
-    // Sign the transaction
-    let builder_tx = signer.sign_tx(tx).map_err(PayloadBuilderError::other)?;
-
-    Ok(builder_tx)
+    /// Validate inbox_entries against supervisor.
+    pub fn validate_supervisor_messages(
+        &self,
+        inbox_entries: Vec<B256>,
+        client: &SupervisorValidator,
+        safety_level: SafetyLevel,
+        timestamp: u64,
+    ) -> Result<Result<(), InteropTxValidatorError>, PayloadBuilderError> {
+        // For block building the timestamp should be `expected time of inclusion` and timeout 0
+        let descriptor = ExecutingDescriptor::new(timestamp, None);
+        let (channel_tx, rx) = std::sync::mpsc::channel();
+        tokio::task::block_in_place(move || {
+            let res = tokio::runtime::Handle::current().block_on(async {
+                client
+                    .validate_messages(inbox_entries.as_slice(), safety_level, descriptor)
+                    .await
+            });
+            let _ = channel_tx.send(res);
+        });
+        rx.recv().map_err(|_| PayloadBuilderError::ChannelClosed)
+    }
 }
 
 fn estimate_gas_for_builder_tx(input: Vec<u8>) -> u64 {
@@ -1384,94 +1183,4 @@ fn estimate_gas_for_builder_tx(input: Vec<u8>) -> u64 {
     let nonzero_cost = nonzero_bytes * 16;
 
     zero_cost + nonzero_cost + 21_000
-}
-
-/// Extracts commitment from access list entries, pointing to 0x420..022 and validates them
-/// against supervisor.
-///
-/// If commitment present pre-interop tx rejected.
-///
-/// Returns (is_valid, is_recoverable)
-pub fn is_cross_tx_valid<N: NodePrimitives>(
-    tx: &N::SignedTx,
-    // TODO: after spec rebase we must make this field not optional
-    client: Option<&SupervisorValidator>,
-    safety_level: SafetyLevel,
-    timestamp: u64,
-    metrics: &OpRBuilderMetrics,
-) -> (bool, bool) {
-    if tx.access_list().is_none() {
-        return (true, true);
-    }
-    let access_list = tx.access_list().unwrap();
-    let inbox_entries = SupervisorValidator::parse_access_list(access_list)
-        .cloned()
-        .collect::<Vec<_>>();
-    if !inbox_entries.is_empty() {
-        metrics.inc_num_cross_chain_tx();
-        if client.is_none() {
-            return (false, true);
-        }
-        match validate_supervisor_messages(inbox_entries, client.unwrap(), safety_level, timestamp)
-        {
-            Ok(res) => match res {
-                Ok(()) => (true, true),
-                Err(err) => {
-                    match err {
-                        // TODO: we should add reconnecting to supervisor in case of disconnect
-                        InteropTxValidatorError::SupervisorServerError(err) => {
-                            warn!(target: "payload_builder", %err, ?tx, "Supervisor error, skipping.");
-                            metrics.inc_num_cross_chain_tx_server_error();
-                            (false, true)
-                        }
-                        InteropTxValidatorError::ValidationTimeout(_) => {
-                            warn!(target: "payload_builder", %err, ?tx, "Cross tx validation timed out, skipping.");
-                            metrics.inc_num_cross_chain_tx_timeout();
-                            (false, true)
-                        }
-                        err => {
-                            trace!(target: "payload_builder", %err, ?tx, "Cross tx rejected.");
-                            metrics.inc_num_cross_chain_tx_fail();
-                            // It's possible that transaction invalid now, but would be valid later.
-                            // We should keep limited queue for transactions that could become valid.
-                            // We should have the limit to ensure that builder won't get overwhelmed.
-                            (false, false)
-                        }
-                    }
-                }
-            },
-            Err(err) => {
-                error!(target: "payload_builder", %err, ?tx, "Client side error during cross tx validation, skipping.");
-                (false, true)
-            }
-        }
-    } else {
-        (true, true)
-    }
-}
-
-/// Validate inbox_entries against supervisor.
-pub fn validate_supervisor_messages(
-    inbox_entries: Vec<B256>,
-    client: &SupervisorValidator,
-    safety_level: SafetyLevel,
-    timestamp: u64,
-) -> Result<Result<(), InteropTxValidatorError>, PayloadBuilderError> {
-    // For block building the timestamp should be `expected time of inclusion` and timeout 0
-    let descriptor = ExecutingDescriptor::new(timestamp, None);
-    let (channel_tx, rx) = std::sync::mpsc::channel();
-    tokio::task::block_in_place(move || {
-        let res = tokio::runtime::Handle::current().block_on(async {
-            client
-                .validate_messages(
-                    inbox_entries.as_slice(),
-                    safety_level,
-                    descriptor,
-                    Some(core::time::Duration::from_millis(100)),
-                )
-                .await
-        });
-        let _ = channel_tx.send(res);
-    });
-    rx.recv().map_err(|_| PayloadBuilderError::ChannelClosed)
 }

--- a/crates/op-rbuilder/src/primitives/reth/execution.rs
+++ b/crates/op-rbuilder/src/primitives/reth/execution.rs
@@ -1,27 +1,11 @@
 //! Heavily influenced by [reth](https://github.com/paradigmxyz/reth/blob/1e965caf5fa176f244a31c0d2662ba1b590938db/crates/optimism/payload/src/builder.rs#L570)
 use alloy_consensus::Transaction;
-use alloy_primitives::{private::alloy_rlp::Encodable, Address, TxHash, B256, U256};
-use reth_node_api::NodePrimitives;
-use reth_optimism_primitives::OpReceipt;
+use alloy_primitives::private::alloy_rlp::Encodable;
+use alloy_primitives::{TxHash, U256};
 use std::collections::HashSet;
 
-/// Holds the state after execution
-#[derive(Debug)]
-pub struct ExecutedPayload<N: NodePrimitives> {
-    /// Tracked execution info
-    pub info: ExecutionInfo<N>,
-    /// Withdrawal hash.
-    pub withdrawals_root: Option<B256>,
-}
-
 #[derive(Default, Debug)]
-pub struct ExecutionInfo<N: NodePrimitives> {
-    /// All executed transactions (unrecovered).
-    pub executed_transactions: Vec<N::SignedTx>,
-    /// The recovered senders for the executed transactions.
-    pub executed_senders: Vec<Address>,
-    /// The transaction receipts
-    pub receipts: Vec<OpReceipt>,
+pub struct ExecutionInfo {
     /// All gas used so far
     pub cumulative_gas_used: u64,
     /// Estimated DA size
@@ -35,13 +19,10 @@ pub struct ExecutionInfo<N: NodePrimitives> {
     pub last_flashblock_index: usize,
 }
 
-impl<N: NodePrimitives> ExecutionInfo<N> {
+impl ExecutionInfo {
     /// Create a new instance with allocated slots.
-    pub fn with_capacity(capacity: usize) -> Self {
+    pub fn new() -> Self {
         Self {
-            executed_transactions: Vec::with_capacity(capacity),
-            executed_senders: Vec::with_capacity(capacity),
-            receipts: Vec::with_capacity(capacity),
             cumulative_gas_used: 0,
             cumulative_da_bytes_used: 0,
             total_fees: U256::ZERO,
@@ -59,7 +40,7 @@ impl<N: NodePrimitives> ExecutionInfo<N> {
     ///   maximum allowed DA limit per block.
     pub fn is_tx_over_limits(
         &self,
-        tx: &N::SignedTx,
+        tx: &(impl Encodable + Transaction),
         block_gas_limit: u64,
         tx_data_limit: Option<u64>,
         block_data_limit: Option<u64>,

--- a/crates/op-rbuilder/src/primitives/reth/mod.rs
+++ b/crates/op-rbuilder/src/primitives/reth/mod.rs
@@ -1,2 +1,2 @@
 mod execution;
-pub use execution::{ExecutedPayload, ExecutionInfo};
+pub use execution::ExecutionInfo;

--- a/crates/op-rbuilder/src/tester/mod.rs
+++ b/crates/op-rbuilder/src/tester/mod.rs
@@ -1,5 +1,7 @@
 use alloy_eips::BlockNumberOrTag;
 use alloy_eips::Encodable2718;
+use alloy_primitives::address;
+use alloy_primitives::hex;
 use alloy_primitives::Address;
 use alloy_primitives::Bytes;
 use alloy_primitives::TxKind;
@@ -186,7 +188,7 @@ pub async fn generate_genesis(output: Option<String>) -> eyre::Result<()> {
 // L1 block info for OP mainnet block 124665056 (stored in input of tx at index 0)
 //
 // https://optimistic.etherscan.io/tx/0x312e290cf36df704a2217b015d6455396830b0ce678b860ebfcc30f41403d7b1
-// const FJORD_DATA: &[u8] = &hex!("440a5e200000146b000f79c500000000000000040000000066d052e700000000013ad8a3000000000000000000000000000000000000000000000000000000003ef1278700000000000000000000000000000000000000000000000000000000000000012fdf87b89884a61e74b322bbcf60386f543bfae7827725efaaf0ab1de2294a590000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985");
+const FJORD_DATA: &[u8] = &hex!("440a5e200000146b000f79c500000000000000040000000066d052e700000000013ad8a3000000000000000000000000000000000000000000000000000000003ef1278700000000000000000000000000000000000000000000000000000000000000012fdf87b89884a61e74b322bbcf60386f543bfae7827725efaaf0ab1de2294a590000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985");
 
 /// A system that continuously generates blocks using the engine API
 pub struct BlockGenerator<'a> {
@@ -342,24 +344,23 @@ impl<'a> BlockGenerator<'a> {
         // in the block since it also includes this info as part of the result.
         // It does not matter if the to address (4200000000000000000000000000000000000015) is
         // not deployed on the L2 chain since Reth queries the block to get the info and not the contract.
-        // let block_info_tx: Bytes = {
-        //     let deposit_tx = TxDeposit {
-        //         source_hash: B256::default(),
-        //         from: address!("DeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001"),
-        //         to: TxKind::Call(address!("4200000000000000000000000000000000000015")),
-        //         mint: None,
-        //         value: U256::default(),
-        //         gas_limit: 210000,
-        //         is_system_transaction: true,
-        //         input: FJORD_DATA.into(),
-        //     };
+        let block_info_tx: Bytes = {
+            let deposit_tx = TxDeposit {
+                source_hash: B256::default(),
+                from: address!("DeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001"),
+                to: TxKind::Call(address!("4200000000000000000000000000000000000015")),
+                mint: None,
+                value: U256::default(),
+                gas_limit: 210000,
+                is_system_transaction: false,
+                input: FJORD_DATA.into(),
+            };
 
-        //     // Create a temporary signer for the deposit
-        //     let signer = OpSigner::random();
-        //     let signed_tx = signer.sign_tx(OpTypedTransaction::Deposit(deposit_tx))?;
-        //     signed_tx.encoded_2718().into()
-        // };
-        let block_info_tx: Bytes = Bytes::default();
+            // Create a temporary signer for the deposit
+            let signer = OpSigner::random();
+            let signed_tx = signer.sign_tx(OpTypedTransaction::Deposit(deposit_tx))?;
+            signed_tx.encoded_2718().into()
+        };
 
         let transactions = if let Some(transactions) = transactions {
             // prepend the block info transaction
@@ -472,7 +473,7 @@ impl<'a> BlockGenerator<'a> {
             mint: Some(value), // Amount to deposit
             value: U256::default(),
             gas_limit: 210000,
-            is_system_transaction: true,
+            is_system_transaction: false,
             input: Bytes::default(),
         };
 

--- a/crates/op-rbuilder/src/tester/mod.rs
+++ b/crates/op-rbuilder/src/tester/mod.rs
@@ -1,12 +1,10 @@
-use crate::tx_signer::Signer;
-use alloy_eips::eip2718::Encodable2718;
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::address;
+use alloy_eips::Encodable2718;
 use alloy_primitives::Address;
 use alloy_primitives::Bytes;
 use alloy_primitives::TxKind;
 use alloy_primitives::B256;
-use alloy_primitives::{hex, U256};
+use alloy_primitives::U256;
 use alloy_rpc_types_engine::ExecutionPayloadV1;
 use alloy_rpc_types_engine::ExecutionPayloadV2;
 use alloy_rpc_types_engine::PayloadAttributes;
@@ -30,6 +28,8 @@ use serde_json::Value;
 use std::str::FromStr;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+
+use crate::tx_signer::OpSigner;
 
 /// Helper for engine api operations
 pub struct EngineApi {
@@ -186,7 +186,7 @@ pub async fn generate_genesis(output: Option<String>) -> eyre::Result<()> {
 // L1 block info for OP mainnet block 124665056 (stored in input of tx at index 0)
 //
 // https://optimistic.etherscan.io/tx/0x312e290cf36df704a2217b015d6455396830b0ce678b860ebfcc30f41403d7b1
-const FJORD_DATA: &[u8] = &hex!("440a5e200000146b000f79c500000000000000040000000066d052e700000000013ad8a3000000000000000000000000000000000000000000000000000000003ef1278700000000000000000000000000000000000000000000000000000000000000012fdf87b89884a61e74b322bbcf60386f543bfae7827725efaaf0ab1de2294a590000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985");
+// const FJORD_DATA: &[u8] = &hex!("440a5e200000146b000f79c500000000000000040000000066d052e700000000013ad8a3000000000000000000000000000000000000000000000000000000003ef1278700000000000000000000000000000000000000000000000000000000000000012fdf87b89884a61e74b322bbcf60386f543bfae7827725efaaf0ab1de2294a590000000000000000000000006887246668a3b87f54deb3b94ba47a6f63f32985");
 
 /// A system that continuously generates blocks using the engine API
 pub struct BlockGenerator<'a> {
@@ -342,23 +342,24 @@ impl<'a> BlockGenerator<'a> {
         // in the block since it also includes this info as part of the result.
         // It does not matter if the to address (4200000000000000000000000000000000000015) is
         // not deployed on the L2 chain since Reth queries the block to get the info and not the contract.
-        let block_info_tx: Bytes = {
-            let deposit_tx = TxDeposit {
-                source_hash: B256::default(),
-                from: address!("DeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001"),
-                to: TxKind::Call(address!("4200000000000000000000000000000000000015")),
-                mint: None,
-                value: U256::default(),
-                gas_limit: 210000,
-                is_system_transaction: true,
-                input: FJORD_DATA.into(),
-            };
+        // let block_info_tx: Bytes = {
+        //     let deposit_tx = TxDeposit {
+        //         source_hash: B256::default(),
+        //         from: address!("DeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001"),
+        //         to: TxKind::Call(address!("4200000000000000000000000000000000000015")),
+        //         mint: None,
+        //         value: U256::default(),
+        //         gas_limit: 210000,
+        //         is_system_transaction: true,
+        //         input: FJORD_DATA.into(),
+        //     };
 
-            // Create a temporary signer for the deposit
-            let signer = Signer::random();
-            let signed_tx = signer.sign_tx(OpTypedTransaction::Deposit(deposit_tx))?;
-            signed_tx.encoded_2718().into()
-        };
+        //     // Create a temporary signer for the deposit
+        //     let signer = OpSigner::random();
+        //     let signed_tx = signer.sign_tx(OpTypedTransaction::Deposit(deposit_tx))?;
+        //     signed_tx.encoded_2718().into()
+        // };
+        let block_info_tx: Bytes = Bytes::default();
 
         let transactions = if let Some(transactions) = transactions {
             // prepend the block info transaction
@@ -476,7 +477,7 @@ impl<'a> BlockGenerator<'a> {
         };
 
         // Create a temporary signer for the deposit
-        let signer = Signer::random();
+        let signer = OpSigner::random();
         let signed_tx = signer.sign_tx(OpTypedTransaction::Deposit(deposit_tx))?;
         let signed_tx_rlp = signed_tx.encoded_2718();
 

--- a/crates/op-rbuilder/src/tx_signer.rs
+++ b/crates/op-rbuilder/src/tx_signer.rs
@@ -3,20 +3,29 @@ use std::str::FromStr;
 use alloy_consensus::SignableTransaction;
 use alloy_primitives::{Address, PrimitiveSignature as Signature, B256, U256};
 use op_alloy_consensus::OpTypedTransaction;
+use op_alloy_rpc_types::OpTransactionRequest;
 use reth_optimism_primitives::OpTransactionSigned;
 use reth_primitives::{public_key_to_address, Recovered};
-use secp256k1::{Message, SecretKey, SECP256K1};
+use secp256k1::{ecdsa::RecoveryId, Message, SecretKey, SECP256K1};
+
+#[derive(Debug, thiserror::Error)]
+pub enum SignerError {
+    #[error("failed to sign tx: {0}")]
+    FailedToSignTx(#[from] secp256k1::Error),
+    #[error("failed to build tx")]
+    FailedToBuildTx,
+}
 
 /// Simple struct to sign txs/messages.
 /// Mainly used to sign payout txs from the builder and to create test data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Signer {
+pub struct OpSigner {
     pub address: Address,
     pub secret: SecretKey,
 }
 
-impl Signer {
-    pub fn try_from_secret(secret: B256) -> Result<Self, secp256k1::Error> {
+impl OpSigner {
+    pub fn try_from_secret(secret: B256) -> Result<Self, SignerError> {
         let secret = SecretKey::from_slice(secret.as_ref())?;
         let pubkey = secret.public_key(SECP256K1);
         let address = public_key_to_address(pubkey);
@@ -24,7 +33,7 @@ impl Signer {
         Ok(Self { address, secret })
     }
 
-    pub fn sign_message(&self, message: B256) -> Result<Signature, secp256k1::Error> {
+    pub fn sign_message(&self, message: B256) -> Result<Signature, SignerError> {
         let s = SECP256K1
             .sign_ecdsa_recoverable(&Message::from_digest_slice(&message[..])?, &self.secret);
         let (rec_id, data) = s.serialize_compact();
@@ -32,15 +41,26 @@ impl Signer {
         let signature = Signature::new(
             U256::try_from_be_slice(&data[..32]).expect("The slice has at most 32 bytes"),
             U256::try_from_be_slice(&data[32..64]).expect("The slice has at most 32 bytes"),
-            i32::from(rec_id) != 0,
+            rec_id != RecoveryId::Zero,
         );
         Ok(signature)
+    }
+
+    pub fn build_and_sign_tx(
+        &self,
+        request: alloy_rpc_types_eth::TransactionRequest,
+    ) -> Result<Recovered<OpTransactionSigned>, SignerError> {
+        let request: OpTransactionRequest = request.into();
+        let Ok(tx) = request.build_typed_tx() else {
+            return Err(SignerError::FailedToBuildTx);
+        };
+        self.sign_tx(tx)
     }
 
     pub fn sign_tx(
         &self,
         tx: OpTypedTransaction,
-    ) -> Result<Recovered<OpTransactionSigned>, secp256k1::Error> {
+    ) -> Result<Recovered<OpTransactionSigned>, SignerError> {
         let signature_hash = match &tx {
             OpTypedTransaction::Legacy(tx) => tx.signature_hash(),
             OpTypedTransaction::Eip2930(tx) => tx.signature_hash(),
@@ -58,7 +78,7 @@ impl Signer {
     }
 }
 
-impl FromStr for Signer {
+impl FromStr for OpSigner {
     type Err = eyre::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -78,7 +98,7 @@ mod test {
         let secret =
             fixed_bytes!("7a3233fcd52c19f9ffce062fd620a8888930b086fba48cfea8fc14aac98a4dce");
         let address = address!("B2B9609c200CA9b7708c2a130b911dabf8B49B20");
-        let signer = Signer::try_from_secret(secret).expect("signer creation");
+        let signer = OpSigner::try_from_secret(secret).expect("signer creation");
         assert_eq!(signer.address, address);
 
         let tx = OpTypedTransaction::Eip1559(TxEip1559 {

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -145,8 +145,6 @@ tempfile = "3.8"
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 
 [features]
-# TODO: remove?
-optimism = []
 redact-sensitive = []
 
 [[bench]]

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -171,10 +171,7 @@ fn test_bundle_timestamp() -> eyre::Result<()> {
         let block_args = block_args.timestamp(base_ts + 1000);
         let mut test_setup = TestSetup::gen_test_setup(block_args)?;
 
-        let adjust_ts = |ts: Option<i32>| match ts {
-            Some(delta) => Some(delta as u64 + base_ts),
-            None => None,
-        };
+        let adjust_ts = |ts: Option<i32>| ts.map(|delta| delta as u64 + base_ts);
         let ok_timestamp_params = vec![
             (Some(1), Some(5000)),
             (None, Some(5000)),

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -361,11 +361,7 @@ where
     // used in the optimism context. If further customisation is required in the future
     // this should be improved on.
     fn timings(&self) -> TimingsConfig {
-        if cfg!(feature = "optimism") {
-            TimingsConfig::optimism()
-        } else {
-            TimingsConfig::ethereum()
-        }
+        TimingsConfig::ethereum()
     }
 }
 

--- a/crates/rbuilder/src/utils/tx_signer.rs
+++ b/crates/rbuilder/src/utils/tx_signer.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::SignableTransaction;
 use alloy_primitives::{Address, PrimitiveSignature as Signature, B256, U256};
 use reth_primitives::{public_key_to_address, Recovered, Transaction, TransactionSigned};
-use secp256k1::{Message, SecretKey, SECP256K1};
+use secp256k1::{ecdsa::RecoveryId, Message, SecretKey, SECP256K1};
 
 /// Simple struct to sign txs/messages.
 /// Mainly used to sign payout txs from the builder and to create test data.
@@ -28,7 +28,7 @@ impl Signer {
         let signature = Signature::new(
             U256::try_from_be_slice(&data[..32]).expect("The slice has at most 32 bytes"),
             U256::try_from_be_slice(&data[32..64]).expect("The slice has at most 32 bytes"),
-            i32::from(rec_id) != 0,
+            rec_id != RecoveryId::Zero,
         );
         Ok(signature)
     }


### PR DESCRIPTION
## 📝 Summary

op-rbuilder changes for reth 1.3.4. Reth had some major upheavals to its payload builder and generator and this mimics the op payload builder implementation as closely as possible.

* Introduction of Block Builder Executor, which means we need to implement our own custom executor to add revert protection
* Refactor of how payload builder is implemented in reth
* Clean up on the signer struct
* Note: flashblocks builder not in scope for this refactor
---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
