### PR TITLE
Feat: custom `Evm` trait

### DIFF
--- a/crates/rbuilder/src/building/evm.rs
+++ b/crates/rbuilder/src/building/evm.rs
@@ -1,20 +1,46 @@
 use crate::building::precompile_cache::{PrecompileCache, WrappedPrecompile};
 use parking_lot::Mutex;
 use reth_evm::{
-    eth::EthEvmContext, EthEvm, EthEvmFactory, Evm, EvmEnv, EvmFactory as RethEvmFactory,
+    eth::EthEvmContext, EthEvm, EthEvmFactory, Evm as RethEvm, EvmEnv,
+    EvmFactory as RethEvmFactory, IntoTxEnv,
 };
 use revm::{
     context::{
-        result::{EVMError, HaltReason},
+        result::{EVMError, HaltReason, ResultAndState},
         TxEnv,
     },
     handler::EthPrecompiles,
-    inspector::NoOpInspector,
     interpreter::interpreter::EthInterpreter,
     primitives::hardfork::SpecId,
     Database, Inspector,
 };
 use std::sync::Arc;
+
+pub trait Evm<DB: Database> {
+    fn transact(
+        &mut self,
+        tx: impl IntoTxEnv<TxEnv>,
+    ) -> Result<ResultAndState<HaltReason>, EVMError<DB::Error>>;
+}
+
+impl<DB, EVM> Evm<DB> for EVM
+where
+    DB: Database<Error: Send + Sync + 'static>,
+    EVM: RethEvm<
+        DB = DB,
+        Tx = TxEnv,
+        Error = EVMError<DB::Error>,
+        HaltReason = HaltReason,
+        Spec = SpecId,
+    >,
+{
+    fn transact(
+        &mut self,
+        tx: impl IntoTxEnv<TxEnv>,
+    ) -> Result<ResultAndState<HaltReason>, EVMError<DB::Error>> {
+        EVM::transact(self, tx)
+    }
+}
 
 /// Custom trait to abstract over EVM construction with a cleaner and more concrete
 /// interface than the `Evm` trait from `alloy-revm`.
@@ -31,29 +57,13 @@ use std::sync::Arc;
 /// See [`EthCachedEvmFactory`] for an implementation that integrates precompile
 /// caching and uses `reth_evm::EthEvm` internally.
 pub trait EvmFactory {
-    type Evm<DB, I>: Evm<
-        DB = DB,
-        Tx = TxEnv,
-        HaltReason = HaltReason,
-        Error = EVMError<DB::Error>,
-        Spec = SpecId,
-    >
-    where
-        DB: Database<Error: Send + Sync + 'static>,
-        I: Inspector<EthEvmContext<DB>>;
-
     /// Create an EVM instance with default (no-op) inspector.
-    fn create_evm<DB>(&self, db: DB, env: EvmEnv) -> Self::Evm<DB, NoOpInspector>
+    fn create_evm<DB>(&self, db: DB, env: EvmEnv) -> impl Evm<DB>
     where
         DB: Database<Error: Send + Sync + 'static>;
 
     /// Create an EVM instance with a provided inspector.
-    fn create_evm_with_inspector<DB, I>(
-        &self,
-        db: DB,
-        env: EvmEnv,
-        inspector: I,
-    ) -> Self::Evm<DB, I>
+    fn create_evm_with_inspector<DB, I>(&self, db: DB, env: EvmEnv, inspector: I) -> impl Evm<DB>
     where
         DB: Database<Error: Send + Sync + 'static>,
         I: Inspector<EthEvmContext<DB>, EthInterpreter>;
@@ -73,13 +83,7 @@ pub struct EthCachedEvmFactory {
 /// It also integrates precompile caching using the [`PrecompileCache`] and
 /// [`WrappedPrecompile`] types.
 impl EvmFactory for EthCachedEvmFactory {
-    type Evm<DB, I>
-        = EthEvm<DB, I, WrappedPrecompile<EthPrecompiles>>
-    where
-        DB: Database<Error: Send + Sync + 'static>,
-        I: Inspector<EthEvmContext<DB>>;
-
-    fn create_evm<DB>(&self, db: DB, env: EvmEnv) -> Self::Evm<DB, NoOpInspector>
+    fn create_evm<DB>(&self, db: DB, env: EvmEnv) -> impl Evm<DB>
     where
         DB: Database<Error: Send + Sync + 'static>,
     {
@@ -95,21 +99,21 @@ impl EvmFactory for EthCachedEvmFactory {
         EthEvm::new(evm, false)
     }
 
-    fn create_evm_with_inspector<DB, I>(
-        &self,
-        db: DB,
-        input: EvmEnv,
-        inspector: I,
-    ) -> Self::Evm<DB, I>
+    fn create_evm_with_inspector<DB, I>(&self, db: DB, env: EvmEnv, inspector: I) -> impl Evm<DB>
     where
         DB: Database<Error: Send + Sync + 'static>,
         I: Inspector<EthEvmContext<DB>, EthInterpreter>,
     {
-        EthEvm::new(
-            self.create_evm(db, input)
-                .into_inner()
-                .with_inspector(inspector),
-            true,
-        )
+        let evm = self
+            .evm_factory
+            .create_evm(db, env)
+            .into_inner()
+            .with_precompiles(WrappedPrecompile::new(
+                EthPrecompiles::default(),
+                self.cache.clone(),
+            ))
+            .with_inspector(inspector);
+
+        EthEvm::new(evm, true)
     }
 }

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     building::{
         estimate_payout_gas_limit,
-        evm::EvmFactory,
+        evm::{Evm, EvmFactory},
         evm_inspector::{RBuilderEVMInspector, UsedStateTrace},
     },
     primitives::{
@@ -22,7 +22,7 @@ use alloy_eips::eip4844::{DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK};
 use alloy_primitives::{Address, B256, U256};
 use reth::revm::database::StateProviderDatabase;
 use reth_errors::ProviderError;
-use reth_evm::{Evm, EvmEnv};
+use reth_evm::EvmEnv;
 use reth_primitives::Receipt;
 use reth_provider::{StateProvider, StateProviderBox};
 use revm::{
@@ -1243,17 +1243,14 @@ fn update_nonce_list_with_updates(
 ///
 /// Gas checks must be done before calling this methods
 /// thats why it can't return `TransactionErr::GasLeft` and  `TransactionErr::BlobGasLeft`
-fn execute_evm<Factory>(
-    evm_factory: &Factory,
+fn execute_evm(
+    evm_factory: &impl EvmFactory,
     evm_env: EvmEnv,
     tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
     used_state_tracer: Option<&mut UsedStateTrace>,
     db: impl Database<Error = ProviderError>,
     blocklist: &HashSet<Address>,
-) -> Result<Result<ResultAndState, TransactionErr>, CriticalCommitOrderError>
-where
-    Factory: EvmFactory,
-{
+) -> Result<Result<ResultAndState, TransactionErr>, CriticalCommitOrderError> {
     let tx = tx_with_blobs.internal_tx_unsecure();
     let mut rbuilder_inspector = RBuilderEVMInspector::new(tx, used_state_tracer);
 

--- a/crates/rbuilder/src/building/payout_tx.rs
+++ b/crates/rbuilder/src/building/payout_tx.rs
@@ -1,10 +1,12 @@
-use super::{evm::EvmFactory, BlockBuildingContext, BlockState, ThreadBlockBuildingContext};
+use super::{
+    evm::{Evm, EvmFactory},
+    BlockBuildingContext, BlockState, ThreadBlockBuildingContext,
+};
 use crate::utils::Signer;
 use alloy_consensus::{constants::KECCAK_EMPTY, TxEip1559};
 use alloy_primitives::{Address, TxKind as TransactionKind, U256};
 use reth_chainspec::ChainSpec;
 use reth_errors::ProviderError;
-use reth_evm::Evm;
 use reth_primitives::{Recovered, Transaction, TransactionSigned};
 use revm::context::result::{EVMError, ExecutionResult};
 
@@ -70,10 +72,11 @@ pub fn insert_test_payout_tx(
     )?;
 
     let mut db = state.new_db_ref(&ctx.shared_cached_reads, &mut local_ctx.cached_reads);
-    let mut evm = ctx.evm_factory.create_evm(db.as_mut(), ctx.evm_env.clone());
+    let cache_account = db.as_mut().load_cache_account(builder_signer.address)?;
 
-    let cache_account = evm.db_mut().load_cache_account(builder_signer.address)?;
     cache_account.increment_balance(tx_value * 2); // double to cover tx value and fee
+
+    let mut evm = ctx.evm_factory.create_evm(db.as_mut(), ctx.evm_env.clone());
 
     let res = evm.transact(&tx)?;
     match res.result {

--- a/crates/rbuilder/src/building/testing/evm_inspector_tests/setup.rs
+++ b/crates/rbuilder/src/building/testing/evm_inspector_tests/setup.rs
@@ -1,12 +1,11 @@
 use crate::building::{
     cached_reads::LocalCachedReads,
-    evm::EvmFactory,
+    evm::{Evm, EvmFactory},
     evm_inspector::{RBuilderEVMInspector, UsedStateTrace},
     testing::test_chain_state::{BlockArgs, NamedAddr, TestChainState, TestContracts, TxArgs},
     BlockState,
 };
 use alloy_primitives::Address;
-use reth_evm::Evm;
 use reth_primitives::{Recovered, TransactionSigned};
 
 #[derive(Debug)]


### PR DESCRIPTION
## 📝 Summary

- Definition of a new `Evm` trait with only one method `transact`.
- `Evm` from `reth_evm`, aliased as `RethEvm`, auto-implement this new `Evm` when trait bounds are satisfied.
- `EvmFactory`'s create_evm methods return `Evm` trait objects.
- Update codebase to reflect these changes, such as mutating the db before creating evm in `payout_tx`

## 💡 Motivation and Context

This PR introduces a new trait `Evm` based on `reth_evm::Evm` but with more concrete trait bounds and less methods (only `transact`). It also simplifies the `EvmFactory` trait by removing the associated `Evm` type and not being constrained by revm inspector trait bounds.

All the logic of `EthCachedEvmFactory` stays the same, and this PR is mostly for better abstraction and giving more control to exactly what the `Evm` should provide to rbuilder.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
