### PR TITLE
Fix isthmus withdrawals hash on payload builder vanilla

### DIFF
--- a/crates/op-rbuilder/src/primitives/reth/execution.rs
+++ b/crates/op-rbuilder/src/primitives/reth/execution.rs
@@ -1,6 +1,6 @@
 //! Heavily influenced by [reth](https://github.com/paradigmxyz/reth/blob/1e965caf5fa176f244a31c0d2662ba1b590938db/crates/optimism/payload/src/builder.rs#L570)
 use alloy_consensus::Transaction;
-use alloy_primitives::{private::alloy_rlp::Encodable, Address, TxHash, B256, U256};
+use alloy_primitives::{private::alloy_rlp::Encodable, Address, TxHash, U256};
 use reth_node_api::NodePrimitives;
 use reth_optimism_primitives::OpReceipt;
 use std::collections::HashSet;
@@ -10,10 +10,6 @@ use std::collections::HashSet;
 pub struct ExecutedPayload<N: NodePrimitives> {
     /// Tracked execution info
     pub info: ExecutionInfo<N>,
-    /// Withdrawal hash.
-    pub withdrawals_root: Option<B256>,
-    /// Requests hash.
-    pub requests_hash: Option<B256>,
 }
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
## 📝 Summary

Add isthmus withdrawal hash fix on the vanilla builder. Previously was added to the flashblocks builder.

## 💡 Motivation and Context

Fix errors around invalid blocks due to incorrect withdrawals hash

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
