### PR TITLE
deps: remove unused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3623,7 +3623,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.8",
- "ssz_rs 0.9.0 (git+https://github.com/ralexstokes/ssz-rs?rev=84ef2b71aa004f6767420badb42c902ad56b8b72)",
+ "ssz_rs",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -8573,19 +8573,14 @@ dependencies = [
  "alloy-node-bindings",
  "alloy-primitives 0.8.23",
  "alloy-provider",
- "alloy-pubsub",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 0.12.6",
- "alloy-serde 0.12.6",
  "alloy-signer-local",
- "alloy-transport",
- "alloy-transport-http",
  "assert_matches",
  "async-trait",
- "atoi",
  "beacon-api-client",
  "bigdecimal 0.4.6",
  "built",
@@ -8593,7 +8588,6 @@ dependencies = [
  "criterion 0.5.1",
  "crossbeam",
  "crossbeam-queue",
- "csv",
  "ctor",
  "dashmap 6.1.0",
  "derivative",
@@ -8609,7 +8603,6 @@ dependencies = [
  "foldhash",
  "futures",
  "governor",
- "humantime",
  "integer-encoding",
  "itertools 0.11.0",
  "jsonrpsee 0.20.4",
@@ -8620,7 +8613,6 @@ dependencies = [
  "metrics_macros",
  "mev-share-sse",
  "mockall",
- "once_cell",
  "parking_lot",
  "primitive-types",
  "priority-queue",
@@ -8628,11 +8620,9 @@ dependencies = [
  "quick_cache",
  "rand 0.8.5",
  "rayon",
- "redis",
  "reipc",
  "reqwest 0.12.9",
  "reth",
- "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-db",
  "reth-db-common",
@@ -8657,8 +8647,6 @@ dependencies = [
  "sha2 0.10.8",
  "shellexpand",
  "sqlx",
- "ssz_rs 0.9.0 (git+https://github.com/ralexstokes/ssz-rs.git)",
- "ssz_rs_derive 0.9.0 (git+https://github.com/ralexstokes/ssz-rs.git)",
  "sysperf",
  "tempfile",
  "test_utils",
@@ -8670,11 +8658,9 @@ dependencies = [
  "toml 0.8.19",
  "tracing",
  "tracing-subscriber",
- "tungstenite 0.23.0",
  "url",
  "uuid",
  "warp",
- "zip",
 ]
 
 [[package]]
@@ -8682,21 +8668,6 @@ name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
-
-[[package]]
-name = "redis"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
-dependencies = [
- "combine",
- "itoa",
- "percent-encoding",
- "ryu",
- "sha1_smol",
- "socket2",
- "url",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -13302,35 +13273,13 @@ dependencies = [
  "bitvec",
  "serde",
  "sha2 0.9.9",
- "ssz_rs_derive 0.9.0 (git+https://github.com/ralexstokes/ssz-rs?rev=84ef2b71aa004f6767420badb42c902ad56b8b72)",
-]
-
-[[package]]
-name = "ssz_rs"
-version = "0.9.0"
-source = "git+https://github.com/ralexstokes/ssz-rs.git#ec3073e2273b4d0873fcb6df68ff4eff79588e92"
-dependencies = [
- "alloy-primitives 0.8.23",
- "bitvec",
- "serde",
- "sha2 0.9.9",
- "ssz_rs_derive 0.9.0 (git+https://github.com/ralexstokes/ssz-rs.git)",
+ "ssz_rs_derive",
 ]
 
 [[package]]
 name = "ssz_rs_derive"
 version = "0.9.0"
 source = "git+https://github.com/ralexstokes/ssz-rs?rev=84ef2b71aa004f6767420badb42c902ad56b8b72#84ef2b71aa004f6767420badb42c902ad56b8b72"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ssz_rs_derive"
-version = "0.9.0"
-source = "git+https://github.com/ralexstokes/ssz-rs.git#ec3073e2273b4d0873fcb6df68ff4eff79588e92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14384,24 +14333,6 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.1.0",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ revm = { version = "20.0.0-alpha.6", features = [
     "secp256k1",
     "optional_balance_check",
 ], default-features = false }
-revm-inspectors = "0.17.0-alpha.1"
+revm-inspectors = { version = "0.17.0-alpha.1", default-features = false }
 op-revm = { version = "1.0.0-alpha.5", default-features = false }
 
 ethereum_ssz_derive = "0.8"

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -21,10 +21,8 @@ eyre.workspace = true
 thiserror.workspace = true
 reth.workspace = true
 reth-db.workspace = true
-reth-db-common.workspace = true
 reth-errors.workspace = true
 reth-payload-builder.workspace = true
-reth-basic-payload-builder.workspace = true
 reth-trie.workspace = true
 reth-trie-parallel.workspace = true
 reth-node-api.workspace = true
@@ -44,19 +42,14 @@ alloy-rlp.workspace = true
 alloy-chains.workspace = true
 alloy-evm.workspace = true
 alloy-provider.workspace = true
-alloy-pubsub.workspace = true
 alloy-rpc-types.workspace = true
 alloy-json-rpc.workspace = true
-alloy-transport-http.workspace = true
 alloy-network.workspace = true
 alloy-network-primitives.workspace = true
-alloy-transport.workspace = true
 alloy-rpc-types-beacon.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-rpc-types-eth.workspace = true
-alloy-node-bindings.workspace = true
 alloy-consensus.workspace = true
-alloy-serde.workspace = true
 alloy-signer-local.workspace = true
 alloy-eips.workspace = true
 
@@ -81,9 +74,6 @@ sqlx = { version = "0.7.1", features = [
 ] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
-csv = "1.2.2"
-zip = "0.6.6"
-atoi = "2.0.0"
 futures = "0.3.28"
 time.workspace = true
 bigdecimal = "0.4.1"
@@ -101,35 +91,28 @@ flate2.workspace = true
 # Version required by ethereum-consensus beacon-api-client
 mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8", default-features = false }
 jsonrpsee = { version = "0.20.3", features = ["full"] }
-ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs.git", version = "0.9.0" }
 beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "cf3c404043230559660810bc0c9d6d5a8498d819" }
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "cf3c404043230559660810bc0c9d6d5a8498d819" }
-ssz_rs_derive = { git = "https://github.com/ralexstokes/ssz-rs.git", version = "0.9.0" }
 uuid = { version = "1.6.1", features = ["serde", "v5", "v4"] }
 prometheus.workspace = true
 warp.workspace = true
 lazy_static.workspace = true
 ctor.workspace = true
-toml = "0.8.8"
+toml = { version = "0.8.8", default-features = false }
 ahash.workspace = true
 rand = "0.8.5"
 lru = "0.12.1"
-humantime = "2.1.0"
 flume = "0.11.0"
 crossbeam-queue = "0.3.10"
 integer-encoding = "4.0.0"
 sha2 = "0.10.8"
 lz4_flex = "0.11.2"
-once_cell = "1.19.0"
 exponential-backoff = "1.2.0"
-tungstenite = "0.23.0"
-redis = "0.25.4"
 governor = "0.6.3"
 derivative = "2.2.0"
 mockall = "0.12.1"
 shellexpand = "3.1.0"
 async-trait = "0.1.80"
-foldhash = "0.1.3"
 eth-sparse-mpt.workspace = true
 sysperf.workspace = true
 crossbeam = "0.8.4"
@@ -146,6 +129,9 @@ quick_cache = "0.6.11"
 built = { version = "0.7.1", features = ["git2", "chrono"] }
 
 [dev-dependencies]
+reth-db-common.workspace = true
+alloy-node-bindings.workspace = true
+foldhash = "0.1.3"
 tempfile = "3.8"
 assert_matches = "1.5.0"
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }


### PR DESCRIPTION
## 📝 Summary

Remove unused `rbuilder` deps and slim down features to reduce compilation time and binary size.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
