### PR TITLE
docs: add guide to install foundry-toolchain for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,31 +188,6 @@ We plan to cut a stable release at least once a month, but this may vary dependi
 
 ## Contributing
 
-We welcome contributions to rbuilder! Our contributor guidelines can be found in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
-
-
-Start by cloning the repo, and running a few common commands:
-
-```bash
-git clone git@github.com:flashbots/rbuilder.git
-cd rbuilder
-
-# Run linter
-make lint
-
-# Run tests
-make test
-
-# Run benchmarks and open the report
-make bench
-make bench-report-open
-```
-Please ensure all the test passed before submite a pull request.
-Note: some test instances might rely on other components:
-[`install foundry-toolchain`]https://book.getfoundry.sh/getting-started/installation
-
-## Contributing
-
 We welcome contributions to **rbuilder**! Please follow our contributor guidelines outlined in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ### Getting Started

--- a/README.md
+++ b/README.md
@@ -207,6 +207,35 @@ make test
 make bench
 make bench-report-open
 ```
+Please ensure all the test passed before submite a pull request.
+Note: some test instances might rely on other components:
+[`install foundry-toolchain`]https://book.getfoundry.sh/getting-started/installation
+
+## Contributing
+
+We welcome contributions to **rbuilder**! Please follow our contributor guidelines outlined in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+### Getting Started
+
+To get started with **rbuilder**, clone the repository and run these common commands:
+
+```bash
+git clone git@github.com:flashbots/rbuilder.git
+cd rbuilder
+
+# Run linter
+make lint
+
+# Run tests
+make test
+
+# Run benchmarks and open the report
+make bench
+make bench-report-open
+```
+
+Before submitting a pull request, ensure that all tests pass successfully. 
+Note that some test instances may rely on other components, such as the [foundry-toolchain](https://book.getfoundry.sh/getting-started/installation).
 
 ---
 


### PR DESCRIPTION
Resolves flashbots/rbuilder#558

## 📝 Summary

Add a guide to install foundry-toolchain first before running a full test.

## 💡 Motivation and Context

Without foundry-toolchain, 'make test' will show some tests failed. New contributors will have to spend unnecessary time in resolving this.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
