### PR TITLE
ordering builder: drop zero profit(opt), zero gas orders

### DIFF
--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -267,6 +267,12 @@ impl OrderingBuilderContext {
         let mut order_attempts: HashMap<OrderId, usize> = HashMap::default();
         // @Perf when gas left is too low we should break.
         while let Some(sim_order) = block_orders.pop_order() {
+            // @Todo we drop such bundles instead of failing simulation for them
+            // because share bundle merging depends on allowing no txs bundles into the block
+            if sim_order.sim_value.gas_used == 0 {
+                continue;
+            }
+
             if let Some(deadline) = self.config.build_duration_deadline() {
                 if build_start.elapsed() > deadline {
                     break;


### PR DESCRIPTION
## 📝 Summary

There are bundles that can pass failed simulation filters because of share bundles semantics of not failing bundles with 0 gas used. This PR fixes that for ordering builder.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
