### PR TITLE
feat: add --version flag for op-rbuilder

### DIFF
--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -2,8 +2,7 @@ use clap::Parser;
 use monitoring::Monitoring;
 use reth::providers::CanonStateSubscriptions;
 use reth_optimism_cli::{chainspec::OpChainSpecParser, Cli};
-use reth_optimism_node::node::OpAddOnsBuilder;
-use reth_optimism_node::OpNode;
+use reth_optimism_node::{node::OpAddOnsBuilder, OpNode};
 
 #[cfg(feature = "flashblocks")]
 use payload_builder::CustomOpPayloadBuilder;
@@ -30,6 +29,13 @@ mod tx_signer;
 use monitor_tx_pool::monitor_tx_pool;
 
 fn main() {
+    // Override the reth version check and print the op-rbuilder version
+    let args: Vec<String> = std::env::args().collect();
+    if args.contains(&"--version".to_string()) || args.contains(&"-V".to_string()) {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        std::process::exit(0);
+    }
+
     Cli::<OpChainSpecParser, args::OpRbuilderArgs>::parse()
         .run(|builder, builder_args| async move {
             let rollup_args = builder_args.rollup_args;


### PR DESCRIPTION
## 📝 Summary

Output op-builder version, not reth version

## 💡 Motivation and Context

Resolves https://github.com/flashbots/op-rbuilder/issues/14

Before
```bash
cargo run -p op-rbuilder --bin op-rbuilder -- --version
...
reth-optimism-cli Version: 1.3.4-dev
Commit SHA: 90c514ca818a36eb8cd36866156c26a4221e9c4a
Build Timestamp: 2025-04-06T12:58:42.729418000Z
Build Features: jemalloc
Build Profile: debug
```

After
```bash
cargo run -p op-rbuilder --bin op-rbuilder -- --version
...
op-rbuilder 0.1.0
```

Could consider outputting more than just the version. 

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
