### PR TITLE
[TRIVIAL] Fix op-rbuilder local devnet docs

### DIFF
--- a/crates/op-rbuilder/README.md
+++ b/crates/op-rbuilder/README.md
@@ -14,7 +14,7 @@ To run op-rbuilder with the op-stack, you need:
 To run the op-rbuilder, run:
 
 ```bash
-cargo run -p op-rbuilder --bin op-rbuilder --features optimism -- node \
+cargo run -p op-rbuilder --bin op-rbuilder -- node \
     --chain /path/to/chain-config.json \
     --http \
     --authrpc.port 9551 \
@@ -24,7 +24,7 @@ cargo run -p op-rbuilder --bin op-rbuilder --features optimism -- node \
 To build the op-rbuilder, run:
 
 ```bash
-cargo build -p op-rbuilder --bin op-rbuilder --features optimism
+cargo build -p op-rbuilder --bin op-rbuilder
 ```
 
 ## Observability
@@ -50,13 +50,13 @@ To run the integration tests, run:
 
 ```bash
 # Generate a genesis file
-cargo run -p op-rbuilder --bin tester --features optimism -- genesis --output genesis.json
+cargo run -p op-rbuilder --bin tester -- genesis --output genesis.json
 
 # Build the op-rbuilder binary
-cargo build -p op-rbuilder --bin op-rbuilder --features optimism
+cargo build -p op-rbuilder --bin op-rbuilder
 
 # Run the integration tests
-cargo run -p op-rbuilder --bin tester --features optimism -- run
+cargo run -p op-rbuilder --bin tester -- run
 ```
 
 ## Local Devnet
@@ -77,7 +77,13 @@ git checkout op-rbuilder
 - Windows: `{FOLDERID_RoamingAppData}/reth/`
 - macOS: `$HOME/Library/Application Support/reth/`
 
-3. Run a clean OP stack in the `optimism` repo:
+3. Ensure the required foundry version is installed:
+
+```bash
+foundryup -C $(jq -r '.foundry' versions.json)
+```
+
+4. Run a clean OP stack in the `optimism` repo:
 
 ```bash
 make devnet-clean && make devnet-down && make devnet-up
@@ -86,7 +92,7 @@ make devnet-clean && make devnet-down && make devnet-up
 4. Run `op-rbuilder` in the `rbuilder` repo on port 8547:
 
 ```bash
-cargo run -p op-rbuilder --bin op-rbuilder --features optimism -- node \
+cargo run -p op-rbuilder --bin op-rbuilder -- node \
     --chain ../optimism/.devnet/genesis-l2.json \
     --http \
     --http.port 8547 \


### PR DESCRIPTION
## 📝 Summary

Updates the op-builder local devnet docs by removing the outdated `optimism` feature flag and adding a hint for the foundry version requirement.

## 💡 Motivation and Context

Smooth devnet spin up.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
