### PR TITLE
perf: precompile cache

### DIFF
--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -1,21 +1,3 @@
-pub mod block_orders;
-pub mod builders;
-pub mod built_block_trace;
-#[cfg(test)]
-pub mod conflict;
-pub mod evm_inspector;
-pub mod fmt;
-pub mod order_commit;
-pub mod payout_tx;
-pub mod sim;
-pub mod testing;
-pub mod tracers;
-use alloy_consensus::{Header, EMPTY_OMMER_ROOT_HASH};
-use alloy_primitives::{Address, Bytes, U256};
-use builders::mock_block_building_helper::MockRootHasher;
-use reth_primitives::BlockBody;
-use reth_primitives_traits::{proofs, Block as _};
-
 use crate::{
     live_builder::{block_list_provider::BlockList, payload_events::InternalPayloadId},
     primitives::{Order, OrderId, SimValue, SimulatedOrder, TransactionSignedEcRecoveredWithBlobs},
@@ -23,6 +5,7 @@ use crate::{
     roothash::RootHashError,
     utils::{a2r_withdrawal, default_cfg_env, timestamp_as_u64, Signer},
 };
+use alloy_consensus::{Header, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::{
     eip1559::{calculate_block_gas_limit, ETHEREUM_BLOCK_GAS_LIMIT_30M},
     eip4844::BlobTransactionSidecar,
@@ -32,9 +15,10 @@ use alloy_eips::{
     merge::BEACON_NONCE,
 };
 use alloy_evm::{block::system_calls::SystemCaller, env::EvmEnv, eth::eip6110};
-use alloy_primitives::B256;
+use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
 use jsonrpsee::core::Serialize;
+use precompile_cache::EthCachedEvmFactory;
 use reth::{
     payload::PayloadId,
     primitives::{Block, Receipt, SealedBlock},
@@ -43,10 +27,12 @@ use reth::{
 };
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_errors::{BlockExecutionError, BlockValidationError, ProviderError};
-use reth_evm::{ConfigureEvm, EthEvmFactory, NextBlockEnvAttributes};
+use reth_evm::{ConfigureEvm, NextBlockEnvAttributes};
 use reth_evm_ethereum::{revm_spec_by_timestamp_and_block_number, EthEvmConfig};
 use reth_node_api::{EngineApiMessageVersion, PayloadBuilderAttributes};
 use reth_payload_builder::EthPayloadBuilderAttributes;
+use reth_primitives::BlockBody;
+use reth_primitives_traits::{proofs, Block as _};
 use revm::{
     context::BlockEnv,
     context_interface::{block::BlobExcessGasAndPrice, result::InvalidTransaction},
@@ -64,18 +50,31 @@ use std::{
 use thiserror::Error;
 use time::OffsetDateTime;
 
-use self::tracers::SimulationTracer;
-pub use block_orders::*;
-pub use built_block_trace::*;
+pub mod block_orders;
+pub mod builders;
+pub mod built_block_trace;
+#[cfg(test)]
+pub mod conflict;
+pub mod evm_inspector;
+pub mod fmt;
+pub mod order_commit;
+pub mod payout_tx;
+pub mod precompile_cache;
+pub mod sim;
+pub mod testing;
+pub mod tracers;
+
+pub use self::{
+    block_orders::*, builders::mock_block_building_helper::MockRootHasher, built_block_trace::*,
+    order_commit::*, payout_tx::*, sim::simulate_order, tracers::SimulationTracer,
+};
+
 #[cfg(test)]
 pub use conflict::*;
-pub use order_commit::*;
-pub use payout_tx::*;
-pub use sim::simulate_order;
 
 #[derive(Debug, Clone)]
 pub struct BlockBuildingContext {
-    pub evm_factory: EthEvmFactory,
+    pub evm_factory: EthCachedEvmFactory,
     pub evm_env: EvmEnv,
     pub attributes: EthPayloadBuilderAttributes,
     pub chain_spec: Arc<ChainSpec>,
@@ -164,7 +163,7 @@ impl BlockBuildingContext {
             )
         });
         Some(BlockBuildingContext {
-            evm_factory: EthEvmFactory::default(),
+            evm_factory: EthCachedEvmFactory::default(),
             evm_env,
             attributes,
             chain_spec,
@@ -247,7 +246,7 @@ impl BlockBuildingContext {
             )
         });
         BlockBuildingContext {
-            evm_factory: EthEvmFactory::default(),
+            evm_factory: EthCachedEvmFactory::default(),
             evm_env,
             attributes,
             chain_spec,

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -18,11 +18,14 @@ use alloy_eips::eip4844::{DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK};
 use alloy_primitives::{Address, B256, U256};
 use reth::revm::{cached::CachedReads, database::StateProviderDatabase};
 use reth_errors::ProviderError;
-use reth_evm::{EthEvmFactory, Evm, EvmEnv, EvmFactory};
+use reth_evm::{Evm, EvmEnv, EvmFactory};
 use reth_primitives::Receipt;
 use reth_provider::{StateProvider, StateProviderBox};
 use revm::{
-    context::result::ResultAndState,
+    context::{
+        result::{HaltReason, ResultAndState},
+        TxEnv,
+    },
     context_interface::result::{EVMError, ExecutionResult, InvalidTransaction},
     database::{states::bundle_state::BundleRetention, BundleState, State, WrapDatabaseRef},
     Database, DatabaseCommit,
@@ -1213,14 +1216,21 @@ fn update_nonce_list_with_updates(
 ///
 /// Gas checks must be done before calling this methods
 /// thats why it can't return `TransactionErr::GasLeft` and  `TransactionErr::BlobGasLeft`
-fn execute_evm(
-    evm_factory: &EthEvmFactory,
-    evm_env: EvmEnv,
+fn execute_evm<Factory>(
+    evm_factory: &Factory,
+    evm_env: EvmEnv<Factory::Spec>,
     tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
     used_state_tracer: Option<&mut UsedStateTrace>,
     db: impl Database<Error = ProviderError>,
     blocklist: &HashSet<Address>,
-) -> Result<Result<ResultAndState, TransactionErr>, CriticalCommitOrderError> {
+) -> Result<Result<ResultAndState, TransactionErr>, CriticalCommitOrderError>
+where
+    Factory: EvmFactory<
+        Tx = TxEnv,
+        HaltReason = HaltReason,
+        Error<ProviderError> = EVMError<ProviderError>,
+    >,
+{
     let tx = tx_with_blobs.internal_tx_unsecure();
     let mut rbuilder_inspector = RBuilderEVMInspector::new(tx, used_state_tracer);
 

--- a/crates/rbuilder/src/building/precompile_cache.rs
+++ b/crates/rbuilder/src/building/precompile_cache.rs
@@ -3,7 +3,7 @@ use ahash::HashMap;
 use alloy_primitives::{Address, Bytes};
 use derive_more::{Deref, DerefMut};
 use lru::LruCache;
-use parking_lot::RwLock;
+use parking_lot::Mutex;
 use reth_evm::{eth::EthEvmContext, EthEvm, EthEvmFactory, EvmEnv, EvmFactory};
 use revm::{
     context::{
@@ -31,7 +31,7 @@ pub struct WrappedPrecompile<P> {
     /// The precompile to wrap.
     precompile: P,
     /// The cache to use.
-    cache: Arc<RwLock<PrecompileCache>>,
+    cache: Arc<Mutex<PrecompileCache>>,
     /// The spec id to use.
     spec: SpecId,
 }
@@ -39,7 +39,7 @@ pub struct WrappedPrecompile<P> {
 impl<P> WrappedPrecompile<P> {
     /// Given a [`PrecompileProvider`] and cache for a specific precompiles, create a
     /// wrapper that can be used inside Evm.
-    pub fn new(precompile: P, cache: Arc<RwLock<PrecompileCache>>) -> Self {
+    pub fn new(precompile: P, cache: Arc<Mutex<PrecompileCache>>) -> Self {
         WrappedPrecompile {
             precompile,
             cache: cache.clone(),
@@ -65,11 +65,10 @@ impl<CTX: ContextTr, P: PrecompileProvider<CTX, Output = InterpreterResult>> Pre
         bytes: &Bytes,
         gas_limit: u64,
     ) -> Result<Option<Self::Output>, String> {
-        let mut cache = self.cache.write();
         let key = (self.spec, bytes.clone(), gas_limit);
 
         // get the result if it exists
-        if let Some(precompiles) = cache.get_mut(address) {
+        if let Some(precompiles) = self.cache.lock().get_mut(address) {
             if let Some(result) = precompiles.get(&key) {
                 inc_precompile_cache_hits();
                 return result.clone().map(Some);
@@ -83,7 +82,8 @@ impl<CTX: ContextTr, P: PrecompileProvider<CTX, Output = InterpreterResult>> Pre
 
         if let Some(output) = output.clone().transpose() {
             // insert the result into the cache
-            cache
+            self.cache
+                .lock()
                 .entry(*address)
                 .or_insert(PrecompileResultCache::new(NonZeroUsize::new(2048).unwrap()))
                 .put(key, output);
@@ -104,7 +104,7 @@ impl<CTX: ContextTr, P: PrecompileProvider<CTX, Output = InterpreterResult>> Pre
 #[derive(Debug, Clone, Default)]
 pub struct EthCachedEvmFactory {
     evm_factory: EthEvmFactory,
-    cache: Arc<RwLock<PrecompileCache>>,
+    cache: Arc<Mutex<PrecompileCache>>,
 }
 
 impl EvmFactory for EthCachedEvmFactory {

--- a/crates/rbuilder/src/building/precompile_cache.rs
+++ b/crates/rbuilder/src/building/precompile_cache.rs
@@ -1,5 +1,4 @@
-use std::{num::NonZeroUsize, sync::Arc};
-
+use crate::telemetry::{inc_precompile_cache_hits, inc_precompile_cache_misses};
 use ahash::HashMap;
 use alloy_primitives::{Address, Bytes};
 use derive_more::{Deref, DerefMut};
@@ -17,6 +16,7 @@ use revm::{
     primitives::hardfork::SpecId,
     Context, Database, Inspector,
 };
+use std::{num::NonZeroUsize, sync::Arc};
 
 /// A precompile cache that stores precompile call results by precompile address.
 #[derive(Deref, DerefMut, Default, Debug)]
@@ -71,9 +71,12 @@ impl<CTX: ContextTr, P: PrecompileProvider<CTX, Output = InterpreterResult>> Pre
         // get the result if it exists
         if let Some(precompiles) = cache.get_mut(address) {
             if let Some(result) = precompiles.get(&key) {
+                inc_precompile_cache_hits();
                 return result.clone().map(Some);
             }
         }
+
+        inc_precompile_cache_misses();
 
         // call the precompile if cache miss
         let output = self.precompile.run(context, address, bytes, gas_limit);

--- a/crates/rbuilder/src/building/precompile_cache.rs
+++ b/crates/rbuilder/src/building/precompile_cache.rs
@@ -1,0 +1,161 @@
+use std::{num::NonZeroUsize, sync::Arc};
+
+use ahash::HashMap;
+use alloy_primitives::{Address, Bytes};
+use derive_more::{Deref, DerefMut};
+use lru::LruCache;
+use parking_lot::RwLock;
+use reth_evm::{eth::EthEvmContext, EthEvm, EthEvmFactory, EvmEnv, EvmFactory};
+use revm::{
+    context::{
+        result::{EVMError, HaltReason},
+        BlockEnv, Cfg, CfgEnv, ContextTr, TxEnv,
+    },
+    handler::{EthPrecompiles, PrecompileProvider},
+    inspector::NoOpInspector,
+    interpreter::{interpreter::EthInterpreter, InterpreterResult},
+    primitives::hardfork::SpecId,
+    Context, Database, Inspector,
+};
+
+/// A precompile cache that stores precompile call results by precompile address.
+#[derive(Deref, DerefMut, Default, Debug)]
+pub struct PrecompileCache(HashMap<Address, PrecompileResultCache>);
+
+/// Precompile result LRU cache  stored by `(spec id, input, gas limit)` key.
+pub type PrecompileResultCache = LruCache<(SpecId, Bytes, u64), Result<InterpreterResult, String>>;
+
+/// A custom precompile that contains the cache and precompile it wraps.
+#[derive(Clone)]
+pub struct WrappedPrecompile<P> {
+    /// The precompile to wrap.
+    precompile: P,
+    /// The cache to use.
+    cache: Arc<RwLock<PrecompileCache>>,
+    /// The spec id to use.
+    spec: SpecId,
+}
+
+impl<P> WrappedPrecompile<P> {
+    /// Given a [`PrecompileProvider`] and cache for a specific precompiles, create a
+    /// wrapper that can be used inside Evm.
+    pub fn new(precompile: P, cache: Arc<RwLock<PrecompileCache>>) -> Self {
+        WrappedPrecompile {
+            precompile,
+            cache: cache.clone(),
+            spec: SpecId::LATEST,
+        }
+    }
+}
+
+impl<CTX: ContextTr, P: PrecompileProvider<CTX, Output = InterpreterResult>> PrecompileProvider<CTX>
+    for WrappedPrecompile<P>
+{
+    type Output = P::Output;
+
+    fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) {
+        self.precompile.set_spec(spec.clone());
+        self.spec = spec.into();
+    }
+
+    fn run(
+        &mut self,
+        context: &mut CTX,
+        address: &Address,
+        bytes: &Bytes,
+        gas_limit: u64,
+    ) -> Result<Option<Self::Output>, String> {
+        let mut cache = self.cache.write();
+        let key = (self.spec, bytes.clone(), gas_limit);
+
+        // get the result if it exists
+        if let Some(precompiles) = cache.get_mut(address) {
+            if let Some(result) = precompiles.get(&key) {
+                return result.clone().map(Some);
+            }
+        }
+
+        // call the precompile if cache miss
+        let output = self.precompile.run(context, address, bytes, gas_limit);
+
+        if let Some(output) = output.clone().transpose() {
+            // insert the result into the cache
+            cache
+                .entry(*address)
+                .or_insert(PrecompileResultCache::new(NonZeroUsize::new(2048).unwrap()))
+                .put(key, output);
+        }
+
+        output
+    }
+
+    fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
+        self.precompile.warm_addresses()
+    }
+
+    fn contains(&self, address: &Address) -> bool {
+        self.precompile.contains(address)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EthCachedEvmFactory {
+    evm_factory: EthEvmFactory,
+    cache: Arc<RwLock<PrecompileCache>>,
+}
+
+impl EvmFactory for EthCachedEvmFactory {
+    type Evm<DB, I>
+        = EthEvm<DB, I, WrappedPrecompile<EthPrecompiles>>
+    where
+        DB: Database<Error: Send + Sync + 'static>,
+        I: Inspector<EthEvmContext<DB>>;
+
+    type Context<DB>
+        = Context<BlockEnv, TxEnv, CfgEnv, DB>
+    where
+        DB: Database<Error: Send + Sync + 'static>;
+
+    type Error<DBError>
+        = EVMError<DBError>
+    where
+        DBError: core::error::Error + Send + Sync + 'static;
+
+    type Tx = TxEnv;
+    type HaltReason = HaltReason;
+    type Spec = SpecId;
+
+    fn create_evm<DB>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector>
+    where
+        DB: Database<Error: Send + Sync + 'static>,
+    {
+        let evm = self
+            .evm_factory
+            .create_evm(db, input)
+            .into_inner()
+            .with_precompiles(WrappedPrecompile::new(
+                EthPrecompiles::default(),
+                self.cache.clone(),
+            ));
+
+        EthEvm::new(evm, false)
+    }
+
+    fn create_evm_with_inspector<DB, I>(
+        &self,
+        db: DB,
+        input: EvmEnv,
+        inspector: I,
+    ) -> Self::Evm<DB, I>
+    where
+        DB: Database<Error: Send + Sync + 'static>,
+        I: Inspector<Self::Context<DB>, EthInterpreter>,
+    {
+        EthEvm::new(
+            self.create_evm(db, input)
+                .into_inner()
+                .with_inspector(inspector),
+            true,
+        )
+    }
+}

--- a/crates/rbuilder/src/live_builder/simulation/simulation_job.rs
+++ b/crates/rbuilder/src/live_builder/simulation/simulation_job.rs
@@ -94,13 +94,14 @@ impl SimulationJob {
         info!(
             ?self.orders_received,
             ?self.orders_simulated_ok,
-        bundles_with_replace = self.orders_with_replacement_key,
-        unique_replace_count = self.unique_replacement_key_bundles.len(),
-        bundles_with_replace_sim_ok = self.orders_with_replacement_key_sim_ok,
-        unique_replace_count_sim_ok = self.unique_replacement_key_bundles_sim_ok.len(),
-            "Stopping simulation job "
+            bundles_with_replace = self.orders_with_replacement_key,
+            unique_replace_count = self.unique_replacement_key_bundles.len(),
+            bundles_with_replace_sim_ok = self.orders_with_replacement_key_sim_ok,
+            unique_replace_count_sim_ok = self.unique_replacement_key_bundles_sim_ok.len(),
+            "Stopping simulation job"
         );
     }
+
     async fn run_no_trace(&mut self) {
         let mut new_commands = Vec::new();
         let mut new_sim_results = Vec::new();
@@ -186,8 +187,7 @@ impl SimulationJob {
         for sim_result in new_sim_results {
             trace!(order_id=?sim_result.simulated_order.order.id(),
             sim_duration_mus = sim_result.simulation_time.as_micros(),
-            profit = format_ether(sim_result.simulated_order.sim_value.coinbase_profit),
-            "Order simulated");
+            profit = format_ether(sim_result.simulated_order.sim_value.coinbase_profit), "Order simulated");
             self.orders_simulated_ok
                 .accumulate(&sim_result.simulated_order.order);
             if let Some(repl_key) = sim_result.simulated_order.order.replacement_key() {

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -6,8 +6,8 @@
 //! When metric server is spawned is serves prometheus metrics at: /debug/metrics/prometheus
 
 #![allow(unexpected_cfgs)]
-use crate::building::BuiltBlockTrace;
 use crate::{
+    building::BuiltBlockTrace,
     live_builder::block_list_provider::{blocklist_hash, BlockList},
     primitives::mev_boost::MevBoostRelayID,
     utils::build_info::Version,
@@ -21,9 +21,10 @@ use prometheus::{
     Counter, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
     Registry,
 };
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
-use std::time::Instant;
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 use time::OffsetDateTime;
 use tracing::error;
 
@@ -177,6 +178,14 @@ register_metrics! {
         &["worker_id"]
     )
     .unwrap();
+    pub static SIMULATION_PRECOMPILE_CACHE_HITS: IntCounter = IntCounter::new(
+        "simulation_precompile_cache_hits",
+        "Precompile cache hits"
+    ).unwrap();
+    pub static SIMULATION_PRECOMPILE_CACHE_MISSES: IntCounter = IntCounter::new(
+        "simulation_precompile_cache_misses",
+        "Precompile cache misses"
+    ).unwrap();
     pub static PROVIDER_REOPEN_COUNTER: IntCounter = IntCounter::new(
         "provider_reopen_counter", "Counter of provider reopens").unwrap();
 
@@ -502,6 +511,14 @@ pub fn add_sim_thread_utilisation_timings(
     SIMULATION_THREAD_WAIT_TIME
         .with_label_values(&[&thread_id.to_string()])
         .inc_by(wait_time.as_micros() as u64);
+}
+
+pub fn inc_precompile_cache_hits() {
+    SIMULATION_PRECOMPILE_CACHE_HITS.inc();
+}
+
+pub fn inc_precompile_cache_misses() {
+    SIMULATION_PRECOMPILE_CACHE_MISSES.inc();
 }
 
 /// landed vs attempt


### PR DESCRIPTION
## 📝 Summary

Adds precompile cache that is valid for the duration of the `BlockBuildingContext`. The precompile cache is installed by replacing `EthEvmFactory` with `EthCachedEvmFactory`. 

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
