### PR TITLE
usec timestamp funcs and safer *

### DIFF
--- a/crates/rbuilder/src/utils/mod.rs
+++ b/crates/rbuilder/src/utils/mod.rs
@@ -159,7 +159,7 @@ pub fn timestamp_ms_to_offset_datetime(timestamp: u64) -> OffsetDateTime {
         .expect("failed to convert timestamp")
 }
 
-/// using u64 for us is safe since 2^64 ms = 2^64/1000/60/60/24/365 years = 584942 years.
+/// using u64 for us is safe since 2^64 us = 2^64/1000/60/60/24/365 years = 584942 years.
 pub fn offset_datetime_to_timestamp_us(date: OffsetDateTime) -> u64 {
     (date.unix_timestamp_nanos() / 1_000) as u64
 }

--- a/crates/rbuilder/src/utils/mod.rs
+++ b/crates/rbuilder/src/utils/mod.rs
@@ -149,12 +149,23 @@ pub fn as_hash_set<T: Eq + std::hash::Hash + Copy>(slice: &[T]) -> ahash::HashSe
     set
 }
 
+/// using u64 for ms is safe since 2^64 ms = 2^64/1000/60/60/24/365 years = 584942417 years.
 pub fn offset_datetime_to_timestamp_ms(date: OffsetDateTime) -> u64 {
     (date.unix_timestamp_nanos() / 1_000_000) as u64
 }
 
 pub fn timestamp_ms_to_offset_datetime(timestamp: u64) -> OffsetDateTime {
-    OffsetDateTime::from_unix_timestamp_nanos((timestamp * 1_000_000) as i128)
+    OffsetDateTime::from_unix_timestamp_nanos((timestamp as i128) * 1_000_000)
+        .expect("failed to convert timestamp")
+}
+
+/// using u64 for us is safe since 2^64 ms = 2^64/1000/60/60/24/365 years = 584942 years.
+pub fn offset_datetime_to_timestamp_us(date: OffsetDateTime) -> u64 {
+    (date.unix_timestamp_nanos() / 1_000) as u64
+}
+
+pub fn timestamp_us_to_offset_datetime(timestamp: u64) -> OffsetDateTime {
+    OffsetDateTime::from_unix_timestamp_nanos((timestamp as i128) * 1_000)
         .expect("failed to convert timestamp")
 }
 


### PR DESCRIPTION
## 📝 Summary

Added offset_datetime_to_timestamp_us/timestamp_us_to_offset_datetime

## 💡 Motivation and Context

They fit nicely on u64 and micro sec is perfect for latency measurements.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [] Added tests (if applicable)
