### PR TITLE
Bid delay + subsidy

### DIFF
--- a/crates/rbuilder/src/live_builder/block_output/bidding/true_block_value_bidder.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding/true_block_value_bidder.rs
@@ -7,18 +7,32 @@ use crate::{
     },
     live_builder::block_output::bid_value_source::interfaces::{BidValueObs, CompetitionBid},
 };
+use alloy_primitives::U256;
+use parking_lot::Mutex;
 use std::sync::Arc;
 use time::OffsetDateTime;
+use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-/// Bidding service giving a TrueBlockValueBidder
+/// Bidding service giving a TrueBlockValueBidder.
+/// This is just an example not really suitable for production since it gives away all the profit!.
 #[derive(Debug)]
-pub struct TrueBlockValueBiddingService {}
+pub struct TrueBlockValueBiddingService {
+    slot_delta_to_start_bidding: time::Duration,
+    subsidy: U256,
+}
 
 impl TrueBlockValueBiddingService {
     /// _landed_blocks is passed to look like a real BiddingService...
-    pub fn new(_landed_blocks: &[LandedBlockInfo]) -> Self {
-        Self {}
+    pub fn new(
+        _landed_blocks: &[LandedBlockInfo],
+        slot_delta_to_start_bidding: time::Duration,
+        subsidy: U256,
+    ) -> Self {
+        Self {
+            slot_delta_to_start_bidding,
+            subsidy,
+        }
     }
 }
 
@@ -27,11 +41,41 @@ impl BiddingService for TrueBlockValueBiddingService {
         &mut self,
         _block: u64,
         _slot: u64,
-        _slot_timestamp: OffsetDateTime,
+        slot_timestamp: OffsetDateTime,
         bid_maker: Box<dyn BidMaker + Send + Sync>,
-        _cancel: CancellationToken,
+        cancel: CancellationToken,
     ) -> Arc<dyn SlotBidder> {
-        Arc::new(TrueBlockValueBidder { bid_maker })
+        let bid_start = slot_timestamp + self.slot_delta_to_start_bidding;
+        let delay = core::time::Duration::try_from(bid_start - OffsetDateTime::now_utc());
+        let inner = if let Ok(delay) = delay {
+            // We create a task that sleeps, sends the last blocks and then "gives back" the bidder.
+            let inner = Arc::new(Mutex::new(TrueBlockValueBidderInner {
+                bid_maker: None,
+                last_block_not_sent: None,
+                subsidy: self.subsidy,
+            }));
+            let inner_clone = inner.clone();
+            tokio::task::spawn(async move {
+                tokio::select! {
+                    _ = sleep(delay) => {},
+                    _ = cancel.cancelled() => return
+                }
+                let mut inner = inner_clone.lock();
+                if let Some(block) = inner.last_block_not_sent.take() {
+                    send_block(block, inner.subsidy, bid_maker.as_ref());
+                }
+                inner.bid_maker = Some(bid_maker);
+            });
+            inner
+        } else {
+            Arc::new(Mutex::new(TrueBlockValueBidderInner {
+                bid_maker: Some(bid_maker),
+                last_block_not_sent: None,
+                subsidy: self.subsidy,
+            }))
+        };
+
+        Arc::new(TrueBlockValueBidder { inner })
     }
 
     /// Dummy win control.
@@ -48,27 +92,53 @@ impl BiddingService for TrueBlockValueBiddingService {
     }
 }
 
+/// This struct coordinates the wait time for the first bid.
+struct TrueBlockValueBidderInner {
+    /// If None UnfinishedBlockBuildingSink::new_block won't bid and instead will store in last_block_not_sent.
+    bid_maker: Option<Box<dyn BidMaker + Send + Sync>>,
+    last_block_not_sent: Option<BiddableUnfinishedBlock>,
+    subsidy: U256,
+}
+
+impl std::fmt::Debug for TrueBlockValueBidderInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrueBlockValueBidderInner").finish()
+    }
+}
+
 /// Bidder that bids every block using its true block value ignoring competition bids.
 #[derive(Debug)]
 struct TrueBlockValueBidder {
-    bid_maker: Box<dyn BidMaker + Send + Sync>,
+    inner: Arc<Mutex<TrueBlockValueBidderInner>>,
 }
 
 impl SlotBidder for TrueBlockValueBidder {}
 
+fn send_block(
+    block: BiddableUnfinishedBlock,
+    subsidy: U256,
+    bid_maker: &(dyn BidMaker + Send + Sync),
+) {
+    let payout_tx_value = if block.can_add_payout_tx() {
+        Some(block.true_block_value() + subsidy)
+    } else {
+        None
+    };
+    bid_maker.send_bid(Bid::new(block, payout_tx_value, None));
+}
+
 impl UnfinishedBlockBuildingSink for TrueBlockValueBidder {
     fn new_block(&self, block: BiddableUnfinishedBlock) {
-        let payout_tx_value = if block.can_add_payout_tx() {
-            Some(block.true_block_value())
+        let mut inner = self.inner.lock();
+        if let Some(bid_maker) = &inner.bid_maker {
+            send_block(block, inner.subsidy, bid_maker.as_ref());
         } else {
-            None
-        };
-        self.bid_maker
-            .send_bid(Bid::new(block, payout_tx_value, None));
+            inner.last_block_not_sent = Some(block);
+        }
     }
 
     fn can_use_suggested_fee_recipient_as_coinbase(&self) -> bool {
-        true
+        false
     }
 }
 

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -46,7 +46,7 @@ use crate::{
 use alloy_chains::ChainKind;
 use alloy_primitives::{
     utils::{format_ether, parse_ether},
-    FixedBytes, B256,
+    FixedBytes, B256, U256,
 };
 use ethereum_consensus::{
     builder::compute_builder_domain, crypto::SecretKey, primitives::Version,
@@ -105,7 +105,15 @@ pub struct Config {
 
     /// selected builder configurations
     pub builders: Vec<BuilderConfig>,
+
+    /// When the sample bidder (see TrueBlockValueBiddingService) will start bidding.
+    /// Usually a negative number.
+    pub slot_delta_to_start_bidding_ms: Option<i64>,
+    /// Value added to the bids (see TrueBlockValueBiddingService).
+    pub subsidy: Option<String>,
 }
+
+const DEFAULT_SLOT_DELTA_TO_START_BIDDING_MS: i64 = -8000;
 
 #[serde_as]
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -362,8 +370,19 @@ impl LiveBuilderConfig for Config {
             self.base_config.coinbase_signer()?.address,
             WALLET_INIT_HISTORY_SIZE,
         )?;
-        let bidding_service: Box<dyn BiddingService> =
-            Box::new(TrueBlockValueBiddingService::new(&wallet_history));
+        let subsidy = self
+            .subsidy
+            .as_ref()
+            .map(|s| parse_ether(s))
+            .unwrap_or(Ok(U256::ZERO))?;
+        let bidding_service: Box<dyn BiddingService> = Box::new(TrueBlockValueBiddingService::new(
+            &wallet_history,
+            time::Duration::milliseconds(
+                self.slot_delta_to_start_bidding_ms
+                    .unwrap_or(DEFAULT_SLOT_DELTA_TO_START_BIDDING_MS),
+            ),
+            subsidy,
+        ));
 
         let sink_factory = Box::new(BlockSealingBidderFactory::new(
             bidding_service,
@@ -537,6 +556,8 @@ impl Default for Config {
                     }),
                 },
             ],
+            slot_delta_to_start_bidding_ms: None,
+            subsidy: None,
         }
     }
 }


### PR DESCRIPTION
## 📝 Summary

This PR adds 2 new features to help debugging:
-  slot_delta_to_start_bidding_ms: time to start bidding. Default -8000ms.
   It helps avoid a race condition when bidding too early.
- subsidy: (String) Value to add to the bids.
  When testing on any testnet you can boost your bids to win more blocks! Obviously you need to fund the account.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
