### PR TITLE
CompetitionBid is now a struct instead of a plain U256

### DIFF
--- a/crates/rbuilder/src/live_builder/block_output/bid_value_source/best_bid_sync_source.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bid_value_source/best_bid_sync_source.rs
@@ -1,4 +1,4 @@
-use super::interfaces::{BidValueObs, BidValueSource};
+use super::interfaces::{BidValueObs, BidValueSource, CompetitionBid};
 use alloy_primitives::U256;
 use parking_lot::Mutex;
 use std::sync::Arc;
@@ -31,17 +31,21 @@ impl BestBidSyncSource {
     }
 
     pub fn best_bid_value(&self) -> Option<U256> {
-        *self.best_bid_source_inner.best_bid.lock()
+        self.best_bid_source_inner
+            .best_bid
+            .lock()
+            .as_ref()
+            .map(|bid| bid.bid())
     }
 }
 
 #[derive(Debug, Default)]
 struct BestBidSyncSourceInner {
-    best_bid: Mutex<Option<U256>>,
+    best_bid: Mutex<Option<CompetitionBid>>,
 }
 
 impl BidValueObs for BestBidSyncSourceInner {
-    fn update_new_bid(&self, bid: U256) {
+    fn update_new_bid(&self, bid: CompetitionBid) {
         *self.best_bid.lock() = Some(bid);
     }
 }

--- a/crates/rbuilder/src/live_builder/block_output/bid_value_source/interfaces.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bid_value_source/interfaces.rs
@@ -1,12 +1,37 @@
 use alloy_primitives::U256;
 use mockall::automock;
 use std::sync::Arc;
+use time::OffsetDateTime;
+
+#[derive(Clone, Debug)]
+pub struct CompetitionBid {
+    bid: U256,
+    /// For metrics. Set on creation which is the first time we see it in our process.
+    creation_time: OffsetDateTime,
+}
+
+impl CompetitionBid {
+    pub fn new(bid: U256) -> Self {
+        Self {
+            bid,
+            creation_time: OffsetDateTime::now_utc(),
+        }
+    }
+
+    pub fn bid(&self) -> U256 {
+        self.bid
+    }
+
+    pub fn creation_time(&self) -> OffsetDateTime {
+        self.creation_time
+    }
+}
 
 /// Sync + Send to allow to be called from another thread.
 #[automock]
 pub trait BidValueObs: std::fmt::Debug + Sync + Send {
     /// @Pending: add source of the bid.
-    fn update_new_bid(&self, bid: U256);
+    fn update_new_bid(&self, bid: CompetitionBid);
 }
 
 /// Object watching a stream af the bids made.

--- a/crates/rbuilder/src/live_builder/block_output/bid_value_source/interfaces.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bid_value_source/interfaces.rs
@@ -18,6 +18,10 @@ impl CompetitionBid {
         }
     }
 
+    pub fn new_for_deserialization(bid: U256, creation_time: OffsetDateTime) -> Self {
+        Self { bid, creation_time }
+    }
+
     pub fn bid(&self) -> U256 {
         self.bid
     }

--- a/crates/rbuilder/src/live_builder/block_output/bidding/true_block_value_bidder.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding/true_block_value_bidder.rs
@@ -5,9 +5,8 @@ use crate::{
     building::builders::{
         block_building_helper::BiddableUnfinishedBlock, UnfinishedBlockBuildingSink,
     },
-    live_builder::block_output::bid_value_source::interfaces::BidValueObs,
+    live_builder::block_output::bid_value_source::interfaces::{BidValueObs, CompetitionBid},
 };
-use alloy_primitives::U256;
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tokio_util::sync::CancellationToken;
@@ -74,7 +73,7 @@ impl UnfinishedBlockBuildingSink for TrueBlockValueBidder {
 }
 
 impl BidValueObs for TrueBlockValueBidder {
-    fn update_new_bid(&self, _bid: U256) {}
+    fn update_new_bid(&self, _bid: CompetitionBid) {}
 }
 
 #[derive(Debug)]

--- a/crates/rbuilder/src/live_builder/block_output/block_sealing_bidder_factory.rs
+++ b/crates/rbuilder/src/live_builder/block_output/block_sealing_bidder_factory.rs
@@ -6,12 +6,11 @@ use crate::{
     live_builder::payload_events::MevBoostSlotData,
     provider::StateProviderFactory,
 };
-use alloy_primitives::U256;
 use std::{fmt::Debug, sync::Arc};
 use tracing::error;
 
 use super::{
-    bid_value_source::interfaces::{BidValueObs, BidValueSource},
+    bid_value_source::interfaces::{BidValueObs, BidValueSource, CompetitionBid},
     bidding::{
         interfaces::{BiddingService, SlotBidder},
         sequential_sealer_bid_maker::SequentialSealerBidMaker,
@@ -71,7 +70,7 @@ struct SlotBidderToBidValueObs {
 }
 
 impl BidValueObs for SlotBidderToBidValueObs {
-    fn update_new_bid(&self, bid: U256) {
+    fn update_new_bid(&self, bid: CompetitionBid) {
         self.bidder.update_new_bid(bid);
     }
 }


### PR DESCRIPTION
## 📝 Summary

This change changes the bid U256 in BidValueObs for a struct:
```
#[derive(Clone, Debug)]
pub struct CompetitionBid {
    bid: U256,
    /// For metrics. Set on creation which is the first time we see it in our process.
    creation_time: OffsetDateTime,
}
```

## 💡 Motivation and Context

This change will allow better metrics on time to response for competition bids.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
