### PR TITLE
Don't mark reverting transactions invalid

### DIFF
--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -1106,8 +1106,9 @@ where
             } else {
                 num_txs_simulated_fail += 1;
                 trace!(target: "payload_builder", ?tx, "skipping reverted transaction");
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
-                info.invalid_tx_hashes.insert(*tx.tx_hash());
+                // TODO: why queued transactions considered reverting being marked invalid
+                // best_txs.mark_invalid(tx.signer(), tx.nonce());
+                // info.invalid_tx_hashes.insert(*tx.tx_hash());
                 continue;
             }
 


### PR DESCRIPTION
## 📝 Summary

Testing branch for reverting transactions being marked invalid and not being considered in the block.

## 💡 Motivation and Context

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
