### PR TITLE
EVM tx cache

### DIFF
--- a/crates/rbuilder/src/backtest/build_block/landed_block_from_db.rs
+++ b/crates/rbuilder/src/backtest/build_block/landed_block_from_db.rs
@@ -125,6 +125,7 @@ impl<ConfigType: LiveBuilderConfig>
             self.block_data.winning_bid_trace.proposer_fee_recipient,
             Some(signer),
             Arc::new(MockRootHasher {}),
+            self.config.base_config().evm_caching_enable,
         ))
     }
 

--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -63,6 +63,7 @@ pub fn backtest_prepare_ctx_for_block<P>(
     blocklist: BlockList,
     sbundle_mergeabe_signers: &[Address],
     builder_signer: Signer,
+    evm_caching_enable: bool,
 ) -> eyre::Result<BacktestBlockInput>
 where
     P: StateProviderFactory + Clone + 'static,
@@ -80,6 +81,7 @@ where
         block_data.winning_bid_trace.proposer_fee_recipient,
         Some(builder_signer),
         Arc::from(provider.root_hasher(parent_num_hash)?),
+        evm_caching_enable,
     );
     backtest_prepare_ctx_for_block_from_building_context(
         ctx,
@@ -145,6 +147,7 @@ where
         blocklist,
         sbundle_mergeabe_signers,
         config.base_config().coinbase_signer()?,
+        config.base_config().evm_caching_enable,
     )?;
 
     let filtered_orders_blocklist_count = sim_errors

--- a/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
@@ -53,6 +53,7 @@ where
         suggested_fee_recipient,
         None,
         Arc::from(provider.root_hasher(parent_num_hash)?),
+        false,
     );
 
     let mut local_ctx = ThreadBlockBuildingContext::default();

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -74,6 +74,7 @@ async fn main() -> eyre::Result<()> {
         suggested_fee_recipient,
         None,
         Arc::from(provider_factory.root_hasher(parent_num_hash)?),
+        config.base_config().evm_caching_enable,
     );
 
     let state_provider = Arc::<dyn StateProvider>::from(

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -113,6 +113,8 @@ async fn main() -> eyre::Result<()> {
         orderpool_sender,
         orderpool_receiver,
         sbundle_merger_selected_signers: Default::default(),
+        evm_caching_enable: false,
+        simulation_use_random_coinbase: true,
     };
 
     let ctrlc = tokio::spawn(async move {

--- a/crates/rbuilder/src/building/cached_reads.rs
+++ b/crates/rbuilder/src/building/cached_reads.rs
@@ -9,17 +9,19 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
+
+use ahash::RandomState;
 use tracing::info;
 
 /// Database cache shared bewteen multiple threads.
 /// It should be created for unique parent block.
 #[derive(Debug, Clone, Default)]
 pub struct SharedCachedReads {
-    pub account_info: DashMap<Address, Option<AccountInfo>>,
-    pub storage: DashMap<(Address, U256), U256>,
+    pub account_info: DashMap<Address, Option<AccountInfo>, RandomState>,
+    pub storage: DashMap<(Address, U256), U256, RandomState>,
 
-    pub code_by_hash: DashMap<B256, Bytecode>,
-    pub block_hash: DashMap<u64, B256>,
+    pub code_by_hash: DashMap<B256, Bytecode, RandomState>,
+    pub block_hash: DashMap<u64, B256, RandomState>,
 
     pub local_hit_count: Arc<AtomicU64>,
     pub local_miss_count: Arc<AtomicU64>,

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -49,6 +49,7 @@ use std::{
 };
 use thiserror::Error;
 use time::OffsetDateTime;
+use tx_sim_cache::TxExecutionCache;
 
 pub mod block_orders;
 pub mod builders;
@@ -65,6 +66,7 @@ pub mod precompile_cache;
 pub mod sim;
 pub mod testing;
 pub mod tracers;
+pub mod tx_sim_cache;
 
 pub use self::{
     block_orders::*, builders::mock_block_building_helper::MockRootHasher, built_block_trace::*,
@@ -94,6 +96,7 @@ pub struct BlockBuildingContext {
     pub root_hasher: Arc<dyn RootHasher>,
     pub payload_id: InternalPayloadId,
     pub shared_cached_reads: Arc<SharedCachedReads>,
+    pub tx_execution_cache: Arc<TxExecutionCache>,
 }
 
 impl BlockBuildingContext {
@@ -111,6 +114,7 @@ impl BlockBuildingContext {
         spec_id: Option<SpecId>,
         root_hasher: Arc<dyn RootHasher>,
         payload_id: InternalPayloadId,
+        evm_caching_enable: bool,
     ) -> Option<BlockBuildingContext> {
         let attributes = EthPayloadBuilderAttributes::try_new(
             attributes.data.parent_block_hash,
@@ -178,6 +182,7 @@ impl BlockBuildingContext {
             root_hasher,
             payload_id,
             shared_cached_reads: Default::default(),
+            tx_execution_cache: Arc::new(TxExecutionCache::new(evm_caching_enable)),
         })
     }
 
@@ -194,6 +199,7 @@ impl BlockBuildingContext {
         suggested_fee_recipient: Address,
         builder_signer: Option<Signer>,
         root_hasher: Arc<dyn RootHasher>,
+        evm_caching_enable: bool,
     ) -> BlockBuildingContext {
         let block_number = onchain_block.header.number;
 
@@ -262,6 +268,7 @@ impl BlockBuildingContext {
             root_hasher,
             payload_id: 0,
             shared_cached_reads: Default::default(),
+            tx_execution_cache: Arc::new(TxExecutionCache::new(evm_caching_enable)),
         }
     }
 
@@ -278,6 +285,7 @@ impl BlockBuildingContext {
             Default::default(),
             Default::default(),
             Arc::new(MockRootHasher {}),
+            false,
         )
     }
 
@@ -415,7 +423,7 @@ pub enum InsertPayoutTxErr {
     NoSigner,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum ExecutionError {
     #[error("Order error: {0}")]
     OrderError(#[from] OrderErr),

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -2,6 +2,7 @@ use super::{
     cached_reads::{CachedDB, LocalCachedReads, SharedCachedReads},
     create_payout_tx,
     tracers::SimulationTracer,
+    tx_sim_cache::{CachedExecutionResult, EVMRecordingDatabase},
     BlockBuildingContext, EstimatePayoutGasErr, ThreadBlockBuildingContext,
 };
 use crate::{
@@ -20,6 +21,7 @@ use ahash::HashSet;
 use alloy_consensus::{constants::KECCAK_EMPTY, Transaction};
 use alloy_eips::eip4844::{DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK};
 use alloy_primitives::{Address, B256, U256};
+use itertools::Itertools;
 use reth::revm::database::StateProviderDatabase;
 use reth_errors::ProviderError;
 use reth_evm::{Evm, EvmEnv};
@@ -194,7 +196,7 @@ pub struct TransactionOk {
     pub receipt: Receipt,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum TransactionErr {
     #[error("Invalid transaction: {0:?}")]
     InvalidTransaction(InvalidTransaction),
@@ -223,7 +225,7 @@ pub struct BundleOk {
     pub original_order_ids: Vec<OrderId>,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum BundleErr {
     #[error("Invalid transaction, hash: {0:?}, err: {1}")]
     InvalidTransaction(B256, TransactionErr),
@@ -284,7 +286,7 @@ pub struct OrderOk {
     pub used_state_trace: Option<UsedStateTrace>,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum OrderErr {
     #[error("Transaction error: {0}")]
     Transaction(#[from] TransactionErr),
@@ -436,34 +438,75 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         // evm start
         // ====================================================
 
-        let used_state_tracer = self.tracer.as_ref().and_then(|tracer| {
-            if tracer.should_collect_used_state_trace() {
+        // this is set to true when user of the commit_* function wants to have used state trace,
+        // on the other hand we always record used state trace when doing evm caching we just can skip showing it
+        let is_recording_used_state = self
+            .tracer
+            .as_ref()
+            .map(|t| t.should_collect_used_state_trace())
+            .unwrap_or_default();
+        let caching_result = self.ctx.tx_execution_cache.get_cached_result(
+            db.as_mut(),
+            tx.hash(),
+            &self.ctx.evm_env.block_env.beneficiary,
+        )?;
+
+        let cached_used_state_trace;
+        let (res, used_state_trace) = if let Some(result) = caching_result.result {
+            cached_used_state_trace = Some(caching_result.used_state_trace);
+            (result, cached_used_state_trace.as_ref().map(|t| t.as_ref()))
+        } else {
+            let used_state_tracer = if is_recording_used_state || caching_result.should_cache {
                 self.tmp_used_state_tracer.clear();
                 Some(&mut self.tmp_used_state_tracer)
             } else {
                 None
-            }
-        });
+            };
 
-        let res = execute_evm(
-            &self.ctx.evm_factory,
-            self.ctx.evm_env.clone(),
-            tx_with_blobs,
-            used_state_tracer,
-            db.as_mut(),
-            &self.ctx.blocklist,
-        )?;
-        let res = match res {
-            Ok(res) => res,
-            Err(err) => return Ok(Err(err)),
+            let mut db = EVMRecordingDatabase::new(db.as_mut(), caching_result.should_cache);
+
+            let res = execute_evm(
+                &self.ctx.evm_factory,
+                self.ctx.evm_env.clone(),
+                tx_with_blobs,
+                used_state_tracer,
+                &mut db,
+                &self.ctx.blocklist,
+            )?;
+
+            if caching_result.should_cache {
+                self.ctx
+                    .tx_execution_cache
+                    .store_result(CachedExecutionResult {
+                        tx_hash: *tx.hash(),
+                        coinbase: self.ctx.evm_env.block_env.beneficiary,
+                        recorded_trace: db.recorded_trace,
+                        result: res.clone(),
+                        used_state_trace: Arc::new(self.tmp_used_state_tracer.clone()),
+                    });
+            }
+
+            let used_state_tracer = if is_recording_used_state {
+                Some(&self.tmp_used_state_tracer)
+            } else {
+                None
+            };
+            (res, used_state_tracer)
         };
 
         // evm end
         // ====================================================
 
+        let res = match res {
+            Ok(res) => res,
+            Err(err) => return Ok(Err(err)),
+        };
+
         if let Some(tracer) = &mut self.tracer {
             tracer.add_gas_used(res.result.gas_used());
-            tracer.add_used_state_trace(&self.tmp_used_state_tracer);
+            if let (true, Some(t)) = (is_recording_used_state, used_state_trace) {
+                tracer.add_used_state_trace(t)
+            }
         }
 
         db.as_mut().commit(res.state);
@@ -798,7 +841,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         let mut insert = res.bundle_ok;
 
         // now pay all kickbacks
-        for (to, payout) in res.payouts_promissed.into_iter() {
+        for (to, payout) in res.payouts_promissed.into_iter().sorted_by_key(|(a, _)| *a) {
             if let Err(err) = self.insert_refund_payout_tx(payout, to, gas_reserved, &mut insert)? {
                 return Ok(Err(err));
             }

--- a/crates/rbuilder/src/building/payout_tx.rs
+++ b/crates/rbuilder/src/building/payout_tx.rs
@@ -43,6 +43,20 @@ pub enum PayoutTxErr {
     NoSigner,
 }
 
+impl PartialEq for PayoutTxErr {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (PayoutTxErr::Reth(_), PayoutTxErr::Reth(_)) => true,
+            (PayoutTxErr::SignError(a), PayoutTxErr::SignError(b)) => a == b,
+            (PayoutTxErr::EvmError(_), PayoutTxErr::EvmError(_)) => true,
+            (PayoutTxErr::NoSigner, PayoutTxErr::NoSigner) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for PayoutTxErr {}
+
 pub fn insert_test_payout_tx(
     to: Address,
     ctx: &BlockBuildingContext,
@@ -95,6 +109,22 @@ pub enum EstimatePayoutGasErr {
     #[error("Failed to estimate gas limit")]
     FailedToEstimate,
 }
+
+impl PartialEq for EstimatePayoutGasErr {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (EstimatePayoutGasErr::Reth(_), EstimatePayoutGasErr::Reth(_)) => true,
+            (EstimatePayoutGasErr::PayoutTxErr(a), EstimatePayoutGasErr::PayoutTxErr(b)) => a == b,
+            (EstimatePayoutGasErr::FailedToEstimate, EstimatePayoutGasErr::FailedToEstimate) => {
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for EstimatePayoutGasErr {}
+
 pub fn estimate_payout_gas_limit(
     to: Address,
     ctx: &BlockBuildingContext,
@@ -192,6 +222,7 @@ mod tests {
             proposer,
             Some(signer),
             Arc::new(MockRootHasher {}),
+            false,
         );
         let mut state = BlockState::new(provider_factory.latest().unwrap());
         let mut local_ctx = ThreadBlockBuildingContext::default();

--- a/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
@@ -15,7 +15,9 @@ use crate::{
     },
 };
 use alloy_primitives::{Address, TxHash};
+use reth_provider::StateProvider;
 use revm::database::states::BundleState;
+use std::sync::Arc;
 
 pub enum NonceValue {
     /// Fixed value
@@ -209,10 +211,9 @@ impl TestSetup {
         )
     }
     fn try_commit_order(&mut self) -> eyre::Result<Result<ExecutionResult, ExecutionError>> {
-        let state_provider = self.test_chain.provider_factory().latest()?;
+        let state_provider: Arc<dyn StateProvider> =
+            Arc::from(self.test_chain.provider_factory().latest()?);
         let mut local_ctx = ThreadBlockBuildingContext::default();
-        let mut block_state = BlockState::new(state_provider)
-            .with_bundle_state(self.bundle_state.take().unwrap_or_default());
 
         let sim_order = SimulatedOrder {
             order: self.order_builder.build_order(),
@@ -220,18 +221,38 @@ impl TestSetup {
             used_state_trace: Default::default(),
         };
 
-        let result = self.partial_block.commit_order(
-            &sim_order,
-            self.test_chain.block_building_context(),
-            &mut local_ctx,
-            &mut block_state,
-            &|_| Ok(()),
-        )?;
+        // we commit order twice to test evm caching
+        let initial_partial_block = self.partial_block.clone();
+        let initial_bundle_state = self.bundle_state.take().unwrap_or_default();
 
-        let (bundle_state, _) = block_state.into_parts();
-        self.bundle_state = Some(bundle_state);
+        let mut results = Vec::new();
+        for _ in 0..2 {
+            let mut block_state = BlockState::new_arc(state_provider.clone())
+                .with_bundle_state(initial_bundle_state.clone());
 
-        Ok(result)
+            let mut partial_block = initial_partial_block.clone();
+
+            let result = partial_block.commit_order(
+                &sim_order,
+                self.test_chain.block_building_context(),
+                &mut local_ctx,
+                &mut block_state,
+                &|_| Ok(()),
+            )?;
+            results.push(result);
+            let (bundle_state, _) = block_state.into_parts();
+
+            self.bundle_state = Some(bundle_state);
+            self.partial_block = partial_block
+        }
+
+        let second_result = results.pop().unwrap();
+        let first_result = results.pop().unwrap();
+        if first_result != second_result {
+            eyre::bail!("Second order commit differs from the first (caching error) first: {:#?}, second: {:#?}", first_result, second_result);
+        }
+
+        Ok(first_result)
     }
 
     pub fn commit_order_ok(&mut self) -> ExecutionResult {

--- a/crates/rbuilder/src/building/testing/test_chain_state.rs
+++ b/crates/rbuilder/src/building/testing/test_chain_state.rs
@@ -396,6 +396,7 @@ impl TestBlockContextBuilder {
             Some(SpecId::SHANGHAI),
             self.root_hasher,
             0,
+            true,
         )
         .unwrap();
         if self.use_suggested_fee_recipient_as_coinbase {

--- a/crates/rbuilder/src/building/tx_sim_cache/evm_db.rs
+++ b/crates/rbuilder/src/building/tx_sim_cache/evm_db.rs
@@ -1,0 +1,91 @@
+use alloy_primitives::Address;
+use alloy_primitives::B256;
+use alloy_primitives::U256;
+use revm::{
+    state::{AccountInfo, Bytecode},
+    Database,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AccessRecord {
+    Account {
+        address: Address,
+        result: Option<AccountInfo>,
+    },
+    Storage {
+        address: Address,
+        index: U256,
+        result: U256,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct TxStateAccessTrace {
+    pub trace: Vec<AccessRecord>,
+}
+
+impl TxStateAccessTrace {
+    fn new() -> Self {
+        Self { trace: Vec::new() }
+    }
+
+    fn push(&mut self, record: AccessRecord) {
+        self.trace.push(record);
+    }
+}
+
+/// revm database wrapper that records state access
+#[derive(Debug)]
+pub struct EVMRecordingDatabase<DB> {
+    pub should_record: bool,
+    pub inner_db: DB,
+    pub recorded_trace: TxStateAccessTrace,
+}
+
+impl<DB> EVMRecordingDatabase<DB> {
+    pub fn new(inner_db: DB, should_record: bool) -> Self {
+        Self {
+            inner_db,
+            recorded_trace: TxStateAccessTrace::new(),
+            should_record,
+        }
+    }
+}
+
+impl<DB: Database> Database for EVMRecordingDatabase<DB> {
+    type Error = DB::Error;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        let result = self.inner_db.basic(address)?;
+        if !self.should_record {
+            return Ok(result);
+        }
+
+        self.recorded_trace.push(AccessRecord::Account {
+            address,
+            result: result.as_ref().map(|r| r.copy_without_code()),
+        });
+        Ok(result)
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.inner_db.code_by_hash(code_hash)
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        let result = self.inner_db.storage(address, index)?;
+        if !self.should_record {
+            return Ok(result);
+        }
+        self.recorded_trace.push(AccessRecord::Storage {
+            address,
+            index,
+            result,
+        });
+        Ok(result)
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        self.inner_db.block_hash(number)
+    }
+}

--- a/crates/rbuilder/src/building/tx_sim_cache/mod.rs
+++ b/crates/rbuilder/src/building/tx_sim_cache/mod.rs
@@ -1,0 +1,385 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use ahash::RandomState;
+use alloy_primitives::Address;
+use alloy_primitives::B256;
+use alloy_primitives::I256;
+use alloy_primitives::U256;
+use dashmap::DashMap;
+use itertools::Itertools;
+use result_store::ActionResult;
+use result_store::ExecutionResultStore;
+use result_store::NextAction;
+use reth_errors::ProviderError;
+use revm::state::AccountInfo;
+use revm::{context::result::ResultAndState, Database};
+use tracing::info;
+
+use crate::utils::signed_uint_delta;
+
+use super::evm_inspector::UsedStateTrace;
+use super::CriticalCommitOrderError;
+use super::TransactionErr;
+
+mod evm_db;
+mod result_store;
+
+pub use evm_db::*;
+
+const NUM_OF_CACHED_EXECUTIONS: usize = 5;
+const PREALLOCATED_TX_CACHE_CAPACITY: usize = 10_000;
+
+#[derive(Debug)]
+pub struct CachedExecutionResult {
+    pub tx_hash: B256,
+    // we store coinbase because builders can use different coinbase (e.g. fee recepient and builder coinbase)
+    pub coinbase: Address,
+    pub recorded_trace: TxStateAccessTrace,
+    pub result: Result<ResultAndState, TransactionErr>,
+    // we always collect used state trace to detect direct reads of coinbase balance
+    pub used_state_trace: Arc<UsedStateTrace>,
+}
+
+#[derive(Debug)]
+pub struct CachingResult {
+    /// None means cache miss
+    pub result: Option<Result<ResultAndState, TransactionErr>>,
+    pub used_state_trace: Arc<UsedStateTrace>,
+    pub should_cache: bool,
+}
+
+impl CachingResult {
+    pub fn new_cache_miss(should_cache: bool) -> Self {
+        Self {
+            result: None,
+            used_state_trace: Arc::new(UsedStateTrace::default()),
+            should_cache,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TxCacheEntryResult {
+    read_coinbase_account: Option<Option<AccountInfo>>,
+    result: Result<ResultAndState, TransactionErr>,
+    used_state_trace: Arc<UsedStateTrace>,
+}
+
+#[derive(Debug, Default)]
+struct TxCacheEntry {
+    store: ExecutionResultStore<TxCacheEntryResult>,
+    count_total_executions: AtomicUsize,
+    count_hits: AtomicUsize,
+    never_cache: AtomicBool,
+}
+
+impl TxCacheEntry {
+    fn has_storage_capacity(&self) -> bool {
+        self.store.len() < NUM_OF_CACHED_EXECUTIONS
+    }
+
+    fn never_cache(&self) -> bool {
+        self.never_cache.load(Ordering::Relaxed)
+    }
+
+    fn store_result(&self, result: CachedExecutionResult) {
+        if !self.has_storage_capacity() {
+            return;
+        }
+
+        if trace_is_not_cachable(&result.used_state_trace, &result.coinbase) {
+            self.never_cache.store(true, Ordering::Relaxed);
+            return;
+        }
+
+        let mut trace = result.recorded_trace.trace;
+        let coinbase_read_entry = trace
+            .iter()
+            .find_position(|r| match r {
+                AccessRecord::Account { address, .. } => address == &result.coinbase,
+                _ => false,
+            })
+            .map(|(idx, _)| idx);
+        let coinbase_read_entry = if let Some(idx) = coinbase_read_entry {
+            match trace.remove(idx) {
+                AccessRecord::Account { result, .. } => Some(result),
+                _ => unreachable!(),
+            }
+        } else {
+            None
+        };
+
+        let result = TxCacheEntryResult {
+            read_coinbase_account: coinbase_read_entry,
+            result: result.result,
+            used_state_trace: result.used_state_trace,
+        };
+        self.store.insert_result(trace, result);
+    }
+
+    fn inc_total_executions(&self) {
+        self.count_total_executions.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn total_executions(&self) -> usize {
+        self.count_total_executions.load(Ordering::Relaxed)
+    }
+
+    fn inc_hits(&self) {
+        self.count_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn hits(&self) -> usize {
+        self.count_hits.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug)]
+pub struct TxExecutionCache {
+    enabled: bool,
+    // (tx_hash, coinbase) -> CachedResult
+    stored_results: DashMap<(B256, Address), Arc<TxCacheEntry>, RandomState>,
+    cache_hits: Arc<AtomicUsize>,
+    cache_asks: Arc<AtomicUsize>,
+}
+
+impl Drop for TxExecutionCache {
+    fn drop(&mut self) {
+        let total = self.cache_asks.load(Ordering::Relaxed);
+        let hits = self.cache_hits.load(Ordering::Relaxed);
+        if total == 0 {
+            return;
+        }
+
+        let rate = hits as f64 / total as f64;
+
+        let mut perfectly_cached_count = 0;
+        let mut tx_count = 0;
+        let mut sum_total_executions = 0;
+        for entry in self.stored_results.iter() {
+            tx_count += 1;
+            let hits = entry.hits();
+            let total_executions = entry.total_executions();
+            sum_total_executions += total_executions;
+            let misses = total_executions - hits;
+            if misses <= NUM_OF_CACHED_EXECUTIONS {
+                perfectly_cached_count += 1;
+            }
+        }
+
+        let theoretical_max_rate =
+            (sum_total_executions - tx_count) as f64 / sum_total_executions as f64;
+
+        let perfectly_cached_rate = perfectly_cached_count as f64 / tx_count as f64;
+
+        info!(
+            rate,
+            theoretical_max_rate,
+            sum_total_executions,
+            tx_count,
+            perfectly_cached_rate,
+            "EVM tx cache"
+        );
+    }
+}
+
+impl TxExecutionCache {
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            stored_results: DashMap::with_capacity_and_hasher(
+                PREALLOCATED_TX_CACHE_CAPACITY,
+                RandomState::default(),
+            ),
+            cache_hits: Default::default(),
+            cache_asks: Default::default(),
+        }
+    }
+}
+
+impl TxExecutionCache {
+    fn get_tx_entry(&self, tx_hash: B256, coinbase: Address) -> Arc<TxCacheEntry> {
+        let key = (tx_hash, coinbase);
+        if let Some(entry) = self.stored_results.get(&key) {
+            return entry.value().clone();
+        }
+        // we use get first and entry last because entry API uses write lock even if entry is occupied
+        self.stored_results.entry(key).or_default().value().clone()
+    }
+
+    pub fn store_result(&self, result: CachedExecutionResult) {
+        if !self.enabled {
+            return;
+        }
+        let entry = self.get_tx_entry(result.tx_hash, result.coinbase);
+
+        entry.store_result(result);
+    }
+
+    fn inc_cache_asks(&self) {
+        self.cache_asks.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn inc_cache_hits(&self) {
+        self.cache_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn get_cached_result(
+        &self,
+        mut db: impl Database<Error = ProviderError>,
+        tx_hash: &B256,
+        coinbase: &Address,
+    ) -> Result<CachingResult, CriticalCommitOrderError> {
+        if !self.enabled {
+            return Ok(CachingResult::new_cache_miss(false));
+        }
+
+        self.inc_cache_asks();
+        let entry = self.get_tx_entry(*tx_hash, *coinbase);
+        entry.inc_total_executions();
+
+        if entry.never_cache() {
+            return Ok(CachingResult::new_cache_miss(false));
+        }
+
+        let cached_result;
+        let mut walker = entry.store.get_walker();
+        loop {
+            let next_action = match walker.next_action() {
+                Some(action) => action,
+                None => {
+                    return Ok(CachingResult::new_cache_miss(entry.has_storage_capacity()));
+                }
+            };
+            let action_result = match next_action {
+                NextAction::CheckAccount(address) => {
+                    let current_account = db.basic(address)?;
+
+                    ActionResult::AccountValue(current_account)
+                }
+                NextAction::CheckStorage(address, index) => {
+                    db.basic(address)?; // we load account here because revm database panics if we never loaded account before slot
+                    let current_value = db.storage(address, index)?;
+                    ActionResult::StorageValue(current_value)
+                }
+                NextAction::DoNothing => ActionResult::DoNothing,
+            };
+            if let Some(res) = walker.action_result(&action_result) {
+                cached_result = res;
+                break;
+            }
+        }
+
+        let mut evm_result = match cached_result.result {
+            Ok(res) => res,
+            Err(_) => {
+                // if tx execution was error (tx not included, we can ingore coinbase handling)
+                self.inc_cache_hits();
+                entry.inc_hits();
+                return Ok(CachingResult {
+                    result: Some(cached_result.result),
+                    used_state_trace: cached_result.used_state_trace,
+                    should_cache: false,
+                });
+            }
+        };
+
+        let used_coinbase = if let Some(account) = cached_result.read_coinbase_account {
+            account
+        } else {
+            // its possible to not read coinbase if tx execution is error, but that case should have been handled above
+            panic!("tx_sim_cache: tx did not read coinbase account");
+        };
+
+        let current_coinbase = db.basic(*coinbase)?;
+
+        let mut coinbase_nonce_delta = 0i64;
+        let mut coinbase_balance_delta = I256::ZERO;
+        match (used_coinbase, current_coinbase) {
+            (None, None) => {
+                // coinbase cached is none and current is none, do nothing
+            }
+            (None, Some(_)) | (Some(_), None) => {
+                // coinbase was created or destoyed
+                // for caution lets just reject these cases
+                return Ok(CachingResult::new_cache_miss(entry.has_storage_capacity()));
+            }
+            (Some(cached_coinbase), Some(current_coinbase)) => {
+                if cached_coinbase.code_hash != current_coinbase.code_hash {
+                    // thats a strange case that we want to just ignore
+                    return Ok(CachingResult::new_cache_miss(entry.has_storage_capacity()));
+                }
+                // if nonce changed we want to modify nonce in the result by that amount
+                coinbase_nonce_delta = current_coinbase.nonce as i64 - cached_coinbase.nonce as i64;
+                coinbase_balance_delta =
+                    signed_uint_delta(current_coinbase.balance, cached_coinbase.balance);
+            }
+        }
+
+        let coinbase_account = match evm_result.state.get_mut(coinbase) {
+            Some(acc) => acc,
+            None => {
+                // strange case when coinbase account was not modified, rejecting just in case
+                return Ok(CachingResult::new_cache_miss(entry.has_storage_capacity()));
+            }
+        };
+
+        match coinbase_account
+            .info
+            .nonce
+            .checked_add_signed(coinbase_nonce_delta)
+        {
+            Some(new_nonce) => coinbase_account.info.nonce = new_nonce,
+            None => {
+                return Ok(CachingResult::new_cache_miss(entry.has_storage_capacity()));
+            }
+        };
+
+        if !checked_add_balance(&mut coinbase_account.info.balance, &coinbase_balance_delta) {
+            return Ok(CachingResult::new_cache_miss(entry.has_storage_capacity()));
+        }
+
+        self.inc_cache_hits();
+        entry.inc_hits();
+        Ok(CachingResult {
+            result: Some(Ok(evm_result)),
+            used_state_trace: cached_result.used_state_trace,
+            should_cache: false,
+        })
+    }
+}
+
+fn checked_add_balance(balance: &mut U256, delta: &I256) -> bool {
+    let negative = delta.is_negative();
+    let delta_abs: U256 = delta.abs().try_into().unwrap();
+    if negative && &delta_abs > balance {
+        return false;
+    }
+
+    let result = if negative {
+        balance.checked_sub(delta_abs)
+    } else {
+        balance.checked_add(delta_abs)
+    };
+    match result {
+        Some(res) => {
+            *balance = res;
+            true
+        }
+        None => false,
+    }
+}
+
+// check if given execution trace actually read coinbase balance or writes to coinbase storage
+// if so we can't cache this tx as it can mess cache
+fn trace_is_not_cachable(used_state_trace: &UsedStateTrace, coinbase: &Address) -> bool {
+    let reads_balance = used_state_trace.read_balances.contains_key(coinbase);
+    let writes_slots = used_state_trace
+        .written_slot_values
+        .keys()
+        .any(|slot_key| &slot_key.address == coinbase);
+    reads_balance || writes_slots
+}

--- a/crates/rbuilder/src/building/tx_sim_cache/mod.rs
+++ b/crates/rbuilder/src/building/tx_sim_cache/mod.rs
@@ -90,7 +90,7 @@ impl TxCacheEntry {
             return;
         }
 
-        if trace_is_not_cachable(&result.used_state_trace, &result.coinbase) {
+        if trace_is_not_cacheable(&result.used_state_trace, &result.coinbase) {
             self.never_cache.store(true, Ordering::Relaxed);
             return;
         }
@@ -375,7 +375,7 @@ fn checked_add_balance(balance: &mut U256, delta: &I256) -> bool {
 
 // check if given execution trace actually read coinbase balance or writes to coinbase storage
 // if so we can't cache this tx as it can mess cache
-fn trace_is_not_cachable(used_state_trace: &UsedStateTrace, coinbase: &Address) -> bool {
+fn trace_is_not_cacheable(used_state_trace: &UsedStateTrace, coinbase: &Address) -> bool {
     let reads_balance = used_state_trace.read_balances.contains_key(coinbase);
     let writes_slots = used_state_trace
         .written_slot_values

--- a/crates/rbuilder/src/building/tx_sim_cache/result_store.rs
+++ b/crates/rbuilder/src/building/tx_sim_cache/result_store.rs
@@ -1,0 +1,283 @@
+use std::sync::Arc;
+
+use alloy_primitives::Address;
+use alloy_primitives::U256;
+use revm::state::AccountInfo;
+
+use parking_lot::RwLock;
+
+use super::AccessRecord;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NextAction {
+    CheckAccount(Address),
+    CheckStorage(Address, U256),
+    DoNothing,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActionResult {
+    AccountValue(Option<AccountInfo>),
+    StorageValue(U256),
+    DoNothing,
+}
+
+#[derive(Debug, Clone)]
+struct StoredResult<R> {
+    trace: Vec<(NextAction, ActionResult)>,
+    result: R,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutionResultStore<R> {
+    nodes: Arc<RwLock<Vec<Arc<StoredResult<R>>>>>,
+}
+
+impl<R> Default for ExecutionResultStore<R> {
+    fn default() -> Self {
+        Self {
+            nodes: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+}
+
+impl<R: Clone + std::fmt::Debug> ExecutionResultStore<R> {
+    pub fn len(&self) -> usize {
+        self.nodes.read().len()
+    }
+
+    pub fn get_walker(&self) -> ExecutionResultStoreWalker<R> {
+        ExecutionResultStoreWalker {
+            store: self.clone(),
+            trace_idx: 0,
+            record_idx: 0,
+        }
+    }
+
+    pub fn insert_result(&self, access_trace: Vec<AccessRecord>, result: R) {
+        let mut trace = Vec::with_capacity(access_trace.len());
+        for record in access_trace {
+            let trace_entry = match record {
+                AccessRecord::Account { address, result } => (
+                    NextAction::CheckAccount(address),
+                    ActionResult::AccountValue(result),
+                ),
+                AccessRecord::Storage {
+                    address,
+                    index,
+                    result,
+                } => (
+                    NextAction::CheckStorage(address, index),
+                    ActionResult::StorageValue(result),
+                ),
+            };
+            trace.push(trace_entry);
+        }
+        if trace.is_empty() {
+            trace.push((NextAction::DoNothing, ActionResult::DoNothing));
+        }
+        {
+            // don't store same result twice
+            let nodes = self.nodes.read().clone();
+            for node in nodes {
+                if node.trace == trace {
+                    return;
+                }
+            }
+        }
+        self.nodes
+            .write()
+            .push(Arc::new(StoredResult { trace, result }));
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutionResultStoreWalker<R> {
+    store: ExecutionResultStore<R>,
+    trace_idx: usize,
+    record_idx: usize,
+}
+
+impl<R: Clone + std::fmt::Debug> ExecutionResultStoreWalker<R> {
+    fn stored_result(&self, idx: usize) -> Option<Arc<StoredResult<R>>> {
+        let nodes = self.store.nodes.read();
+        nodes.get(idx).map(Arc::clone)
+    }
+
+    pub fn next_action(&self) -> Option<NextAction> {
+        let stored_result = self.stored_result(self.trace_idx)?;
+        let (action, _result) = stored_result.trace.get(self.record_idx)?;
+        Some(action.clone())
+    }
+
+    pub fn action_result(&mut self, action_result: &ActionResult) -> Option<R> {
+        let stored_result = self.stored_result(self.trace_idx)?;
+        let (_action, expected_result) = stored_result
+            .trace
+            .get(self.record_idx)
+            .expect("must exist");
+        if action_result == expected_result {
+            self.record_idx += 1;
+            if self.record_idx == stored_result.trace.len() {
+                return Some(stored_result.result.clone());
+            }
+        } else {
+            self.trace_idx += 1;
+            self.record_idx = 0;
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::test_utils::{addr, u256};
+
+    use super::*;
+
+    type Store = ExecutionResultStore<u64>;
+
+    fn account(address: u64, balance: u64) -> AccessRecord {
+        AccessRecord::Account {
+            address: addr(address),
+            result: Some(AccountInfo {
+                balance: u256(balance),
+                nonce: 0,
+                code_hash: Default::default(),
+                code: None,
+            }),
+        }
+    }
+
+    fn storage(address: u64, slot: u64, value: u64) -> AccessRecord {
+        AccessRecord::Storage {
+            address: addr(address),
+            index: u256(slot),
+            result: u256(value),
+        }
+    }
+
+    fn get_storage(trace: &[AccessRecord], address: Address, slot: U256) -> Option<U256> {
+        for tr in trace {
+            if let AccessRecord::Storage {
+                address: rec_address,
+                index,
+                result,
+            } = tr
+            {
+                if rec_address == &address && index == &slot {
+                    return Some(*result);
+                }
+            }
+        }
+        None
+    }
+
+    fn get_account(trace: &[AccessRecord], address: Address) -> Option<Option<AccountInfo>> {
+        for tr in trace {
+            if let AccessRecord::Account {
+                address: rec_address,
+                result,
+            } = tr
+            {
+                if rec_address == &address {
+                    return Some(result.clone());
+                }
+            }
+        }
+        None
+    }
+
+    fn get_result_using_walker(current_state: &[AccessRecord], store: &Store) -> Option<u64> {
+        let mut walker = store.get_walker();
+        loop {
+            let next_action = match walker.next_action() {
+                Some(a) => a,
+                None => {
+                    return None;
+                }
+            };
+            let result = match next_action {
+                NextAction::CheckAccount(address) => {
+                    let account =
+                        get_account(current_state, address).expect("asked about unknown account");
+                    ActionResult::AccountValue(account)
+                }
+                NextAction::CheckStorage(address, slot) => {
+                    let storage =
+                        get_storage(current_state, address, slot).expect("asked about uknown slot");
+                    ActionResult::StorageValue(storage)
+                }
+                NextAction::DoNothing => ActionResult::DoNothing,
+            };
+            if let Some(result) = walker.action_result(&result) {
+                return Some(result);
+            }
+        }
+    }
+
+    #[test]
+    fn test_basic_result_insert() {
+        let store = Store::default();
+
+        let mut cached_data: Vec<(_, u64)> = Vec::new();
+        let trace = vec![account(0x0, 0), storage(0x0, 0, 0)];
+        cached_data.push((trace, 1));
+        let trace = vec![
+            account(0x0, 1),
+            account(0x1, 0),
+            storage(0x1, 1, 0),
+            storage(0x2, 2, 0),
+        ];
+        cached_data.push((trace, 2));
+        let trace = vec![account(0x0, 1), account(0x1, 0), storage(0x1, 1, 2)];
+        cached_data.push((trace.clone(), 3));
+        cached_data.push((trace, 3)); // insert the same result again, shoudl be noop
+
+        for (trace, result) in &cached_data {
+            store.insert_result(trace.clone(), *result);
+        }
+
+        for (state, result) in &cached_data {
+            let found = get_result_using_walker(state, &store);
+            assert_eq!(*result, found.expect("result not found"));
+        }
+
+        let mut non_cached_data = Vec::new();
+        let trace = vec![account(0x0, 50)];
+        non_cached_data.push(trace);
+        let trace = vec![account(0x0, 1), account(0x1, 0), storage(0x1, 1, 120)];
+        non_cached_data.push(trace);
+        let trace = vec![account(0x0, 1), account(0x1, 0), storage(0x1, 1, 200)];
+        non_cached_data.push(trace);
+
+        for state in non_cached_data {
+            let found = get_result_using_walker(&state, &store);
+            assert_eq!(None, found);
+        }
+    }
+
+    #[test]
+    fn test_empty_result_insert() {
+        // this can happen if tx errors before reading any state
+        let store = Store::default();
+
+        store.insert_result(Vec::new(), 1);
+
+        let found = get_result_using_walker(&[], &store);
+        assert_eq!(1, found.expect("result not found"));
+    }
+
+    #[test]
+    fn test_len_multiple_same_results() {
+        let store = Store::default();
+        let trace = vec![account(0x0, 1)];
+        store.insert_result(trace.clone(), 1);
+        store.insert_result(trace.clone(), 1);
+
+        assert_eq!(1, store.len());
+
+        let found = get_result_using_walker(&trace, &store);
+        assert_eq!(1, found.expect("result not found"));
+    }
+}

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -121,6 +121,7 @@ pub struct BaseConfig {
 
     /// Number of threads used for incoming order simulation
     pub simulation_threads: usize,
+    pub simulation_use_random_coinbase: bool,
 
     /// uses cached sparse trie for root hash
     pub root_hash_use_sparse_trie: bool,
@@ -137,6 +138,8 @@ pub struct BaseConfig {
 
     /// Config for IPC state provider
     pub ipc_provider: Option<IpcProviderConfig>,
+
+    pub evm_caching_enable: bool,
 
     // backtest config
     backtest_fetch_mempool_data_dir: EnvOrValue<String>,
@@ -253,6 +256,9 @@ impl BaseConfig {
             orderpool_sender,
             orderpool_receiver,
             sbundle_merger_selected_signers: Arc::new(self.sbundle_mergeable_signers()),
+
+            evm_caching_enable: self.evm_caching_enable,
+            simulation_use_random_coinbase: self.simulation_use_random_coinbase,
         })
     }
 
@@ -570,10 +576,12 @@ impl Default for BaseConfig {
             backtest_builders: Vec::new(),
             live_builders: vec!["mgp-ordering".to_string(), "mp-ordering".to_string()],
             simulation_threads: 1,
+            simulation_use_random_coinbase: true,
             sbundle_mergeable_signers: None,
             sbundle_mergeabe_signers: None,
             require_non_empty_blocklist: Some(DEFAULT_REQUIRE_NON_EMPTY_BLOCKLIST),
             ipc_provider: None,
+            evm_caching_enable: false,
         }
     }
 }

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -225,7 +225,7 @@ async fn run_submit_to_relays_job(
             txs = block.sealed_block.body().transactions.len(),
             bundles,
             builder_name = block.builder_name,
-            fill_time_ms = block.trace.fill_time.as_millis(),
+            fill_time_ms = block.trace.fill_time.as_micros() as f64 / 1000.0,
             finalize_time_ms = block.trace.finalize_time.as_millis(),
         );
         info!(

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -123,6 +123,9 @@ where
     pub orderpool_sender: mpsc::Sender<ReplaceableOrderPoolCommand>,
     pub orderpool_receiver: mpsc::Receiver<ReplaceableOrderPoolCommand>,
     pub sbundle_merger_selected_signers: Arc<Vec<Address>>,
+
+    pub evm_caching_enable: bool,
+    pub simulation_use_random_coinbase: bool,
 }
 
 impl<P, BlocksSourceType: SlotSource> LiveBuilder<P, BlocksSourceType>
@@ -179,6 +182,7 @@ where
             OrderSimulationPool::new(
                 self.provider.clone(),
                 self.simulation_threads,
+                self.simulation_use_random_coinbase,
                 self.global_cancellation.clone(),
             )
         };
@@ -295,6 +299,7 @@ where
                 None,
                 root_hasher,
                 payload.payload_id,
+                self.evm_caching_enable,
             ) {
                 mark_building_started(block_ctx.timestamp());
                 builder_pool.start_block_building(

--- a/crates/rbuilder/src/live_builder/simulation/mod.rs
+++ b/crates/rbuilder/src/live_builder/simulation/mod.rs
@@ -4,6 +4,7 @@ mod simulation_job;
 use crate::{
     building::{
         sim::{SimTree, SimulatedResult, SimulationRequest},
+        tx_sim_cache::TxExecutionCache,
         BlockBuildingContext,
     },
     live_builder::order_input::orderpool::OrdersForBlock,
@@ -55,6 +56,7 @@ pub struct OrderSimulationPool<P> {
     running_tasks: Arc<Mutex<Vec<JoinHandle<()>>>>,
     current_contexts: Arc<Mutex<CurrentSimulationContexts>>,
     worker_threads: Vec<std::thread::JoinHandle<()>>,
+    use_random_coinbase: bool,
 }
 
 /// Result of a simulation.
@@ -70,7 +72,12 @@ impl<P> OrderSimulationPool<P>
 where
     P: StateProviderFactory + Clone + 'static,
 {
-    pub fn new(provider: P, num_workers: usize, global_cancellation: CancellationToken) -> Self {
+    pub fn new(
+        provider: P,
+        num_workers: usize,
+        use_random_coinbase: bool,
+        global_cancellation: CancellationToken,
+    ) -> Self {
         let mut result = Self {
             provider,
             running_tasks: Arc::new(Mutex::new(Vec::new())),
@@ -78,6 +85,7 @@ where
                 contexts: HashMap::default(),
             })),
             worker_threads: Vec::new(),
+            use_random_coinbase,
         };
         for i in 0..num_workers {
             let ctx = Arc::clone(&result.current_contexts);
@@ -107,12 +115,15 @@ where
     ) -> SlotOrderSimResults {
         let (slot_sim_results_sender, slot_sim_results_receiver) = mpsc::channel(10_000);
 
-        let ctx = {
+        let ctx = if self.use_random_coinbase {
             // use random coinbase for simulations to make top of the block simulation bypass harder
             let mut ctx = ctx;
             let signer = Signer::random();
             ctx.evm_env.block_env.beneficiary = signer.address;
             ctx.builder_signer = Some(signer);
+            ctx.tx_execution_cache = TxExecutionCache::new(false).into();
+            ctx
+        } else {
             ctx
         };
 
@@ -205,7 +216,7 @@ mod tests {
         )
         .unwrap();
 
-        let sim_pool = OrderSimulationPool::new(provider_factory_reopener, 4, cancel.clone());
+        let sim_pool = OrderSimulationPool::new(provider_factory_reopener, 4, true, cancel.clone());
         let (order_sender, order_receiver) = mpsc::unbounded_channel();
         let orders_for_block = OrdersForBlock {
             new_order_sub: order_receiver,

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -233,7 +233,7 @@ register_metrics! {
     // Metrics for important step of the block processing
     pub static BLOCK_FILL_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_fill_time", "Block Fill Times (ms)")
-            .buckets(exponential_buckets_range(1.0, 3000.0, 100)),
+            .buckets(exponential_buckets_range(0.01, 3000.0, 200)),
         &["builder_name"]
     )
     .unwrap();


### PR DESCRIPTION
# Motivation

Builder constantly builds different blocks for a slot and most of transactions are execution over and over with the same result. 

Here, we cache execution of transactions and next time we apply tx that was already executed we only check if state that is currently available is the same as for the cached result.

# Config
* `simulation_use_random_coinbase: bool` if top of block simulation should use random coinbase
* `evm_caching_enable: bool` if evm caching should be enabled

# Results

* Cache hit rate: typically around 80-90% of txs are cached and cache hit rate is around 70-90%

* The speedup for EVM part of execution is huge, verifying tx state and applying result is much faster than EVM execution, for most txs its around 10 microseconds while typical execution is around 300 microseconds. There are txs that take multiple milliseconds to execute and for those time saved is huge.

## Speedup of block fill time.

To measure this I compare average block fill time for the given block of builder with and without caching. I only look at blocks where average gas used is the same in both builders.

The speedup of block fill time is distributed like this: average: 2.5x, median: 2.3x, p10: 1.5x, p90: 3.8x

## Limiting factor

The limiting factor of speedup and cache hit rate are txs that are always failing when filling block. We execute txs like that only once, their execution is never cached. Successful txs that we execute over and over are almost perfectly cached.

# Caveats

I don't recommend enabling it on prod for now because I've seen one root hash related block simulation error that is hard to explain. Currently our dev version builder is broken in that part so that might be it.