### PR TITLE
op-rbuilder: Update Documentation / CI Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /test/
 /integration_logs
 genesis.json
+/op-reth
 
 # editors
 .code

--- a/crates/op-rbuilder/README.md
+++ b/crates/op-rbuilder/README.md
@@ -49,14 +49,18 @@ op-rbuilder has an integration test framework that runs the builder against mock
 To run the integration tests, run:
 
 ```bash
+# Ensure you have op-reth installed in your path,
+# you can download it with the command below and move it to a locaiton in your path
+./scripts/ci/download-op-reth.sh
+
 # Generate a genesis file
-cargo run -p op-rbuilder --bin tester --features optimism -- genesis --output genesis.json
+cargo run -p op-rbuilder --bin tester -- genesis --output genesis.json
 
 # Build the op-rbuilder binary
-cargo build -p op-rbuilder --bin op-rbuilder --features optimism
+cargo build -p op-rbuilder --bin op-rbuilder
 
 # Run the integration tests
-cargo run -p op-rbuilder --bin tester --features optimism -- run
+cargo run -p op-rbuilder --bin tester -- run
 ```
 
 ## Local Devnet

--- a/crates/op-rbuilder/README.md
+++ b/crates/op-rbuilder/README.md
@@ -50,7 +50,7 @@ To run the integration tests, run:
 
 ```bash
 # Ensure you have op-reth installed in your path,
-# you can download it with the command below and move it to a locaiton in your path
+# you can download it with the command below and move it to a location in your path
 ./scripts/ci/download-op-reth.sh
 
 # Generate a genesis file

--- a/crates/op-rbuilder/README.md
+++ b/crates/op-rbuilder/README.md
@@ -57,10 +57,12 @@ To run the integration tests, run:
 cargo run -p op-rbuilder --bin tester -- genesis --output genesis.json
 
 # Build the op-rbuilder binary
+# To test flashblocks add flashblocks as a feature
 cargo build -p op-rbuilder --bin op-rbuilder
 
 # Run the integration tests
-cargo run -p op-rbuilder --bin tester -- run
+# To test flashblocks add flashblocks as a feature
+cargo test --package op-rbuilder --lib --features integration -- integration::integration_test::tests
 ```
 
 ## Local Devnet

--- a/scripts/ci/download-op-reth.sh
+++ b/scripts/ci/download-op-reth.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=${VERSION:-1.3.9}
+VERSION=${VERSION:-1.3.12}
 
 ARCH=$(uname -m)
 case $ARCH in

--- a/scripts/ci/download-op-reth.sh
+++ b/scripts/ci/download-op-reth.sh
@@ -1,13 +1,39 @@
 #!/bin/bash
 
-# Download the op-reth release
-wget https://github.com/paradigmxyz/reth/releases/download/v1.3.4/op-reth-v1.3.4-x86_64-unknown-linux-gnu.tar.gz
+VERSION=${VERSION:-1.3.9}
+
+ARCH=$(uname -m)
+case $ARCH in
+    "x86_64")
+        if [[ "$(uname)" == "Darwin" ]]; then
+            ARCH_STRING="x86_64-apple-darwin"
+        else
+            ARCH_STRING="x86_64-unknown-linux-gnu"
+        fi
+        ;;
+    "arm64" | "aarch64")
+        if [[ "$(uname)" == "Darwin" ]]; then
+            ARCH_STRING="aarch64-apple-darwin"
+        else
+            ARCH_STRING="aarch64-unknown-linux-gnu"
+        fi
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
+FILENAME="op-reth-v${VERSION}-${ARCH_STRING}.tar.gz"
+echo "Downloading ${FILENAME}"
+
+wget -q "https://github.com/paradigmxyz/reth/releases/download/v${VERSION}/${FILENAME}"
 
 # Extract the tar.gz file
-tar -xzf op-reth-v1.3.4-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf "${FILENAME}"
 
 # Make the binary executable
 chmod +x op-reth
 
 # Clean up the tar.gz file (optional)
-rm op-reth-v1.3.4-x86_64-unknown-linux-gnu.tar.gz
+rm "${FILENAME}"


### PR DESCRIPTION
## 📝 Summary

1. Update the version of op-reth used by CI
2. Make the CI script work on macOS as well as linux
3. Update the instructions for running/testing op-rbuilder

## 💡 Motivation and Context

1. The CI script was handy for downloading Reth
2. The instructions didn't work for me (due to the optimism feature being removed etc).

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
