### PR TITLE
Introduce ThreadBlockBuildingContext, remove old CachedReads.

### DIFF
--- a/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
@@ -117,14 +117,13 @@ where
                     builder_name: builder_name.clone(),
                     sim_orders: &sim_orders,
                     provider: provider_factory.clone(),
-                    cached_reads: None,
                 };
                 let build_res = config.build_backtest_block(builder_name, input);
                 if let Err(err) = &build_res {
                     println!("Error building block: {:?}", err);
                     return None;
                 }
-                let (block, _) = build_res.ok()?;
+                let block = build_res.ok()?;
                 println!(
                     "Built block {} with builder: {:?}",
                     ctx.block(),

--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{Address, U256};
-use reth::revm::cached::CachedReads;
 use reth_chainspec::ChainSpec;
 use serde::{Deserialize, Serialize};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
@@ -180,19 +179,15 @@ where
     let simulated_total_gas = sim_orders.iter().map(|o| o.sim_value.gas_used).sum();
     let mut builder_outputs = Vec::new();
 
-    let mut cached_reads = Some(CachedReads::default());
     for building_algorithm_name in builders_names {
         let input = BacktestSimulateBlockInput {
             ctx: ctx.clone(),
             builder_name: building_algorithm_name.clone(),
             sim_orders: &sim_orders,
             provider: provider.clone(),
-            cached_reads,
         };
 
-        let (block, new_cached_reads) =
-            config.build_backtest_block(&building_algorithm_name, input)?;
-        cached_reads = Some(new_cached_reads);
+        let block = config.build_backtest_block(&building_algorithm_name, input)?;
         builder_outputs.push(BacktestBuilderOutput {
             orders_included: block.trace.included_orders.len(),
             builder_name: building_algorithm_name,

--- a/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
@@ -1,7 +1,7 @@
 use crate::{
     building::{
         evm_inspector::SlotKey, tracers::AccumulatorSimulationTracer, BlockBuildingContext,
-        BlockState, PartialBlock, PartialBlockFork,
+        BlockState, PartialBlock, PartialBlockFork, ThreadBlockBuildingContext,
     },
     provider::StateProviderFactory,
     utils::{extract_onchain_block_txs, find_suggested_fee_recipient, signed_uint_delta},
@@ -55,12 +55,14 @@ where
         Arc::from(provider.root_hasher(parent_num_hash)?),
     );
 
+    let mut local_ctx = ThreadBlockBuildingContext::default();
+
     let state_provider = provider.history_by_block_hash(ctx.attributes.parent)?;
     let mut partial_block = PartialBlock::new(true);
     let mut state = BlockState::new(state_provider);
 
     partial_block
-        .pre_block_call(&ctx, &mut state)
+        .pre_block_call(&ctx, &mut local_ctx, &mut state)
         .with_context(|| "Failed to pre_block_call")?;
 
     let mut cumulative_gas_used = 0;
@@ -68,14 +70,23 @@ where
     let mut written_slots: HashMap<SlotKey, Vec<B256>> = HashMap::default();
 
     for (idx, tx) in txs.into_iter().enumerate() {
-        let coinbase_balance_before = state.balance(coinbase)?;
+        let coinbase_balance_before = state.balance(
+            coinbase,
+            &ctx.shared_cached_reads,
+            &mut local_ctx.cached_reads,
+        )?;
         let mut accumulator_tracer = AccumulatorSimulationTracer::default();
         let result = {
-            let mut fork = PartialBlockFork::new(&mut state).with_tracer(&mut accumulator_tracer);
-            fork.commit_tx(&tx, &ctx, cumulative_gas_used, 0, cumulative_blob_gas_used)?
+            let mut fork = PartialBlockFork::new(&mut state, &ctx, &mut local_ctx)
+                .with_tracer(&mut accumulator_tracer);
+            fork.commit_tx(&tx, cumulative_gas_used, 0, cumulative_blob_gas_used)?
                 .with_context(|| format!("Failed to commit tx: {} {:?}", idx, tx.hash()))?
         };
-        let coinbase_balance_after = state.balance(coinbase)?;
+        let coinbase_balance_after = state.balance(
+            coinbase,
+            &ctx.shared_cached_reads,
+            &mut local_ctx.cached_reads,
+        )?;
         let coinbase_profit = signed_uint_delta(coinbase_balance_after, coinbase_balance_before);
 
         cumulative_gas_used += result.gas_used;

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -6,12 +6,14 @@ use clap::Parser;
 use eyre::Context;
 use itertools::Itertools;
 use rbuilder::{
-    building::{BlockBuildingContext, BlockState, PartialBlock, PartialBlockFork},
+    building::{
+        BlockBuildingContext, BlockState, PartialBlock, PartialBlockFork,
+        ThreadBlockBuildingContext,
+    },
     live_builder::{base_config::load_config_toml_and_env, cli::LiveBuilderConfig, config::Config},
     provider::StateProviderFactory,
     utils::{extract_onchain_block_txs, find_suggested_fee_recipient, http_provider},
 };
-use reth::revm::cached::CachedReads;
 use reth_provider::StateProvider;
 use std::{path::PathBuf, sync::Arc, time::Instant};
 use tracing::{debug, info};
@@ -82,16 +84,15 @@ async fn main() -> eyre::Result<()> {
 
     let mut build_times_ms = Vec::new();
     let mut finalize_time_ms = Vec::new();
-    let mut cached_reads = Some(CachedReads::default());
     for _ in 0..cli.iters {
         let ctx = ctx.clone();
         let txs = txs.clone();
         let state_provider = state_provider.clone();
-        let (new_cached_reads, build_time, finalize_time) =
+        let (build_time, finalize_time) =
             tokio::task::spawn_blocking(move || -> eyre::Result<_> {
                 let partial_block = PartialBlock::new(true);
-                let mut state = BlockState::new_arc(state_provider)
-                    .with_cached_reads(cached_reads.unwrap_or_default());
+                let mut state = BlockState::new_arc(state_provider);
+                let mut local_ctx = ThreadBlockBuildingContext::default();
 
                 let build_time = Instant::now();
 
@@ -99,8 +100,8 @@ async fn main() -> eyre::Result<()> {
                 let mut cumulative_blob_gas_used = 0;
                 for (idx, tx) in txs.into_iter().enumerate() {
                     let result = {
-                        let mut fork = PartialBlockFork::new(&mut state);
-                        fork.commit_tx(&tx, &ctx, cumulative_gas_used, 0, cumulative_blob_gas_used)?
+                        let mut fork = PartialBlockFork::new(&mut state, &ctx, &mut local_ctx);
+                        fork.commit_tx(&tx, cumulative_gas_used, 0, cumulative_blob_gas_used)?
                             .with_context(|| {
                                 format!("Failed to commit tx: {} {:?}", idx, tx.hash())
                             })?
@@ -112,7 +113,7 @@ async fn main() -> eyre::Result<()> {
                 let build_time = build_time.elapsed();
 
                 let finalize_time = Instant::now();
-                let finalized_block = partial_block.finalize(&mut state, &ctx)?;
+                let finalized_block = partial_block.finalize(&mut state, &ctx, &mut local_ctx)?;
                 let finalize_time = finalize_time.elapsed();
 
                 debug!(
@@ -120,11 +121,10 @@ async fn main() -> eyre::Result<()> {
                     finalized_block.sealed_block.state_root
                 );
 
-                Ok((finalized_block.cached_reads, build_time, finalize_time))
+                Ok((build_time, finalize_time))
             })
             .await??;
 
-        cached_reads = Some(new_cached_reads);
         build_times_ms.push(build_time.as_millis());
         finalize_time_ms.push(finalize_time.as_millis());
     }

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -16,7 +16,7 @@ use rbuilder::{
             BlockBuildingAlgorithm, BlockBuildingAlgorithmInput, OrderConsumer,
             UnfinishedBlockBuildingSink, UnfinishedBlockBuildingSinkFactory,
         },
-        BlockBuildingContext, SimulatedOrderStore,
+        BlockBuildingContext, SimulatedOrderStore, ThreadBlockBuildingContext,
     },
     live_builder::{
         base_config::{
@@ -206,6 +206,7 @@ impl DummyBuildingAlgorithm {
     where
         P: StateProviderFactory + Clone + 'static,
     {
+        let mut local_ctx = ThreadBlockBuildingContext::default();
         let block_state = provider
             .history_by_block_hash(ctx.attributes.parent)?
             .into();
@@ -213,7 +214,7 @@ impl DummyBuildingAlgorithm {
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
             block_state,
             ctx.clone(),
-            None,
+            &mut local_ctx,
             BUILDER_NAME.to_string(),
             false,
             CancellationToken::new(),
@@ -221,7 +222,7 @@ impl DummyBuildingAlgorithm {
 
         for order in orders {
             // don't care about the result
-            let _ = block_building_helper.commit_order(&order, &|_| Ok(()))?;
+            let _ = block_building_helper.commit_order(&mut local_ctx, &order, &|_| Ok(()))?;
         }
         Ok(Box::new(block_building_helper))
     }

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -1,5 +1,4 @@
 use alloy_primitives::{utils::format_ether, U256};
-use reth::revm::cached::CachedReads;
 use reth_provider::StateProvider;
 use std::{
     cmp::max,
@@ -15,7 +14,7 @@ use crate::{
         estimate_payout_gas_limit, tracers::GasUsedSimulationTracer, BlockBuildingContext,
         BlockState, BuiltBlockTrace, BuiltBlockTraceError, CriticalCommitOrderError,
         EstimatePayoutGasErr, ExecutionError, ExecutionResult, FinalizeError, FinalizeResult,
-        PartialBlock,
+        PartialBlock, ThreadBlockBuildingContext,
     },
     primitives::{SimValue, SimulatedOrder},
     telemetry::{self, add_block_fill_time, add_order_simulation_time},
@@ -39,6 +38,7 @@ pub trait BlockBuildingHelper: Send + Sync {
     /// See [PartialBlock::commit_order]
     fn commit_order(
         &mut self,
+        local_ctx: &mut ThreadBlockBuildingContext,
         order: &SimulatedOrder,
         result_filter: &dyn Fn(&SimValue) -> Result<(), ExecutionError>,
     ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError>;
@@ -62,21 +62,16 @@ pub trait BlockBuildingHelper: Send + Sync {
     ///     This only works if can_add_payout_tx.
     fn finalize_block(
         self: Box<Self>,
+        local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: Option<U256>,
         seen_competition_bid: Option<U256>,
     ) -> Result<FinalizeBlockResult, BlockBuildingHelperError>;
-
-    /// Useful if we want to give away this object but keep on building some other way.
-    fn clone_cached_reads(&self) -> CachedReads;
 
     /// BuiltBlockTrace for current state.
     fn built_block_trace(&self) -> &BuiltBlockTrace;
 
     /// BlockBuildingContext used for building.
     fn building_context(&self) -> &BlockBuildingContext;
-
-    /// Updates the cached reads for the block state.
-    fn update_cached_reads(&mut self, cached_reads: CachedReads);
 
     /// Name of the builder that pregenerated this block.
     /// BE CAREFUL: Might be ambiguous if several building parts were involved...
@@ -182,8 +177,6 @@ impl BlockBuildingHelperError {
 
 pub struct FinalizeBlockResult {
     pub block: Block,
-    /// Since finalize_block eats the object we need the cached_reads in case we create a new
-    pub cached_reads: CachedReads,
 }
 
 impl BlockBuildingHelperFromProvider {
@@ -196,7 +189,7 @@ impl BlockBuildingHelperFromProvider {
     pub fn new(
         state_provider: Arc<dyn StateProvider>,
         building_ctx: BlockBuildingContext,
-        cached_reads: Option<CachedReads>,
+        local_ctx: &mut ThreadBlockBuildingContext,
         builder_name: String,
         discard_txs: bool,
         cancel_on_fatal_error: CancellationToken,
@@ -209,10 +202,9 @@ impl BlockBuildingHelperFromProvider {
             .unwrap_or_default();
         let mut partial_block =
             PartialBlock::new(discard_txs).with_tracer(GasUsedSimulationTracer::default());
-        let mut block_state =
-            BlockState::new_arc(state_provider).with_cached_reads(cached_reads.unwrap_or_default());
+        let mut block_state = BlockState::new_arc(state_provider);
         partial_block
-            .pre_block_call(&building_ctx, &mut block_state)
+            .pre_block_call(&building_ctx, local_ctx, &mut block_state)
             .map_err(|_| BlockBuildingHelperError::PreBlockCallFailed)?;
         let payout_tx_gas = if building_ctx.coinbase_is_suggested_fee_recipient() {
             None
@@ -220,6 +212,7 @@ impl BlockBuildingHelperFromProvider {
             let payout_tx_gas = estimate_payout_gas_limit(
                 building_ctx.attributes.suggested_fee_recipient,
                 &building_ctx,
+                local_ctx,
                 &mut block_state,
                 0,
             )?;
@@ -281,6 +274,7 @@ impl BlockBuildingHelperFromProvider {
     /// Inserts payout tx if necessary and updates built_block_trace.
     fn finalize_block_execution(
         &mut self,
+        local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: Option<U256>,
     ) -> Result<(), BlockBuildingHelperError> {
         self.built_block_trace.coinbase_reward = self.partial_block.coinbase_profit;
@@ -295,6 +289,7 @@ impl BlockBuildingHelperFromProvider {
                 payout_tx_gas,
                 payout_tx_value,
                 &self.building_ctx,
+                local_ctx,
                 &mut self.block_state,
             ) {
                 Ok(()) => (payout_tx_value, self.true_block_value()?),
@@ -309,9 +304,11 @@ impl BlockBuildingHelperFromProvider {
         };
         // Since some extra money might arrived directly the suggested_fee_recipient (when suggested_fee_recipient != coinbase)
         // we check the fee_recipient delta and make our bid include that! This is supposed to be what the relay will check.
-        let fee_recipient_balance_after = self
-            .block_state
-            .balance(self.building_ctx.attributes.suggested_fee_recipient)?;
+        let fee_recipient_balance_after = self.block_state.balance(
+            self.building_ctx.attributes.suggested_fee_recipient,
+            &self.building_ctx.shared_cached_reads,
+            &mut local_ctx.cached_reads,
+        )?;
         let fee_recipient_balance_diff = fee_recipient_balance_after
             .checked_sub(self._fee_recipient_balance_start)
             .unwrap_or_default();
@@ -337,6 +334,7 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
     /// Forwards to partial_block and updates trace.
     fn commit_order(
         &mut self,
+        local_ctx: &mut ThreadBlockBuildingContext,
         order: &SimulatedOrder,
         result_filter: &dyn Fn(&SimValue) -> Result<(), ExecutionError>,
     ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
@@ -344,6 +342,7 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
         let result = self.partial_block.commit_order(
             order,
             &self.building_ctx,
+            local_ctx,
             &mut self.block_state,
             result_filter,
         );
@@ -394,6 +393,7 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
 
     fn finalize_block(
         mut self: Box<Self>,
+        local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: Option<U256>,
         seen_competition_bid: Option<U256>,
     ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
@@ -402,30 +402,31 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
         }
         let start_time = Instant::now();
 
-        self.finalize_block_execution(payout_tx_value)?;
+        self.finalize_block_execution(local_ctx, payout_tx_value)?;
         // This could be moved outside of this func (pre finalize) since I don´t think the payout tx can change much.
         self.built_block_trace
             .verify_bundle_consistency(&self.building_ctx.blocklist)?;
 
         let sim_gas_used = self.partial_block.tracer.used_gas;
         let block_number = self.building_context().block();
-        let finalized_block = match self
-            .partial_block
-            .finalize(&mut self.block_state, &self.building_ctx)
-        {
-            Ok(finalized_block) => finalized_block,
-            Err(err) => {
-                if err.is_consistent_db_view_err() {
-                    debug!(
-                        block_number,
-                        payload_id = self.building_ctx.payload_id,
-                        "Can't build on this head, cancelling slot"
-                    );
-                    self.cancel_on_fatal_error.cancel();
+        let finalized_block =
+            match self
+                .partial_block
+                .finalize(&mut self.block_state, &self.building_ctx, local_ctx)
+            {
+                Ok(finalized_block) => finalized_block,
+                Err(err) => {
+                    if err.is_consistent_db_view_err() {
+                        debug!(
+                            block_number,
+                            payload_id = self.building_ctx.payload_id,
+                            "Can't build on this head, cancelling slot"
+                        );
+                        self.cancel_on_fatal_error.cancel();
+                    }
+                    return Err(BlockBuildingHelperError::FinalizeError(err));
                 }
-                return Err(BlockBuildingHelperError::FinalizeError(err));
-            }
-        };
+            };
         self.built_block_trace.update_orders_sealed_at();
         self.built_block_trace.root_hash_time = finalized_block.root_hash_time;
         self.built_block_trace.finalize_time = start_time.elapsed();
@@ -445,14 +446,7 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
             builder_name: self.builder_name.clone(),
             execution_requests: finalized_block.execution_requests,
         };
-        Ok(FinalizeBlockResult {
-            block,
-            cached_reads: finalized_block.cached_reads,
-        })
-    }
-
-    fn clone_cached_reads(&self) -> CachedReads {
-        self.block_state.clone_cached_reads()
+        Ok(FinalizeBlockResult { block })
     }
 
     fn built_block_trace(&self) -> &BuiltBlockTrace {
@@ -465,10 +459,6 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
 
     fn box_clone(&self) -> Box<dyn BlockBuildingHelper> {
         Box::new(self.clone())
-    }
-
-    fn update_cached_reads(&mut self, cached_reads: CachedReads) {
-        self.block_state = self.block_state.clone().with_cached_reads(cached_reads);
     }
 
     fn builder_name(&self) -> &str {

--- a/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
@@ -1,3 +1,4 @@
+use crate::building::ThreadBlockBuildingContext;
 use crate::live_builder::simulation::SimulatedOrderCommand;
 use crate::primitives::SimValue;
 use crate::provider::RootHasher;
@@ -12,7 +13,6 @@ use crate::{
 use alloy_primitives::B256;
 use alloy_primitives::U256;
 use reth::providers::ExecutionOutcome;
-use reth::revm::cached::CachedReads;
 use reth_primitives::SealedBlock;
 use time::OffsetDateTime;
 use tokio::sync::broadcast;
@@ -66,6 +66,7 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
 
     fn commit_order(
         &mut self,
+        _local_ctx: &mut ThreadBlockBuildingContext,
         _order: &SimulatedOrder,
         _result_filter: &dyn Fn(&SimValue) -> Result<(), ExecutionError>,
     ) -> Result<Result<&ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
@@ -90,6 +91,7 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
 
     fn finalize_block(
         mut self: Box<Self>,
+        _local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: Option<U256>,
         seen_competition_bid: Option<U256>,
     ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
@@ -108,14 +110,7 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
             execution_requests: Default::default(),
         };
 
-        Ok(FinalizeBlockResult {
-            block,
-            cached_reads: CachedReads::default(),
-        })
-    }
-
-    fn clone_cached_reads(&self) -> CachedReads {
-        CachedReads::default()
+        Ok(FinalizeBlockResult { block })
     }
 
     fn built_block_trace(&self) -> &BuiltBlockTrace {
@@ -124,10 +119,6 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
 
     fn building_context(&self) -> &BlockBuildingContext {
         &self.block_building_context
-    }
-
-    fn update_cached_reads(&mut self, _cached_reads: CachedReads) {
-        unimplemented!()
     }
 
     fn builder_name(&self) -> &str {

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -18,7 +18,7 @@ use ahash::HashSet;
 use alloy_eips::eip4844::BlobTransactionSidecar;
 use alloy_primitives::{Address, Bytes};
 use block_building_helper::BiddableUnfinishedBlock;
-use reth::{primitives::SealedBlock, revm::cached::CachedReads};
+use reth::primitives::SealedBlock;
 use std::{fmt::Debug, sync::Arc};
 use tokio::sync::{
     broadcast,
@@ -236,7 +236,6 @@ pub struct BacktestSimulateBlockInput<'a, P> {
     pub builder_name: String,
     pub sim_orders: &'a Vec<Arc<SimulatedOrder>>,
     pub provider: P,
-    pub cached_reads: Option<CachedReads>,
 }
 
 /// Handles error from block filling stage.

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -12,7 +12,7 @@ use crate::{
             block_building_helper::BlockBuildingHelper, LiveBuilderInput, OrderIntakeConsumer,
         },
         BlockBuildingContext, ExecutionError, OrderPriority, PrioritizedOrderStore,
-        SimulatedOrderSink, Sorting,
+        SimulatedOrderSink, Sorting, ThreadBlockBuildingContext,
     },
     primitives::{AccountNonce, OrderId, SimValue},
     provider::StateProviderFactory,
@@ -21,7 +21,6 @@ use crate::{
 };
 use ahash::{HashMap, HashSet};
 use derivative::Derivative;
-use reth::revm::cached::CachedReads;
 use reth_provider::StateProvider;
 use serde::Deserialize;
 use std::{
@@ -154,7 +153,7 @@ pub fn run_ordering_builder<P, OrderPriorityType>(
 pub fn backtest_simulate_block<P, OrderPriorityType: OrderPriority>(
     ordering_config: OrderingBuilderConfig,
     input: BacktestSimulateBlockInput<'_, P>,
-) -> eyre::Result<(Block, CachedReads)>
+) -> eyre::Result<Block>
 where
     P: StateProviderFactory + Clone + 'static,
 {
@@ -164,13 +163,13 @@ where
         .history_by_block_number(input.ctx.evm_env.block_env.number - 1)?;
     let block_orders =
         block_orders_from_sim_orders::<OrderPriorityType>(input.sim_orders, &state_provider)?;
+    let mut local_ctx = ThreadBlockBuildingContext::default();
     let mut builder = OrderingBuilderContext::new(
         Arc::from(state_provider),
         input.builder_name,
         input.ctx.clone(),
         ordering_config,
-    )
-    .with_cached_reads(input.cached_reads.unwrap_or_default());
+    );
     let block_builder = builder.build_block(
         block_orders,
         use_suggested_fee_recipient_as_coinbase,
@@ -182,11 +181,9 @@ where
     } else {
         Some(block_builder.true_block_value()?)
     };
-    let finalize_block_result = block_builder.finalize_block(payout_tx_value, None)?;
-    Ok((
-        finalize_block_result.block,
-        finalize_block_result.cached_reads,
-    ))
+    let finalize_block_result =
+        block_builder.finalize_block(&mut local_ctx, payout_tx_value, None)?;
+    Ok(finalize_block_result.block)
 }
 
 #[derive(Derivative)]
@@ -199,7 +196,7 @@ pub struct OrderingBuilderContext {
     config: OrderingBuilderConfig,
 
     // caches
-    cached_reads: Option<CachedReads>,
+    local_ctx: ThreadBlockBuildingContext,
 
     // scratchpad
     failed_orders: HashSet<OrderId>,
@@ -217,22 +214,11 @@ impl OrderingBuilderContext {
             state,
             builder_name,
             ctx,
+            local_ctx: Default::default(),
             config,
-            cached_reads: None,
             failed_orders: HashSet::default(),
             order_attempts: HashMap::default(),
         }
-    }
-
-    pub fn with_cached_reads(self, cached_reads: CachedReads) -> Self {
-        Self {
-            cached_reads: Some(cached_reads),
-            ..self
-        }
-    }
-
-    pub fn take_cached_reads(&mut self) -> Option<CachedReads> {
-        self.cached_reads.take()
     }
 
     /// use_suggested_fee_recipient_as_coinbase: all the mev profit goes directly to the slot suggested_fee_recipient so we avoid the payout tx.
@@ -261,7 +247,7 @@ impl OrderingBuilderContext {
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
             self.state.clone(),
             new_ctx,
-            self.cached_reads.take(),
+            &mut self.local_ctx,
             self.builder_name.clone(),
             self.config.discard_txs,
             cancel_block,
@@ -269,7 +255,6 @@ impl OrderingBuilderContext {
 
         self.fill_orders(&mut block_building_helper, block_orders, build_start)?;
         block_building_helper.set_trace_fill_time(build_start.elapsed());
-        self.cached_reads = Some(block_building_helper.clone_cached_reads());
         Ok(Box::new(block_building_helper))
     }
 
@@ -293,9 +278,13 @@ impl OrderingBuilderContext {
                 block_building_helper.builder_name(),
             );
             let start_time = Instant::now();
-            let commit_result = block_building_helper.commit_order(&sim_order, &|sim_result| {
-                simulation_too_low::<OrderPriorityType>(&sim_order.sim_value, sim_result)
-            })?;
+            let commit_result = block_building_helper.commit_order(
+                &mut self.local_ctx,
+                &sim_order,
+                &|sim_result| {
+                    simulation_too_low::<OrderPriorityType>(&sim_order.sim_value, sim_result)
+                },
+            )?;
             let order_commit_time = start_time.elapsed();
             let mut gas_used = 0;
             let mut execution_error = None;

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use ahash::HashMap;
 use alloy_primitives::utils::format_ether;
-use reth::revm::cached::CachedReads;
 use reth_provider::StateProvider;
 use std::{sync::Arc, time::Instant};
 use time::OffsetDateTime;
@@ -19,7 +18,7 @@ use crate::{
             },
             handle_building_error, UnfinishedBlockBuildingSink,
         },
-        BlockBuildingContext,
+        BlockBuildingContext, ThreadBlockBuildingContext,
     },
     telemetry::mark_builder_considers_order,
 };
@@ -28,8 +27,8 @@ use crate::{
 pub struct BlockBuildingResultAssembler {
     state: Arc<dyn StateProvider>,
     ctx: BlockBuildingContext,
+    pub local_ctx: ThreadBlockBuildingContext,
     cancellation_token: CancellationToken,
-    cached_reads: Option<CachedReads>,
     discard_txs: bool,
     coinbase_payment: bool,
     can_use_suggested_fee_recipient_as_coinbase: bool,
@@ -63,8 +62,8 @@ impl BlockBuildingResultAssembler {
         Self {
             state,
             ctx,
+            local_ctx: Default::default(),
             cancellation_token,
-            cached_reads: None,
             discard_txs: config.discard_txs,
             coinbase_payment: config.coinbase_payment,
             can_use_suggested_fee_recipient_as_coinbase,
@@ -197,7 +196,7 @@ impl BlockBuildingResultAssembler {
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
             self.state.clone(),
             ctx,
-            self.cached_reads.clone(),
+            &mut self.local_ctx,
             self.builder_name.clone(),
             self.discard_txs,
             self.cancellation_token.clone(),
@@ -230,7 +229,9 @@ impl BlockBuildingResultAssembler {
                     block_building_helper.builder_name(),
                 );
                 let start_time = Instant::now();
-                let commit_result = block_building_helper.commit_order(sim_order, &|_| Ok(()))?;
+                let commit_result =
+                    block_building_helper
+                        .commit_order(&mut self.local_ctx, sim_order, &|_| Ok(()))?;
                 let order_commit_time = start_time.elapsed();
 
                 let mut gas_used = 0;
@@ -256,19 +257,18 @@ impl BlockBuildingResultAssembler {
             }
         }
         block_building_helper.set_trace_fill_time(build_start.elapsed());
-        self.cached_reads = Some(block_building_helper.clone_cached_reads());
         Ok(Box::new(block_building_helper))
     }
 
     pub fn build_backtest_block(
-        &self,
+        &mut self,
         best_results: HashMap<GroupId, (ResolutionResult, ConflictGroup)>,
         orders_closed_at: OffsetDateTime,
     ) -> eyre::Result<Box<dyn BlockBuildingHelper>> {
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
             self.state.clone(),
             self.ctx.clone(),
-            None, // No cached reads for backtest start
+            &mut self.local_ctx,
             String::from("backtest_builder"),
             self.discard_txs,
             CancellationToken::new(),
@@ -299,7 +299,9 @@ impl BlockBuildingResultAssembler {
             for (order_idx, _) in sequence_of_orders.sequence_of_orders.iter() {
                 let sim_order = &order_group.orders[*order_idx];
 
-                let commit_result = block_building_helper.commit_order(sim_order, &|_| Ok(()))?;
+                let commit_result =
+                    block_building_helper
+                        .commit_order(&mut self.local_ctx, sim_order, &|_| Ok(()))?;
 
                 match commit_result {
                     Ok(res) => {

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
@@ -4,7 +4,7 @@ use derivative::Derivative;
 use eyre::Result;
 use itertools::Itertools;
 use rand::{seq::SliceRandom, SeedableRng};
-use reth::{providers::StateProvider, revm::cached::CachedReads};
+use reth::providers::StateProvider;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::trace;
@@ -15,7 +15,10 @@ use super::{
 };
 
 use crate::{
-    building::{BlockBuildingContext, BlockState, ExecutionError, ExecutionResult, PartialBlock},
+    building::{
+        BlockBuildingContext, BlockState, ExecutionError, ExecutionResult, PartialBlock,
+        ThreadBlockBuildingContext,
+    },
     primitives::{OrderId, SimulatedOrder},
 };
 
@@ -28,7 +31,6 @@ pub struct ResolverContext {
     pub state: Arc<dyn StateProvider>,
     pub ctx: BlockBuildingContext,
     pub cancellation_token: CancellationToken,
-    pub cache: Option<CachedReads>,
     pub simulation_cache: Arc<SharedSimulationCache>,
 }
 
@@ -46,14 +48,12 @@ impl ResolverContext {
         state: Arc<dyn StateProvider>,
         ctx: BlockBuildingContext,
         cancellation_token: CancellationToken,
-        cache: Option<CachedReads>,
         simulation_cache: Arc<SharedSimulationCache>,
     ) -> Self {
         ResolverContext {
             state,
             ctx,
             cancellation_token,
-            cache,
             simulation_cache,
         }
     }
@@ -82,12 +82,9 @@ impl ResolverContext {
         };
 
         for sequence_of_orders in sequence_to_try {
-            let (resolution_result, state) =
+            let (resolution_result, _state) =
                 self.process_sequence_of_orders(sequence_of_orders, &task, self.state.clone())?;
             self.update_best_result(resolution_result, &mut best_resolution_result);
-
-            let (new_cached_reads, _, _) = state.into_parts();
-            self.cache = Some(new_cached_reads);
         }
 
         trace!(
@@ -133,6 +130,9 @@ impl ResolverContext {
         task: &ConflictTask,
         state_provider: Arc<dyn StateProvider>,
     ) -> Result<(ResolutionResult, BlockState)> {
+        // @todo actually reuse it for the duration of the block
+        let mut local_ctx = ThreadBlockBuildingContext::default();
+
         let order_id_to_index = self.initialize_order_id_to_index_map(task);
         let full_sequence_of_orders = self.initialize_full_order_ids_vec(&sequence_of_orders, task);
 
@@ -143,8 +143,8 @@ impl ResolverContext {
 
         // Initialize state and partial block
         let mut partial_block = PartialBlock::new(true);
-        let mut state = self.initialize_block_state(&cached_state_option, state_provider);
-        partial_block.pre_block_call(&self.ctx, &mut state)?;
+        let mut state = self.initialize_block_state(state_provider);
+        partial_block.pre_block_call(&self.ctx, &mut local_ctx, &mut state)?;
 
         // Initialize sequenced_order_result
         let mut sequenced_order_result =
@@ -171,7 +171,13 @@ impl ResolverContext {
             }
 
             let sim_order = &task.group.orders[order_idx];
-            match partial_block.commit_order(sim_order, &self.ctx, &mut state, &|_| Ok(()))? {
+            match partial_block.commit_order(
+                sim_order,
+                &self.ctx,
+                &mut local_ctx,
+                &mut state,
+                &|_| Ok(()),
+            )? {
                 Ok(res) => self.handle_successful_commit(
                     res,
                     sim_order,
@@ -279,24 +285,8 @@ impl ResolverContext {
     }
 
     /// Initializes the block state, using a cached state if available.
-    fn initialize_block_state(
-        &mut self,
-        cached_state_option: &Option<Arc<CachedSimulationState>>,
-        state_provider: Arc<dyn StateProvider>,
-    ) -> BlockState {
-        if let Some(cached_state) = &cached_state_option {
-            // Use cached state
-            BlockState::new_arc(state_provider.clone())
-                .with_cached_reads(cached_state.cached_reads.clone())
-                .with_bundle_state(cached_state.bundle_state.clone())
-        } else {
-            // If we don't have a cached state from the simulation cache, we use the cached reads from the block state in some cases
-            if let Some(cache) = &self.cache {
-                BlockState::new_arc(state_provider).with_cached_reads(cache.clone())
-            } else {
-                BlockState::new_arc(state_provider)
-            }
-        }
+    fn initialize_block_state(&mut self, state_provider: Arc<dyn StateProvider>) -> BlockState {
+        BlockState::new_arc(state_provider)
     }
 
     /// Stores the simulation state in the cache.
@@ -307,9 +297,8 @@ impl ResolverContext {
         total_profit: U256,
         per_order_profits: &[(OrderId, U256)],
     ) {
-        let (cached_reads, bundle_state, _) = state.clone().into_parts();
+        let (bundle_state, _) = state.clone().into_parts();
         let cached_simulation_state = CachedSimulationState {
-            cached_reads,
             bundle_state,
             total_profit,
             per_order_profits: per_order_profits.to_owned(),

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
@@ -117,7 +117,6 @@ where
             state,
             ctx.clone(),
             cancellation_token.clone(),
-            None,
             simulation_cache,
         );
         let task_id = task.group_idx;

--- a/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
@@ -36,7 +36,6 @@ use crate::{
     },
     provider::StateProviderFactory,
 };
-use reth::revm::cached::CachedReads;
 
 use self::{
     block_building_result_assembler::BlockBuildingResultAssembler,
@@ -282,7 +281,7 @@ fn run_order_intake(
 pub fn parallel_build_backtest<P>(
     input: BacktestSimulateBlockInput<'_, P>,
     config: ParallelBuilderConfig,
-) -> Result<(Block, CachedReads)>
+) -> Result<Block>
 where
     P: StateProviderFactory + Clone + 'static,
 {
@@ -339,7 +338,7 @@ where
 
     // Block building result assembler creation
     let assembler_start = Instant::now();
-    let block_building_result_assembler = BlockBuildingResultAssembler::new(
+    let mut block_building_result_assembler = BlockBuildingResultAssembler::new(
         &config,
         Arc::clone(&best_results),
         block_state.clone(),
@@ -372,7 +371,11 @@ where
     } else {
         Some(block_building_helper.true_block_value()?)
     };
-    let finalize_block_result = block_building_helper.finalize_block(payout_tx_value, None)?;
+    let finalize_block_result = block_building_helper.finalize_block(
+        &mut block_building_result_assembler.local_ctx,
+        payout_tx_value,
+        None,
+    )?;
     let building_duration = building_start.elapsed();
     let total_duration = start_time.elapsed();
 
@@ -384,10 +387,7 @@ where
     trace!("Block building time: {:?}", building_duration);
     trace!("Total time taken: {:?}", total_duration);
 
-    Ok((
-        finalize_block_result.block,
-        finalize_block_result.cached_reads,
-    ))
+    Ok(finalize_block_result.block)
 }
 
 #[derive(Debug)]

--- a/crates/rbuilder/src/building/builders/parallel_builder/simulation_cache.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/simulation_cache.rs
@@ -2,7 +2,6 @@ use crate::primitives::OrderId;
 use ahash::HashMap;
 use alloy_primitives::U256;
 use parking_lot::RwLock as PLRwLock;
-use reth::revm::cached::CachedReads;
 use revm::database::BundleState;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -12,7 +11,6 @@ use std::sync::{
 /// An instance of a simulation result that has been cached.
 #[derive(Debug, Clone)]
 pub struct CachedSimulationState {
-    pub cached_reads: CachedReads,
     pub bundle_state: BundleState,
     pub total_profit: U256,
     pub per_order_profits: Vec<(OrderId, U256)>,
@@ -211,10 +209,8 @@ mod tests {
         }
 
         fn create_cached_simulation_state(&mut self) -> CachedSimulationState {
-            let mut cached_reads = CachedReads::default();
             let mut storage = AlloyHashMap::default();
             storage.insert(U256::from(self.last_used_id), U256::from(self.last_used_id));
-            cached_reads.insert_account(Address::random(), AccountInfo::default(), storage);
 
             let mut storage_bundle_account: AlloyHashMap<U256, StorageSlot> =
                 AlloyHashMap::default();
@@ -234,7 +230,6 @@ mod tests {
             bundle_state.state.insert(Address::random(), account);
 
             CachedSimulationState {
-                cached_reads,
                 bundle_state,
                 total_profit: U256::from(self.last_used_id),
                 per_order_profits: vec![(self.create_order_id(), U256::from(10))],
@@ -244,7 +239,7 @@ mod tests {
 
     /// This test verifies that we can store a cached simulation state for a specific ordering
     /// and then retrieve it correctly. It checks if the retrieved state matches the stored state,
-    /// including BundleState and CachedReads, and if the cached index is correct.
+    /// including BundleState, and if the cached index is correct.
     #[test]
     fn test_store_and_retrieve_cached_state() {
         let cache = SharedSimulationCache::new();

--- a/crates/rbuilder/src/building/cached_reads.rs
+++ b/crates/rbuilder/src/building/cached_reads.rs
@@ -1,0 +1,206 @@
+//! Caching layer for database, its used to minimize disc access.
+//! There are 2 caches: one global shared between different threads and one owned by local thread.
+
+use ahash::HashMap;
+use alloy_primitives::{Address, B256, U256};
+use dashmap::DashMap;
+use revm::{bytecode::Bytecode, state::AccountInfo, Database};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use tracing::info;
+
+/// Database cache shared bewteen multiple threads.
+/// It should be created for unique parent block.
+#[derive(Debug, Clone, Default)]
+pub struct SharedCachedReads {
+    pub account_info: DashMap<Address, Option<AccountInfo>>,
+    pub storage: DashMap<(Address, U256), U256>,
+
+    pub code_by_hash: DashMap<B256, Bytecode>,
+    pub block_hash: DashMap<u64, B256>,
+
+    pub local_hit_count: Arc<AtomicU64>,
+    pub local_miss_count: Arc<AtomicU64>,
+    pub shared_hit_count: Arc<AtomicU64>,
+    pub shared_miss_count: Arc<AtomicU64>,
+}
+
+impl Drop for SharedCachedReads {
+    fn drop(&mut self) {
+        let local_hit_count = self.local_hit_count.load(Ordering::Relaxed);
+        let local_miss_count = self.local_miss_count.load(Ordering::Relaxed);
+        let local_hit_perc =
+            100.0 * local_hit_count as f64 / (local_hit_count + local_miss_count) as f64;
+        let shared_hit_count = self.shared_hit_count.load(Ordering::Relaxed);
+        let shared_miss_count = self.shared_miss_count.load(Ordering::Relaxed);
+        let shared_hit_perc =
+            100.0 * shared_hit_count as f64 / (shared_hit_count + shared_miss_count) as f64;
+        info!(
+            local_hit_count,
+            local_miss_count,
+            shared_hit_count,
+            shared_miss_count,
+            local_hit_perc,
+            shared_hit_perc,
+            "Storage cache stats"
+        );
+    }
+}
+
+/// Database cache local to some process. It should be created for unique parent block.
+/// It should be created for unique parent block.
+#[derive(Debug, Clone, Default)]
+pub struct LocalCachedReads {
+    pub account_info: HashMap<Address, Option<AccountInfo>>,
+    pub storage: HashMap<(Address, U256), U256>,
+}
+
+#[derive(Debug)]
+pub struct CachedDB<'a, 'b, DB> {
+    db: DB,
+    local_cache: &'a mut LocalCachedReads,
+    shared_cache: &'b SharedCachedReads,
+}
+
+impl<'a, 'b, DB> CachedDB<'a, 'b, DB> {
+    pub fn new(
+        db: DB,
+        local_cache: &'a mut LocalCachedReads,
+        shared_cache: &'b SharedCachedReads,
+    ) -> Self {
+        Self {
+            db,
+            local_cache,
+            shared_cache,
+        }
+    }
+
+    fn inc_local_hit(&self) {
+        self.shared_cache
+            .local_hit_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    fn inc_local_miss(&self) {
+        self.shared_cache
+            .local_miss_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    fn inc_shared_hit(&self) {
+        self.shared_cache
+            .shared_hit_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    fn inc_shared_miss(&self) {
+        self.shared_cache
+            .shared_miss_count
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl<DB: Database> Database for CachedDB<'_, '_, DB> {
+    type Error = DB::Error;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        let mut result = None;
+        let mut local_cache_fill = false;
+        let mut shared_cache_fill = false;
+
+        if let Some(data) = self.local_cache.account_info.get(&address) {
+            self.inc_local_hit();
+            result = Some(data.clone());
+        } else {
+            self.inc_local_miss();
+            local_cache_fill = true;
+        }
+
+        if result.is_none() {
+            if let Some(data) = self.shared_cache.account_info.get(&address) {
+                self.inc_shared_hit();
+                result = Some(data.clone());
+            } else {
+                self.inc_shared_miss();
+                shared_cache_fill = true;
+            }
+        }
+        let result = if let Some(result) = result {
+            result
+        } else {
+            self.db.basic(address)?
+        };
+
+        if local_cache_fill {
+            self.local_cache
+                .account_info
+                .insert(address, result.clone());
+        }
+        if shared_cache_fill {
+            self.shared_cache
+                .account_info
+                .insert(address, result.clone());
+        }
+        Ok(result)
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        if let Some(data) = self.shared_cache.code_by_hash.get(&code_hash) {
+            self.inc_shared_hit();
+            return Ok(data.clone());
+        }
+        self.inc_shared_miss();
+        let data = self.db.code_by_hash(code_hash)?;
+        self.shared_cache
+            .code_by_hash
+            .insert(code_hash, data.clone());
+        Ok(data)
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        let mut result = None;
+        let mut local_cache_fill = false;
+        let mut shared_cache_fill = false;
+
+        if let Some(data) = self.local_cache.storage.get(&(address, index)) {
+            self.inc_local_hit();
+            result = Some(*data);
+        } else {
+            self.inc_local_miss();
+            local_cache_fill = true;
+        }
+
+        if result.is_none() {
+            if let Some(data) = self.shared_cache.storage.get(&(address, index)) {
+                self.inc_shared_hit();
+                result = Some(*data);
+            } else {
+                self.inc_shared_miss();
+                shared_cache_fill = true;
+            }
+        }
+        let result = if let Some(result) = result {
+            result
+        } else {
+            self.db.storage(address, index)?
+        };
+
+        if local_cache_fill {
+            self.local_cache.storage.insert((address, index), result);
+        }
+        if shared_cache_fill {
+            self.shared_cache.storage.insert((address, index), result);
+        }
+        Ok(result)
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        if let Some(data) = self.shared_cache.block_hash.get(&number) {
+            self.inc_shared_hit();
+            return Ok(*data);
+        }
+        self.inc_shared_miss();
+        let data = self.db.block_hash(number)?;
+        self.shared_cache.block_hash.insert(number, data);
+        Ok(data)
+    }
+}

--- a/crates/rbuilder/src/building/conflict.rs
+++ b/crates/rbuilder/src/building/conflict.rs
@@ -1,4 +1,4 @@
-use super::{BlockBuildingContext, BlockState, PartialBlockFork};
+use super::{BlockBuildingContext, BlockState, PartialBlockFork, ThreadBlockBuildingContext};
 use crate::primitives::{Order, OrderId};
 use alloy_primitives::{Address, U256};
 use itertools::Itertools;
@@ -30,12 +30,13 @@ pub fn find_conflict_slow(
     orders: &[Order],
 ) -> eyre::Result<HashMap<(OrderId, OrderId), Conflict>> {
     let mut state_provider = Arc::<dyn StateProvider>::from(state_provider);
+    let mut local_ctx = ThreadBlockBuildingContext::default();
     let profits_alone = {
         let mut profits_alone = HashMap::new();
         for order in orders {
             let mut state = BlockState::new_arc(state_provider);
-            let mut fork = PartialBlockFork::new(&mut state);
-            if let Ok(res) = fork.commit_order(order, ctx, 0, 0, 0, true)? {
+            let mut fork = PartialBlockFork::new(&mut state, ctx, &mut local_ctx);
+            if let Ok(res) = fork.commit_order(order, 0, 0, 0, true)? {
                 profits_alone.insert(order.id(), res.coinbase_profit);
             };
             state_provider = state.into_provider();
@@ -72,10 +73,10 @@ pub fn find_conflict_slow(
         }
 
         let mut state = BlockState::new_arc(state_provider);
-        let mut fork = PartialBlockFork::new(&mut state);
+        let mut fork = PartialBlockFork::new(&mut state, ctx, &mut local_ctx);
         let mut gas_used = 0;
         let mut blob_gas_used = 0;
-        match fork.commit_order(order1, ctx, gas_used, 0, blob_gas_used, true)? {
+        match fork.commit_order(order1, gas_used, 0, blob_gas_used, true)? {
             Ok(res) => {
                 gas_used += res.gas_used;
                 blob_gas_used += res.blob_gas_used;
@@ -84,7 +85,7 @@ pub fn find_conflict_slow(
                 results.insert(pair, Conflict::Fatal);
             }
         };
-        match fork.commit_order(order2, ctx, gas_used, 0, blob_gas_used, true)? {
+        match fork.commit_order(order2, gas_used, 0, blob_gas_used, true)? {
             Ok(re) => {
                 let profit_alone = *profits_alone.get(&order2.id()).unwrap();
                 let profit_with_conflict = re.coinbase_profit;

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -17,13 +17,13 @@ use alloy_eips::{
 use alloy_evm::{block::system_calls::SystemCaller, env::EvmEnv, eth::eip6110};
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
+use cached_reads::{LocalCachedReads, SharedCachedReads};
 use jsonrpsee::core::Serialize;
 use precompile_cache::EthCachedEvmFactory;
 use reth::{
     payload::PayloadId,
     primitives::{Block, Receipt, SealedBlock},
     providers::ExecutionOutcome,
-    revm::cached::CachedReads,
 };
 use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_errors::{BlockExecutionError, BlockValidationError, ProviderError};
@@ -53,6 +53,7 @@ use time::OffsetDateTime;
 pub mod block_orders;
 pub mod builders;
 pub mod built_block_trace;
+pub mod cached_reads;
 #[cfg(test)]
 pub mod conflict;
 pub mod evm_inspector;
@@ -91,6 +92,7 @@ pub struct BlockBuildingContext {
     pub spec_id: SpecId,
     pub root_hasher: Arc<dyn RootHasher>,
     pub payload_id: InternalPayloadId,
+    pub shared_cached_reads: Arc<SharedCachedReads>,
 }
 
 impl BlockBuildingContext {
@@ -174,6 +176,7 @@ impl BlockBuildingContext {
             spec_id,
             root_hasher,
             payload_id,
+            shared_cached_reads: Default::default(),
         })
     }
 
@@ -257,6 +260,7 @@ impl BlockBuildingContext {
             spec_id,
             root_hasher,
             payload_id: 0,
+            shared_cached_reads: Default::default(),
         }
     }
 
@@ -293,6 +297,17 @@ impl BlockBuildingContext {
     pub fn coinbase_is_suggested_fee_recipient(&self) -> bool {
         self.evm_env.block_env.beneficiary == self.attributes.suggested_fee_recipient
     }
+}
+
+/// This context should be owned by one thread for the duration of the slot.
+/// For example, copy of this should be owned by each builder thread, top of block simulation, finalization thread.
+///
+/// Its important to not reuse this cache from one payload job to another.
+///
+/// Caches shared between threads should go to BlockBuildingContext.
+#[derive(Debug, Clone, Default)]
+pub struct ThreadBlockBuildingContext {
+    pub cached_reads: LocalCachedReads,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -439,7 +454,6 @@ impl ExecutionError {
 
 pub struct FinalizeResult {
     pub sealed_block: SealedBlock,
-    pub cached_reads: CachedReads,
     // sidecars for all txs in SealedBlock
     pub txs_blob_sidecars: Vec<Arc<BlobTransactionSidecar>>,
     /// The Pectra execution requests for this bid.
@@ -501,6 +515,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         &mut self,
         order: &SimulatedOrder,
         ctx: &BlockBuildingContext,
+        local_ctx: &mut ThreadBlockBuildingContext,
         state: &mut BlockState,
         result_filter: &dyn Fn(&SimValue) -> Result<(), ExecutionError>,
     ) -> Result<Result<ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
@@ -511,11 +526,10 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             ))));
         }
 
-        let mut fork = PartialBlockFork::new(state).with_tracer(&mut self.tracer);
+        let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
         let rollback = fork.rollback_point();
         let exec_result = fork.commit_order(
             &order.order,
-            ctx,
             self.gas_used,
             self.gas_reserved,
             self.blob_gas_used,
@@ -579,6 +593,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         gas_limit: u64,
         value: U256,
         ctx: &BlockBuildingContext,
+        local_ctx: &mut ThreadBlockBuildingContext,
         state: &mut BlockState,
     ) -> Result<(), InsertPayoutTxErr> {
         let builder_signer = ctx
@@ -587,7 +602,11 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             .ok_or(InsertPayoutTxErr::NoSigner)?;
         self.free_reserved_gas();
         let nonce = state
-            .nonce(builder_signer.address)
+            .nonce(
+                builder_signer.address,
+                &ctx.shared_cached_reads,
+                &mut local_ctx.cached_reads,
+            )
             .map_err(CriticalCommitOrderError::Reth)?;
         let tx = create_payout_tx(
             ctx.chain_spec.as_ref(),
@@ -600,8 +619,8 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         )?;
         // payout tx has no blobs so it's safe to unwrap
         let tx = TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx).unwrap();
-        let mut fork = PartialBlockFork::new(state).with_tracer(&mut self.tracer);
-        let exec_result = fork.commit_tx(&tx, ctx, self.gas_used, 0, self.blob_gas_used)?;
+        let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
+        let exec_result = fork.commit_tx(&tx, self.gas_used, 0, self.blob_gas_used)?;
         let ok_result = exec_result?;
         if !ok_result.receipt.success {
             return Err(InsertPayoutTxErr::PayoutTxReverted);
@@ -620,8 +639,9 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         &self,
         state: &mut BlockState,
         ctx: &BlockBuildingContext,
+        local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<(Option<Requests>, Option<B256>), FinalizeError> {
-        let mut db = state.new_db_ref();
+        let mut db = state.new_db_ref(&ctx.shared_cached_reads, &mut local_ctx.cached_reads);
 
         // Apply and gather execution requests
         let requests = if ctx
@@ -682,9 +702,10 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         self,
         state: &mut BlockState,
         ctx: &BlockBuildingContext,
+        local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<FinalizeResult, FinalizeError> {
-        let (requests, withdrawals_root) = self.process_requests(state, ctx)?;
-        let (cached_reads, bundle) = state.clone_bundle_and_cache();
+        let (requests, withdrawals_root) = self.process_requests(state, ctx, local_ctx)?;
+        let bundle = state.clone_bundle();
         let block_number = ctx.evm_env.block_env.number;
 
         let requests_hash = requests.as_ref().map(|requests| requests.requests_hash());
@@ -785,7 +806,6 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
 
         Ok(FinalizeResult {
             sealed_block: block.seal_slow(),
-            cached_reads,
             txs_blob_sidecars,
             root_hash_time,
             execution_requests: requests.map(|er| er.take()).unwrap_or_default(),
@@ -795,9 +815,10 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
     pub fn pre_block_call(
         &mut self,
         ctx: &BlockBuildingContext,
+        local_ctx: &mut ThreadBlockBuildingContext,
         state: &mut BlockState,
     ) -> eyre::Result<()> {
-        let mut db = state.new_db_ref();
+        let mut db = state.new_db_ref(&ctx.shared_cached_reads, &mut local_ctx.cached_reads);
         let mut system_caller = SystemCaller::new(ctx.chain_spec.clone());
         let mut evm = EthEvmConfig::new(ctx.chain_spec.clone())
             .evm_with_env(db.as_mut(), ctx.evm_env.clone());

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -1,5 +1,8 @@
 use super::{
-    create_payout_tx, tracers::SimulationTracer, BlockBuildingContext, EstimatePayoutGasErr,
+    cached_reads::{CachedDB, LocalCachedReads, SharedCachedReads},
+    create_payout_tx,
+    tracers::SimulationTracer,
+    BlockBuildingContext, EstimatePayoutGasErr, ThreadBlockBuildingContext,
 };
 use crate::{
     building::{
@@ -16,7 +19,7 @@ use ahash::HashSet;
 use alloy_consensus::{constants::KECCAK_EMPTY, Transaction};
 use alloy_eips::eip4844::{DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK};
 use alloy_primitives::{Address, B256, U256};
-use reth::revm::{cached::CachedReads, database::StateProviderDatabase};
+use reth::revm::database::StateProviderDatabase;
 use reth_errors::ProviderError;
 use reth_evm::{Evm, EvmEnv, EvmFactory};
 use reth_primitives::Receipt;
@@ -27,7 +30,7 @@ use revm::{
         TxEnv,
     },
     context_interface::result::{EVMError, ExecutionResult, InvalidTransaction},
-    database::{states::bundle_state::BundleRetention, BundleState, State, WrapDatabaseRef},
+    database::{states::bundle_state::BundleRetention, BundleState, State},
     Database, DatabaseCommit,
 };
 use std::{collections::HashMap, sync::Arc};
@@ -36,7 +39,6 @@ use thiserror::Error;
 #[derive(Clone)]
 pub struct BlockState {
     provider: Arc<dyn StateProvider>,
-    cached_reads: CachedReads,
     bundle_state: Option<BundleState>,
 }
 
@@ -48,22 +50,12 @@ impl BlockState {
     pub fn new_arc(provider: Arc<dyn StateProvider>) -> Self {
         Self {
             provider,
-            cached_reads: CachedReads::default(),
             bundle_state: Some(BundleState::default()),
         }
     }
 
-    pub fn state_provider(&self) -> &dyn StateProvider {
-        &self.provider
-    }
-
     pub fn into_provider(self) -> Arc<dyn StateProvider> {
         self.provider
-    }
-
-    pub fn with_cached_reads(mut self, cached_reads: CachedReads) -> Self {
-        self.cached_reads = cached_reads;
-        self
     }
 
     pub fn with_bundle_state(mut self, bundle_state: BundleState) -> Self {
@@ -71,20 +63,21 @@ impl BlockState {
         self
     }
 
-    pub fn into_parts(self) -> (CachedReads, BundleState, Arc<dyn StateProvider>) {
-        (self.cached_reads, self.bundle_state.unwrap(), self.provider)
+    pub fn into_parts(self) -> (BundleState, Arc<dyn StateProvider>) {
+        (self.bundle_state.unwrap(), self.provider)
     }
 
-    pub fn clone_bundle_and_cache(&self) -> (CachedReads, BundleState) {
-        (
-            self.cached_reads.clone(),
-            self.bundle_state.clone().unwrap(),
-        )
+    pub fn clone_bundle(&self) -> BundleState {
+        self.bundle_state.clone().unwrap()
     }
 
-    pub fn new_db_ref(&mut self) -> BlockStateDBRef<impl Database<Error = ProviderError> + '_> {
+    pub fn new_db_ref<'a, 'b, 'c>(
+        &'a mut self,
+        shared_cache_reads: &'b SharedCachedReads,
+        local_cache_reads: &'c mut LocalCachedReads,
+    ) -> BlockStateDBRef<'a, CachedDB<'c, 'b, impl Database<Error = ProviderError> + 'a>> {
         let state_provider = StateProviderDatabase::new(&self.provider);
-        let cachedb = WrapDatabaseRef(self.cached_reads.as_db(state_provider));
+        let cachedb = CachedDB::new(state_provider, local_cache_reads, shared_cache_reads);
         let bundle_state = self.bundle_state.take().unwrap();
         let db = State::builder()
             .with_database(cachedb)
@@ -94,8 +87,13 @@ impl BlockState {
         BlockStateDBRef::new(db, &mut self.bundle_state)
     }
 
-    pub fn balance(&mut self, address: Address) -> Result<U256, ProviderError> {
-        let mut db = self.new_db_ref();
+    pub fn balance(
+        &mut self,
+        address: Address,
+        shared_cache_reads: &SharedCachedReads,
+        local_cache_reads: &mut LocalCachedReads,
+    ) -> Result<U256, ProviderError> {
+        let mut db = self.new_db_ref(shared_cache_reads, local_cache_reads);
         Ok(db
             .as_mut()
             .basic(address)?
@@ -103,8 +101,13 @@ impl BlockState {
             .unwrap_or_default())
     }
 
-    pub fn nonce(&mut self, address: Address) -> Result<u64, ProviderError> {
-        let mut db = self.new_db_ref();
+    pub fn nonce(
+        &mut self,
+        address: Address,
+        shared_cache_reads: &SharedCachedReads,
+        local_cache_reads: &mut LocalCachedReads,
+    ) -> Result<u64, ProviderError> {
+        let mut db = self.new_db_ref(shared_cache_reads, local_cache_reads);
         Ok(db
             .as_mut()
             .basic(address)?
@@ -112,17 +115,18 @@ impl BlockState {
             .unwrap_or_default())
     }
 
-    pub fn code_hash(&mut self, address: Address) -> Result<B256, ProviderError> {
-        let mut db = self.new_db_ref();
+    pub fn code_hash(
+        &mut self,
+        address: Address,
+        shared_cache_reads: &SharedCachedReads,
+        local_cache_reads: &mut LocalCachedReads,
+    ) -> Result<B256, ProviderError> {
+        let mut db = self.new_db_ref(shared_cache_reads, local_cache_reads);
         Ok(db
             .as_mut()
             .basic(address)?
             .map(|acc| acc.code_hash)
             .unwrap_or_else(|| KECCAK_EMPTY))
-    }
-
-    pub fn clone_cached_reads(&self) -> CachedReads {
-        self.cached_reads.clone()
     }
 }
 
@@ -292,9 +296,11 @@ pub enum OrderErr {
     NegativeProfit(U256),
 }
 
-pub struct PartialBlockFork<'a, 'b, Tracer: SimulationTracer> {
+pub struct PartialBlockFork<'a, 'b, 'c, 'd, Tracer: SimulationTracer> {
     pub rollbacks: usize,
+    pub ctx: &'c BlockBuildingContext,
     pub state: &'a mut BlockState,
+    pub local_ctx: &'d mut ThreadBlockBuildingContext,
     pub tracer: Option<&'b mut Tracer>,
     /// Temporary state trace used as a scratchpad for tx execution
     tmp_used_state_tracer: UsedStateTrace,
@@ -331,14 +337,16 @@ pub enum CriticalCommitOrderError {
 /// If a tx inside a bundle or sbundle fails with TransactionErr (don't confuse this with reverting which is TransactionOk with !.receipt.success)
 /// and it's configured as allowed to revert (for bundles tx in reverting_tx_hashes, for sbundles: TxRevertBehavior != NotAllowed) we continue the
 /// the execution of the bundle/sbundle.
-impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
+impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, Tracer> {
     pub fn with_tracer<NewTracer: SimulationTracer>(
         self,
         tracer: &'b mut NewTracer,
-    ) -> PartialBlockFork<'a, 'b, NewTracer> {
+    ) -> PartialBlockFork<'a, 'b, 'c, 'd, NewTracer> {
         PartialBlockFork {
             rollbacks: self.rollbacks,
             state: self.state,
+            ctx: self.ctx,
+            local_ctx: self.local_ctx,
             tracer: Some(tracer),
             tmp_used_state_tracer: self.tmp_used_state_tracer,
         }
@@ -388,7 +396,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     pub fn commit_tx(
         &mut self,
         tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        ctx: &BlockBuildingContext,
         mut cumulative_gas_used: u64,
         gas_reserved: u64,
         mut cumulative_blob_gas_used: u64,
@@ -399,18 +406,22 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
             return Ok(Err(TransactionErr::BlobGasLeft));
         }
 
-        let mut db = self.state.new_db_ref();
+        let mut db = self.state.new_db_ref(
+            &self.ctx.shared_cached_reads,
+            &mut self.local_ctx.cached_reads,
+        );
         let tx = &tx_with_blobs.internal_tx_unsecure();
-        if ctx.blocklist.contains(&tx.signer())
+        if self.ctx.blocklist.contains(&tx.signer())
             || tx
                 .to()
-                .map(|to| ctx.blocklist.contains(&to))
+                .map(|to| self.ctx.blocklist.contains(&to))
                 .unwrap_or(false)
         {
             return Ok(Err(TransactionErr::Blocklist));
         }
 
-        match ctx
+        match self
+            .ctx
             .evm_env
             .block_env
             .gas_limit
@@ -437,12 +448,12 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         });
 
         let res = execute_evm(
-            &ctx.evm_factory,
-            ctx.evm_env.clone(),
+            &self.ctx.evm_factory,
+            self.ctx.evm_env.clone(),
             tx_with_blobs,
             used_state_tracer,
             db.as_mut(),
-            &ctx.blocklist,
+            &self.ctx.blocklist,
         )?;
         let res = match res {
             Ok(res) => res,
@@ -490,13 +501,12 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     fn commit_bundle(
         &mut self,
         bundle: &Bundle,
-        ctx: &BlockBuildingContext,
         cumulative_gas_used: u64,
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
         allow_tx_skip: bool,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
-        let current_block = ctx.evm_env.block_env.number;
+        let current_block = self.ctx.evm_env.block_env.number;
         // None is good for any block
         if let Some(block) = bundle.block {
             if block != current_block {
@@ -511,7 +521,7 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         let (min_ts, max_ts, block_ts) = (
             bundle.min_timestamp.unwrap_or(0),
             bundle.max_timestamp.unwrap_or(u64::MAX),
-            ctx.evm_env.block_env.timestamp,
+            self.ctx.evm_env.block_env.timestamp,
         );
         if !(min_ts <= block_ts && block_ts <= max_ts) {
             return Ok(Err(BundleErr::IncorrectTimestamp {
@@ -524,7 +534,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         self.execute_with_rollback(|s| {
             s.commit_bundle_no_rollback(
                 bundle,
-                ctx,
                 cumulative_gas_used,
                 gas_reserved,
                 cumulative_blob_gas_used,
@@ -545,18 +554,18 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
 
     fn estimate_refund_payout_tx(
         &mut self,
-        ctx: &BlockBuildingContext,
         to: Address,
         refundable_value: U256,
         gas_used: u64,
     ) -> Result<ReservedPayout, BundleErr> {
-        let gas_limit = match estimate_payout_gas_limit(to, ctx, self.state, gas_used) {
-            Ok(gas_limit) => gas_limit,
-            Err(err) => {
-                return Err(BundleErr::EstimatePayoutGas(err));
-            }
-        };
-        let base_fee = U256::from(ctx.evm_env.block_env.basefee) * U256::from(gas_limit);
+        let gas_limit =
+            match estimate_payout_gas_limit(to, self.ctx, self.local_ctx, self.state, gas_used) {
+                Ok(gas_limit) => gas_limit,
+                Err(err) => {
+                    return Err(BundleErr::EstimatePayoutGas(err));
+                }
+            };
+        let base_fee = U256::from(self.ctx.evm_env.block_env.basefee) * U256::from(gas_limit);
         if base_fee > refundable_value {
             return Err(BundleErr::NotEnoughRefundForGas {
                 to,
@@ -576,22 +585,25 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     /// On success insert_result is updated.
     fn insert_refund_payout_tx(
         &mut self,
-        ctx: &BlockBuildingContext,
         payout: ReservedPayout,
         to: Address,
         gas_reserved: u64,
         insert_result: &mut BundleOk,
     ) -> Result<Result<(), BundleErr>, CriticalCommitOrderError> {
-        let builder_signer = if let Some(signer) = ctx.builder_signer.as_ref() {
+        let builder_signer = if let Some(signer) = self.ctx.builder_signer.as_ref() {
             signer
         } else {
             return Ok(Err(BundleErr::NoSigner));
         };
 
-        let nonce = self.state.nonce(builder_signer.address)?;
+        let nonce = self.state.nonce(
+            builder_signer.address,
+            &self.ctx.shared_cached_reads,
+            &mut self.local_ctx.cached_reads,
+        )?;
         let payout_tx = match create_payout_tx(
-            ctx.chain_spec.as_ref(),
-            ctx.evm_env.block_env.basefee,
+            self.ctx.chain_spec.as_ref(),
+            self.ctx.evm_env.block_env.basefee,
             builder_signer,
             nonce,
             to,
@@ -606,7 +618,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         };
         let res = self.commit_tx(
             &payout_tx,
-            ctx,
             insert_result.cumulative_gas_used,
             gas_reserved,
             insert_result.cumulative_blob_gas_used,
@@ -639,7 +650,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     fn commit_bundle_no_rollback(
         &mut self,
         bundle: &Bundle,
-        ctx: &BlockBuildingContext,
         cumulative_gas_used: u64,
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
@@ -659,11 +669,14 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         };
         for tx_with_blobs in &bundle.txs {
             let tx_hash = tx_with_blobs.hash();
-            let coinbase_balance_before = self.state.balance(ctx.evm_env.block_env.beneficiary)?;
+            let coinbase_balance_before = self.state.balance(
+                self.ctx.evm_env.block_env.beneficiary,
+                &self.ctx.shared_cached_reads,
+                &mut self.local_ctx.cached_reads,
+            )?;
             let rollback_point = self.rollback_point();
             let result = self.commit_tx(
                 tx_with_blobs,
-                ctx,
                 insert.cumulative_gas_used,
                 gas_reserved,
                 insert.cumulative_blob_gas_used,
@@ -681,8 +694,11 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                     }
 
                     let coinbase_profit = {
-                        let coinbase_balance_after =
-                            self.state.balance(ctx.evm_env.block_env.beneficiary)?;
+                        let coinbase_balance_after = self.state.balance(
+                            self.ctx.evm_env.block_env.beneficiary,
+                            &self.ctx.shared_cached_reads,
+                            &mut self.local_ctx.cached_reads,
+                        )?;
                         coinbase_balance_after.checked_sub(coinbase_balance_before)
                     };
                     if let Some(profit) = coinbase_profit {
@@ -711,7 +727,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         if let Some(refunds_cfg) = &bundle.refund {
             let refundable_value = get_percent(refundable_profit, refunds_cfg.percent as usize);
             let payout = match self.estimate_refund_payout_tx(
-                ctx,
                 refunds_cfg.recipient,
                 refundable_value,
                 insert.cumulative_gas_used,
@@ -720,7 +735,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                 Err(err) => return Ok(Err(err)),
             };
             if let Err(err) = self.insert_refund_payout_tx(
-                ctx,
                 payout,
                 refunds_cfg.recipient,
                 gas_reserved,
@@ -736,13 +750,12 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     fn commit_share_bundle(
         &mut self,
         bundle: &ShareBundle,
-        ctx: &BlockBuildingContext,
         cumulative_gas_used: u64,
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
         allow_tx_skip: bool,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
-        let current_block = ctx.evm_env.block_env.number;
+        let current_block = self.ctx.evm_env.block_env.number;
         if !(bundle.block <= current_block && current_block <= bundle.max_block) {
             return Ok(Err(BundleErr::TargetBlockIncorrect {
                 block: current_block,
@@ -753,7 +766,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         self.execute_with_rollback(|s| {
             s.commit_share_bundle_no_rollback(
                 bundle,
-                ctx,
                 cumulative_gas_used,
                 gas_reserved,
                 cumulative_blob_gas_used,
@@ -766,7 +778,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     fn commit_share_bundle_no_rollback(
         &mut self,
         bundle: &ShareBundle,
-        ctx: &BlockBuildingContext,
         cumulative_gas_used: u64,
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
@@ -774,7 +785,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
         let res = self.commit_share_bundle_inner(
             bundle.inner_bundle(),
-            ctx,
             cumulative_gas_used,
             gas_reserved,
             cumulative_blob_gas_used,
@@ -791,9 +801,7 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
 
         // now pay all kickbacks
         for (to, payout) in res.payouts_promissed.into_iter() {
-            if let Err(err) =
-                self.insert_refund_payout_tx(ctx, payout, to, gas_reserved, &mut insert)?
-            {
+            if let Err(err) = self.insert_refund_payout_tx(payout, to, gas_reserved, &mut insert)? {
                 return Ok(Err(err));
             }
         }
@@ -804,7 +812,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     fn commit_share_bundle_inner(
         &mut self,
         bundle: &ShareBundleInner,
-        ctx: &BlockBuildingContext,
         cumulative_gas_used: u64,
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
@@ -813,7 +820,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         self.execute_with_rollback(|s| {
             s.commit_share_bundle_inner_no_rollback(
                 bundle,
-                ctx,
                 cumulative_gas_used,
                 gas_reserved,
                 cumulative_blob_gas_used,
@@ -825,7 +831,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     fn commit_share_bundle_inner_no_rollback(
         &mut self,
         bundle: &ShareBundleInner,
-        ctx: &BlockBuildingContext,
         cumulative_gas_used: u64,
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
@@ -842,7 +847,11 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
             paid_kickbacks: Vec::new(),
             original_order_ids: Vec::new(),
         };
-        let coinbase_balance_before = self.state.balance(ctx.evm_env.block_env.beneficiary)?;
+        let coinbase_balance_before = self.state.balance(
+            self.ctx.evm_env.block_env.beneficiary,
+            &self.ctx.shared_cached_reads,
+            &mut self.local_ctx.cached_reads,
+        )?;
         let refundable_elements = bundle
             .refund
             .iter()
@@ -855,11 +864,13 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                 ShareBundleBody::Tx(sbundle_tx) => {
                     let rollback_point = self.rollback_point();
                     let tx = &sbundle_tx.tx;
-                    let coinbase_balance_before =
-                        self.state.balance(ctx.evm_env.block_env.beneficiary)?;
+                    let coinbase_balance_before = self.state.balance(
+                        self.ctx.evm_env.block_env.beneficiary,
+                        &self.ctx.shared_cached_reads,
+                        &mut self.local_ctx.cached_reads,
+                    )?;
                     let result = self.commit_tx(
                         tx,
-                        ctx,
                         insert.cumulative_gas_used,
                         gas_reserved,
                         insert.cumulative_blob_gas_used,
@@ -880,8 +891,11 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                             }
 
                             let coinbase_profit = {
-                                let coinbase_balance_after =
-                                    self.state.balance(ctx.evm_env.block_env.beneficiary)?;
+                                let coinbase_balance_after = self.state.balance(
+                                    self.ctx.evm_env.block_env.beneficiary,
+                                    &self.ctx.shared_cached_reads,
+                                    &mut self.local_ctx.cached_reads,
+                                )?;
                                 coinbase_balance_after.checked_sub(coinbase_balance_before)
                             };
                             if let Some(profit) = coinbase_profit {
@@ -904,7 +918,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                 ShareBundleBody::Bundle(inner_bundle) => {
                     let inner_res = self.commit_share_bundle_inner(
                         inner_bundle,
-                        ctx,
                         insert.cumulative_gas_used,
                         gas_reserved,
                         insert.cumulative_blob_gas_used,
@@ -984,7 +997,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         let mut payouts_promised = HashMap::new();
         for (to, refundable_value) in inner_payouts.drain() {
             let payout = match self.estimate_refund_payout_tx(
-                ctx,
                 to,
                 refundable_value,
                 insert.cumulative_gas_used,
@@ -996,7 +1008,11 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         }
 
         let coinbase_diff_before_payouts = {
-            let coinbase_balance_after = self.state.balance(ctx.evm_env.block_env.beneficiary)?;
+            let coinbase_balance_after = self.state.balance(
+                self.ctx.evm_env.block_env.beneficiary,
+                &self.ctx.shared_cached_reads,
+                &mut self.local_ctx.cached_reads,
+            )?;
             coinbase_balance_after
                 .checked_sub(coinbase_balance_before)
                 .unwrap_or_default()
@@ -1024,7 +1040,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     pub fn commit_order(
         &mut self,
         order: &Order,
-        ctx: &BlockBuildingContext,
         cumulative_gas_used: u64,
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
@@ -1033,7 +1048,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
         self.execute_with_rollback(|s| {
             s.commit_order_no_rollback(
                 order,
-                ctx,
                 cumulative_gas_used,
                 gas_reserved,
                 cumulative_blob_gas_used,
@@ -1045,18 +1059,20 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     fn commit_order_no_rollback(
         &mut self,
         order: &Order,
-        ctx: &BlockBuildingContext,
         cumulative_gas_used: u64,
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
         allow_tx_skip: bool,
     ) -> Result<Result<OrderOk, OrderErr>, CriticalCommitOrderError> {
-        let coinbase_balance_before = self.state.balance(ctx.evm_env.block_env.beneficiary)?;
+        let coinbase_balance_before = self.state.balance(
+            self.ctx.evm_env.block_env.beneficiary,
+            &self.ctx.shared_cached_reads,
+            &mut self.local_ctx.cached_reads,
+        )?;
         match order {
             Order::Tx(tx) => {
                 let res = self.commit_tx(
                     &tx.tx_with_blobs,
-                    ctx,
                     cumulative_gas_used,
                     gas_reserved,
                     cumulative_blob_gas_used,
@@ -1065,8 +1081,11 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                     Ok(ok) => {
                         // Builder does not sign txs in this code path, so allow negative coinbase
                         // profit.
-                        let coinbase_balance_after =
-                            self.state.balance(ctx.evm_env.block_env.beneficiary)?;
+                        let coinbase_balance_after = self.state.balance(
+                            self.ctx.evm_env.block_env.beneficiary,
+                            &self.ctx.shared_cached_reads,
+                            &mut self.local_ctx.cached_reads,
+                        )?;
                         let coinbase_profit =
                             coinbase_balance_after.saturating_sub(coinbase_balance_before);
                         Ok(Ok(OrderOk {
@@ -1089,7 +1108,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
             Order::Bundle(bundle) => {
                 let res = self.commit_bundle(
                     bundle,
-                    ctx,
                     cumulative_gas_used,
                     gas_reserved,
                     cumulative_blob_gas_used,
@@ -1099,8 +1117,11 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                     Ok(ok) => {
                         // Builder does not sign txs in this code path, so allow negative coinbase
                         // profit.
-                        let coinbase_balance_after =
-                            self.state.balance(ctx.evm_env.block_env.beneficiary)?;
+                        let coinbase_balance_after = self.state.balance(
+                            self.ctx.evm_env.block_env.beneficiary,
+                            &self.ctx.shared_cached_reads,
+                            &mut self.local_ctx.cached_reads,
+                        )?;
                         let coinbase_profit =
                             coinbase_balance_after.saturating_sub(coinbase_balance_before);
                         Ok(Ok(OrderOk {
@@ -1123,7 +1144,6 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
             Order::ShareBundle(bundle) => {
                 let res = self.commit_share_bundle(
                     bundle,
-                    ctx,
                     cumulative_gas_used,
                     gas_reserved,
                     cumulative_blob_gas_used,
@@ -1131,8 +1151,11 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
                 )?;
                 match res {
                     Ok(ok) => {
-                        let coinbase_balance_after =
-                            self.state.balance(ctx.evm_env.block_env.beneficiary)?;
+                        let coinbase_balance_after = self.state.balance(
+                            self.ctx.evm_env.block_env.beneficiary,
+                            &self.ctx.shared_cached_reads,
+                            &mut self.local_ctx.cached_reads,
+                        )?;
                         // Builder does sign txs in this code path, so do not allow negative coinbase
                         // profit.
                         let coinbase_profit = match coinbase_profit(
@@ -1165,10 +1188,16 @@ impl<'a, 'b, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, Tracer> {
     }
 }
 
-impl<'a> PartialBlockFork<'a, '_, ()> {
-    pub fn new(state: &'a mut BlockState) -> Self {
+impl<'a, 'c, 'd> PartialBlockFork<'a, '_, 'c, 'd, ()> {
+    pub fn new(
+        state: &'a mut BlockState,
+        ctx: &'c BlockBuildingContext,
+        local_ctx: &'d mut ThreadBlockBuildingContext,
+    ) -> Self {
         Self {
             rollbacks: 0,
+            ctx,
+            local_ctx,
             state,
             tracer: None,
             tmp_used_state_tracer: Default::default(),

--- a/crates/rbuilder/src/building/payout_tx.rs
+++ b/crates/rbuilder/src/building/payout_tx.rs
@@ -1,4 +1,4 @@
-use super::{BlockBuildingContext, BlockState};
+use super::{BlockBuildingContext, BlockState, ThreadBlockBuildingContext};
 use crate::utils::Signer;
 use alloy_consensus::{constants::KECCAK_EMPTY, TxEip1559};
 use alloy_primitives::{Address, TxKind as TransactionKind, U256};
@@ -46,12 +46,17 @@ pub enum PayoutTxErr {
 pub fn insert_test_payout_tx(
     to: Address,
     ctx: &BlockBuildingContext,
+    local_ctx: &mut ThreadBlockBuildingContext,
     state: &mut BlockState,
     gas_limit: u64,
 ) -> Result<Option<u64>, PayoutTxErr> {
     let builder_signer = ctx.builder_signer.as_ref().ok_or(PayoutTxErr::NoSigner)?;
 
-    let nonce = state.nonce(builder_signer.address)?;
+    let nonce = state.nonce(
+        builder_signer.address,
+        &ctx.shared_cached_reads,
+        &mut local_ctx.cached_reads,
+    )?;
 
     let tx_value = 10u128.pow(18); // 10 ether
     let tx = create_payout_tx(
@@ -64,7 +69,7 @@ pub fn insert_test_payout_tx(
         U256::from(tx_value),
     )?;
 
-    let mut db = state.new_db_ref();
+    let mut db = state.new_db_ref(&ctx.shared_cached_reads, &mut local_ctx.cached_reads);
     let mut evm = ctx.evm_factory.create_evm(db.as_mut(), ctx.evm_env.clone());
 
     let cache_account = evm.db_mut().load_cache_account(builder_signer.address)?;
@@ -93,11 +98,12 @@ pub enum EstimatePayoutGasErr {
 pub fn estimate_payout_gas_limit(
     to: Address,
     ctx: &BlockBuildingContext,
+    local_ctx: &mut ThreadBlockBuildingContext,
     state: &mut BlockState,
     gas_used: u64,
 ) -> Result<u64, EstimatePayoutGasErr> {
     tracing::trace!(address = ?to, "Estimating payout gas");
-    if state.code_hash(to)? == KECCAK_EMPTY {
+    if state.code_hash(to, &ctx.shared_cached_reads, &mut local_ctx.cached_reads)? == KECCAK_EMPTY {
         return Ok(21_000);
     }
 
@@ -107,10 +113,10 @@ pub fn estimate_payout_gas_limit(
         .gas_limit
         .checked_sub(gas_used)
         .unwrap_or_default();
-    let estimation = insert_test_payout_tx(to, ctx, state, gas_left)?
+    let estimation = insert_test_payout_tx(to, ctx, local_ctx, state, gas_left)?
         .ok_or(EstimatePayoutGasErr::FailedToEstimate)?;
 
-    if insert_test_payout_tx(to, ctx, state, estimation)?.is_some() {
+    if insert_test_payout_tx(to, ctx, local_ctx, state, estimation)?.is_some() {
         return Ok(estimation);
     }
 
@@ -124,7 +130,7 @@ pub fn estimate_payout_gas_limit(
             return Ok(right);
         }
 
-        if insert_test_payout_tx(to, ctx, state, mid)?.is_some() {
+        if insert_test_payout_tx(to, ctx, local_ctx, state, mid)?.is_some() {
             right = mid;
         } else {
             left = mid;
@@ -188,8 +194,10 @@ mod tests {
             Arc::new(MockRootHasher {}),
         );
         let mut state = BlockState::new(provider_factory.latest().unwrap());
+        let mut local_ctx = ThreadBlockBuildingContext::default();
 
-        let estimate_result = estimate_payout_gas_limit(proposer, &ctx, &mut state, 0);
+        let estimate_result =
+            estimate_payout_gas_limit(proposer, &ctx, &mut local_ctx, &mut state, 0);
         assert_matches!(estimate_result, Ok(_));
         assert_eq!(estimate_result.unwrap(), 21_000);
     }

--- a/crates/rbuilder/src/building/sim.rs
+++ b/crates/rbuilder/src/building/sim.rs
@@ -1,6 +1,6 @@
 use super::{
     tracers::{AccumulatorSimulationTracer, SimulationTracer},
-    OrderErr, PartialBlockFork,
+    OrderErr, PartialBlockFork, ThreadBlockBuildingContext,
 };
 use crate::{
     building::{BlockBuildingContext, BlockState, CriticalCommitOrderError},
@@ -12,7 +12,6 @@ use crate::{
 use ahash::{HashMap, HashSet};
 use alloy_primitives::Address;
 use rand::seq::SliceRandom;
-use reth::revm::cached::CachedReads;
 use reth_errors::ProviderError;
 use reth_provider::StateProvider;
 use std::{
@@ -329,7 +328,7 @@ where
     let mut sim_errors = Vec::new();
     let mut state_for_sim =
         Arc::<dyn StateProvider>::from(provider.history_by_block_hash(ctx.attributes.parent)?);
-    let mut cache_reads = Some(CachedReads::default());
+    let mut local_ctx = ThreadBlockBuildingContext::default();
     loop {
         // mix new orders into the sim_tree
         if randomize_insertion && !orders.is_empty() {
@@ -350,17 +349,16 @@ where
         let mut sim_results = Vec::new();
         for sim_task in sim_tasks {
             let start_time = Instant::now();
-            let mut block_state = BlockState::new_arc(state_for_sim)
-                .with_cached_reads(cache_reads.take().unwrap_or_default());
+            let mut block_state = BlockState::new_arc(state_for_sim);
             let sim_result = simulate_order(
                 sim_task.parents.clone(),
                 sim_task.order.clone(),
                 ctx,
+                &mut local_ctx,
                 &mut block_state,
             )?;
-            let (new_cache_reads, _, provider) = block_state.into_parts();
+            let (_, provider) = block_state.into_parts();
             state_for_sim = provider;
-            cache_reads = Some(new_cache_reads);
             match sim_result.result {
                 OrderSimResult::Failed(err) => {
                     trace!(
@@ -405,12 +403,13 @@ pub fn simulate_order(
     parent_orders: Vec<Order>,
     order: Order,
     ctx: &BlockBuildingContext,
+    local_ctx: &mut ThreadBlockBuildingContext,
     state: &mut BlockState,
 ) -> Result<OrderSimResultWithGas, CriticalCommitOrderError> {
     let mut tracer = AccumulatorSimulationTracer::new();
-    let mut fork = PartialBlockFork::new(state).with_tracer(&mut tracer);
+    let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut tracer);
     let rollback_point = fork.rollback_point();
-    let sim_res = simulate_order_using_fork(parent_orders, order, ctx, &mut fork);
+    let sim_res = simulate_order_using_fork(parent_orders, order, &mut fork);
     fork.rollback(rollback_point);
     let sim_res = sim_res?;
     Ok(OrderSimResultWithGas {
@@ -423,15 +422,14 @@ pub fn simulate_order(
 pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
     parent_orders: Vec<Order>,
     order: Order,
-    ctx: &BlockBuildingContext,
-    fork: &mut PartialBlockFork<'_, '_, Tracer>,
+    fork: &mut PartialBlockFork<'_, '_, '_, '_, Tracer>,
 ) -> Result<OrderSimResult, CriticalCommitOrderError> {
     let start = Instant::now();
     // simulate parents
     let mut gas_used = 0;
     let mut blob_gas_used = 0;
     for parent in parent_orders {
-        let result = fork.commit_order(&parent, ctx, gas_used, 0, blob_gas_used, true)?;
+        let result = fork.commit_order(&parent, gas_used, 0, blob_gas_used, true)?;
         match result {
             Ok(res) => {
                 gas_used += res.gas_used;
@@ -445,7 +443,7 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
     }
 
     // simulate
-    let result = fork.commit_order(&order, ctx, gas_used, 0, blob_gas_used, true)?;
+    let result = fork.commit_order(&order, gas_used, 0, blob_gas_used, true)?;
     let sim_time = start.elapsed();
     add_order_simulation_time(sim_time, "sim", result.is_ok()); // we count parent sim time + order sim time time here
 

--- a/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
@@ -4,8 +4,10 @@
 //! test setup is used to build orders and commit them
 use crate::{
     building::{
+        cached_reads::{LocalCachedReads, SharedCachedReads},
         testing::test_chain_state::{BlockArgs, NamedAddr, TestChainState, TxArgs},
         BlockState, ExecutionError, ExecutionResult, OrderErr, PartialBlock,
+        ThreadBlockBuildingContext,
     },
     primitives::{
         order_builder::OrderBuilder, BundleRefund, BundleReplacementData, OrderId, Refund,
@@ -13,7 +15,6 @@ use crate::{
     },
 };
 use alloy_primitives::{Address, TxHash};
-use reth::revm::cached::CachedReads;
 use revm::database::states::BundleState;
 
 pub enum NonceValue {
@@ -28,7 +29,6 @@ pub struct TestSetup {
     partial_block: PartialBlock<()>,
     order_builder: OrderBuilder,
     bundle_state: Option<BundleState>,
-    cached_reads: Option<CachedReads>,
     test_chain: TestChainState,
 }
 
@@ -38,7 +38,6 @@ impl TestSetup {
             partial_block: PartialBlock::new(true),
             order_builder: OrderBuilder::None,
             bundle_state: None,
-            cached_reads: None,
             test_chain: TestChainState::new(block_args)?,
         })
     }
@@ -211,9 +210,9 @@ impl TestSetup {
     }
     fn try_commit_order(&mut self) -> eyre::Result<Result<ExecutionResult, ExecutionError>> {
         let state_provider = self.test_chain.provider_factory().latest()?;
+        let mut local_ctx = ThreadBlockBuildingContext::default();
         let mut block_state = BlockState::new(state_provider)
-            .with_bundle_state(self.bundle_state.take().unwrap_or_default())
-            .with_cached_reads(self.cached_reads.take().unwrap_or_default());
+            .with_bundle_state(self.bundle_state.take().unwrap_or_default());
 
         let sim_order = SimulatedOrder {
             order: self.order_builder.build_order(),
@@ -224,12 +223,12 @@ impl TestSetup {
         let result = self.partial_block.commit_order(
             &sim_order,
             self.test_chain.block_building_context(),
+            &mut local_ctx,
             &mut block_state,
             &|_| Ok(()),
         )?;
 
-        let (cached_reads, bundle_state, _) = block_state.into_parts();
-        self.cached_reads = Some(cached_reads);
+        let (bundle_state, _) = block_state.into_parts();
         self.bundle_state = Some(bundle_state);
 
         Ok(result)
@@ -272,21 +271,33 @@ impl TestSetup {
     }
 
     pub fn current_nonce(&self, named_addr: NamedAddr) -> eyre::Result<u64> {
+        let mut local_cached_reads = LocalCachedReads::default();
+        let shared_cached_reads = SharedCachedReads::default();
+
         let state_provider = self.test_chain.provider_factory().latest()?;
         let mut block_state = BlockState::new(state_provider)
-            .with_bundle_state(self.bundle_state.clone().unwrap_or_default())
-            .with_cached_reads(self.cached_reads.clone().unwrap_or_default());
+            .with_bundle_state(self.bundle_state.clone().unwrap_or_default());
 
-        Ok(block_state.nonce(self.test_chain.named_address(named_addr)?)?)
+        Ok(block_state.nonce(
+            self.test_chain.named_address(named_addr)?,
+            &shared_cached_reads,
+            &mut local_cached_reads,
+        )?)
     }
 
     pub fn balance(&self, named_addr: NamedAddr) -> eyre::Result<i128> {
+        let mut local_cached_reads = LocalCachedReads::default();
+        let shared_cached_reads = SharedCachedReads::default();
+
         let state_provider = self.test_chain.provider_factory().latest()?;
         let mut block_state = BlockState::new(state_provider)
-            .with_bundle_state(self.bundle_state.clone().unwrap_or_default())
-            .with_cached_reads(self.cached_reads.clone().unwrap_or_default());
+            .with_bundle_state(self.bundle_state.clone().unwrap_or_default());
         Ok(block_state
-            .balance(self.test_chain.named_address(named_addr)?)?
+            .balance(
+                self.test_chain.named_address(named_addr)?,
+                &shared_cached_reads,
+                &mut local_cached_reads,
+            )?
             .to())
     }
 

--- a/crates/rbuilder/src/building/testing/evm_inspector_tests/setup.rs
+++ b/crates/rbuilder/src/building/testing/evm_inspector_tests/setup.rs
@@ -1,4 +1,5 @@
 use crate::building::{
+    cached_reads::LocalCachedReads,
     evm_inspector::{RBuilderEVMInspector, UsedStateTrace},
     testing::test_chain_state::{BlockArgs, NamedAddr, TestChainState, TestContracts, TxArgs},
     BlockState,
@@ -84,11 +85,15 @@ impl TestSetup {
     ) -> eyre::Result<UsedStateTrace> {
         let mut used_state_trace = UsedStateTrace::default();
         let mut inspector = RBuilderEVMInspector::new(&tx, Some(&mut used_state_trace));
+        let mut local_cached_reads = LocalCachedReads::default();
 
         // block state
         let state_provider = self.test_chain.provider_factory().latest()?;
         let mut block_state = BlockState::new(state_provider);
-        let mut db_ref = block_state.new_db_ref();
+        let mut db_ref = block_state.new_db_ref(
+            &self.test_chain.block_building_context().shared_cached_reads,
+            &mut local_cached_reads,
+        );
 
         // execute transaction
         {

--- a/crates/rbuilder/src/live_builder/block_output/bidding/sequential_sealer_bid_maker.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding/sequential_sealer_bid_maker.rs
@@ -1,4 +1,7 @@
-use crate::live_builder::block_output::relay_submit::BlockBuildingSink;
+use crate::{
+    building::ThreadBlockBuildingContext,
+    live_builder::block_output::relay_submit::BlockBuildingSink,
+};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use tokio::sync::Notify;
@@ -93,7 +96,10 @@ impl SequentialSealerBidMakerProcess {
             let block_number = block.building_context().block();
             let builder_name = block.builder_name().to_string();
             match tokio::task::spawn_blocking(move || {
-                block.finalize_block(payout_tx_val, seen_competition_bid)
+                // @todo better use of the local context
+                // finalize is not state intensive and it will still used shared cache from the context
+                let mut local_ctx = ThreadBlockBuildingContext::default();
+                block.finalize_block(&mut local_ctx, payout_tx_val, seen_competition_bid)
             })
             .await
             {

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use reth::revm::cached::CachedReads;
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 use sysperf::{format_results, gather_system_info, run_all_benchmarks};
@@ -66,7 +65,7 @@ pub trait LiveBuilderConfig: Debug + DeserializeOwned + Sync {
         &self,
         building_algorithm_name: &str,
         input: BacktestSimulateBlockInput<'_, P>,
-    ) -> eyre::Result<(Block, CachedReads)>
+    ) -> eyre::Result<Block>
     where
         P: StateProviderFactory + Clone + 'static;
 }

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -54,7 +54,6 @@ use ethereum_consensus::{
 };
 use eyre::Context;
 use lazy_static::lazy_static;
-use reth::revm::cached::CachedReads;
 use reth_chainspec::{Chain, ChainSpec, NamedChain};
 use reth_db::DatabaseEnv;
 use reth_node_api::NodeTypesWithDBAdapter;
@@ -405,7 +404,7 @@ impl LiveBuilderConfig for Config {
         &self,
         building_algorithm_name: &str,
         input: BacktestSimulateBlockInput<'_, P>,
-    ) -> eyre::Result<(Block, CachedReads)>
+    ) -> eyre::Result<Block>
     where
         P: StateProviderFactory + Clone + 'static,
     {

--- a/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
+++ b/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
@@ -1,14 +1,13 @@
 use crate::{
     building::{
         sim::{NonceKey, OrderSimResult, SimulatedResult},
-        simulate_order, BlockState,
+        simulate_order, BlockState, ThreadBlockBuildingContext,
     },
     live_builder::simulation::CurrentSimulationContexts,
     provider::StateProviderFactory,
     telemetry::{self, add_sim_thread_utilisation_timings, mark_order_simulation_end},
 };
 use parking_lot::Mutex;
-use reth::revm::cached::CachedReads;
 use std::{
     sync::Arc,
     thread::sleep,
@@ -46,7 +45,8 @@ pub fn run_sim_worker<P>(
             }
         };
 
-        let mut cached_reads = CachedReads::default();
+        let mut local_ctx = ThreadBlockBuildingContext::default();
+
         let mut last_sim_finished = Instant::now();
 
         let state_provider =
@@ -63,12 +63,12 @@ pub fn run_sim_worker<P>(
 
             let order_id = task.order.id();
             let start_time = Instant::now();
-            let mut block_state =
-                BlockState::new_arc(state_provider.clone()).with_cached_reads(cached_reads);
+            let mut block_state = BlockState::new_arc(state_provider.clone());
             let sim_result = simulate_order(
                 task.parents.clone(),
                 task.order,
                 &current_sim_context.block_ctx,
+                &mut local_ctx,
                 &mut block_state,
             );
             let sim_ok = match sim_result {
@@ -103,7 +103,6 @@ pub fn run_sim_worker<P>(
                     break;
                 }
             };
-            (cached_reads, _, _) = block_state.into_parts();
 
             mark_order_simulation_end(order_id, sim_ok);
             last_sim_finished = Instant::now();


### PR DESCRIPTION
The idea behind ThreadBlockBuildingContext is to have a place that is owned by a particular thread (for example, max profit ordering builder) that can be used as a scratchpad for caching without doing global caching shared between all threads.

Currently we have only one place for caches BlockBuildingContext. It is global and shared between all builders, top of block simulation, and finalization thread. This approach solves many problems with caching. For example, we use it for eth-sparse-mpt root hash caching.

But sometimes we would like to have a cache that is local to the current thread to avoid the overhead of mutex and multiple threads.

I've seen the need for caches like this multiple times. This commit adds support for local caches like this.

The first thing that is moved to this new setup of 2 caches is cached reads. We had a lot of trouble with passing CachedReads struct around and it introduced itself into traits where it does not belong such as BlockBuildingHelper or backtesting code. Here we move CachedReads to this uniform setup and it simplifies cached reads state handling.

## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
