### PR TITLE
Feat: `EthCachedEvmFactory` in `evm` module

### DIFF
--- a/crates/rbuilder/src/building/evm.rs
+++ b/crates/rbuilder/src/building/evm.rs
@@ -1,0 +1,77 @@
+use crate::building::precompile_cache::{PrecompileCache, WrappedPrecompile};
+use parking_lot::Mutex;
+use reth_evm::{eth::EthEvmContext, EthEvm, EthEvmFactory, EvmEnv, EvmFactory};
+use revm::{
+    context::{
+        result::{EVMError, HaltReason},
+        TxEnv,
+    },
+    handler::EthPrecompiles,
+    inspector::NoOpInspector,
+    interpreter::interpreter::EthInterpreter,
+    primitives::hardfork::SpecId,
+    Database, Inspector,
+};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Default)]
+pub struct EthCachedEvmFactory {
+    evm_factory: EthEvmFactory,
+    cache: Arc<Mutex<PrecompileCache>>,
+}
+
+impl EvmFactory for EthCachedEvmFactory {
+    type Evm<DB, I>
+        = EthEvm<DB, I, WrappedPrecompile<EthPrecompiles>>
+    where
+        DB: Database<Error: Send + Sync + 'static>,
+        I: Inspector<EthEvmContext<DB>>;
+
+    type Context<DB>
+        = EthEvmContext<DB>
+    where
+        DB: Database<Error: Send + Sync + 'static>;
+
+    type Error<DBError>
+        = EVMError<DBError>
+    where
+        DBError: core::error::Error + Send + Sync + 'static;
+
+    type Tx = TxEnv;
+    type HaltReason = HaltReason;
+    type Spec = SpecId;
+
+    fn create_evm<DB>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector>
+    where
+        DB: Database<Error: Send + Sync + 'static>,
+    {
+        let evm = self
+            .evm_factory
+            .create_evm(db, input)
+            .into_inner()
+            .with_precompiles(WrappedPrecompile::new(
+                EthPrecompiles::default(),
+                self.cache.clone(),
+            ));
+
+        EthEvm::new(evm, false)
+    }
+
+    fn create_evm_with_inspector<DB, I>(
+        &self,
+        db: DB,
+        input: EvmEnv,
+        inspector: I,
+    ) -> Self::Evm<DB, I>
+    where
+        DB: Database<Error: Send + Sync + 'static>,
+        I: Inspector<Self::Context<DB>, EthInterpreter>,
+    {
+        EthEvm::new(
+            self.create_evm(db, input)
+                .into_inner()
+                .with_inspector(inspector),
+            true,
+        )
+    }
+}

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -18,8 +18,8 @@ use alloy_evm::{block::system_calls::SystemCaller, env::EvmEnv, eth::eip6110};
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
 use cached_reads::{LocalCachedReads, SharedCachedReads};
+use evm::EthCachedEvmFactory;
 use jsonrpsee::core::Serialize;
-use precompile_cache::EthCachedEvmFactory;
 use reth::{
     payload::PayloadId,
     primitives::{Block, Receipt, SealedBlock},
@@ -56,6 +56,7 @@ pub mod built_block_trace;
 pub mod cached_reads;
 #[cfg(test)]
 pub mod conflict;
+pub mod evm;
 pub mod evm_inspector;
 pub mod fmt;
 pub mod order_commit;

--- a/crates/rbuilder/src/building/precompile_cache.rs
+++ b/crates/rbuilder/src/building/precompile_cache.rs
@@ -4,17 +4,11 @@ use alloy_primitives::{Address, Bytes};
 use derive_more::{Deref, DerefMut};
 use lru::LruCache;
 use parking_lot::Mutex;
-use reth_evm::{eth::EthEvmContext, EthEvm, EthEvmFactory, EvmEnv, EvmFactory};
 use revm::{
-    context::{
-        result::{EVMError, HaltReason},
-        BlockEnv, Cfg, CfgEnv, ContextTr, TxEnv,
-    },
-    handler::{EthPrecompiles, PrecompileProvider},
-    inspector::NoOpInspector,
-    interpreter::{interpreter::EthInterpreter, InterpreterResult},
+    context::{Cfg, ContextTr},
+    handler::PrecompileProvider,
+    interpreter::InterpreterResult,
     primitives::hardfork::SpecId,
-    Context, Database, Inspector,
 };
 use std::{num::NonZeroUsize, sync::Arc};
 
@@ -98,67 +92,5 @@ impl<CTX: ContextTr, P: PrecompileProvider<CTX, Output = InterpreterResult>> Pre
 
     fn contains(&self, address: &Address) -> bool {
         self.precompile.contains(address)
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct EthCachedEvmFactory {
-    evm_factory: EthEvmFactory,
-    cache: Arc<Mutex<PrecompileCache>>,
-}
-
-impl EvmFactory for EthCachedEvmFactory {
-    type Evm<DB, I>
-        = EthEvm<DB, I, WrappedPrecompile<EthPrecompiles>>
-    where
-        DB: Database<Error: Send + Sync + 'static>,
-        I: Inspector<EthEvmContext<DB>>;
-
-    type Context<DB>
-        = Context<BlockEnv, TxEnv, CfgEnv, DB>
-    where
-        DB: Database<Error: Send + Sync + 'static>;
-
-    type Error<DBError>
-        = EVMError<DBError>
-    where
-        DBError: core::error::Error + Send + Sync + 'static;
-
-    type Tx = TxEnv;
-    type HaltReason = HaltReason;
-    type Spec = SpecId;
-
-    fn create_evm<DB>(&self, db: DB, input: EvmEnv) -> Self::Evm<DB, NoOpInspector>
-    where
-        DB: Database<Error: Send + Sync + 'static>,
-    {
-        let evm = self
-            .evm_factory
-            .create_evm(db, input)
-            .into_inner()
-            .with_precompiles(WrappedPrecompile::new(
-                EthPrecompiles::default(),
-                self.cache.clone(),
-            ));
-
-        EthEvm::new(evm, false)
-    }
-
-    fn create_evm_with_inspector<DB, I>(
-        &self,
-        db: DB,
-        input: EvmEnv,
-        inspector: I,
-    ) -> Self::Evm<DB, I>
-    where
-        DB: Database<Error: Send + Sync + 'static>,
-        I: Inspector<Self::Context<DB>, EthInterpreter>,
-    {
-        EthEvm::new(
-            self.create_evm(db, input)
-                .into_inner()
-                .with_inspector(inspector),
-            true,
-        )
     }
 }


### PR DESCRIPTION
## 📝 Summary

- The `EthCachedEvmFactory` was moved to new module `evm` under `building` (`rbuilder::building::evm`)
- `EthCachedEvmFactory::Context` is defined to `EthEvmContext<DB>`, which is an alias of `Context<BlockEnv, TxEnv, CfgEnv, DB>`

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
