### PR TITLE
Add metric to track number of invalid removed transactions

### DIFF
--- a/crates/op-rbuilder/src/metrics.rs
+++ b/crates/op-rbuilder/src/metrics.rs
@@ -56,11 +56,18 @@ pub struct OpRBuilderMetrics {
     pub tx_byte_size: Histogram,
     /// Number of reverted transactions
     pub num_reverted_tx: Counter,
+    /// Number of invalid txs being removed
+    pub num_removed_invalid_tx: Counter,
 }
 
 impl OpRBuilderMetrics {
     pub fn inc_num_reverted_tx(&self, num_reverted_tx: usize) {
         self.num_reverted_tx.increment(num_reverted_tx as u64);
+    }
+
+    pub fn inc_num_removed_invalid_tx(&self, num_removed_invalid_tx: usize) {
+        self.num_removed_invalid_tx
+            .increment(num_removed_invalid_tx as u64);
     }
 
     pub fn inc_builder_landed_blocks(&self) {

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -564,6 +564,8 @@ impl<Txs> OpBuilder<'_, Txs> {
             (None, None)
         };
 
+        ctx.metrics
+            .inc_num_removed_invalid_tx(info.invalid_tx_hashes.len());
         remove_invalid(info.invalid_tx_hashes.iter().copied().collect());
 
         let payload = ExecutedPayload {


### PR DESCRIPTION
## 📝 Summary

Nice addition to track how much invalid transaction we remove during block building

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
