### PR TITLE
Fixes for redistribution

### DIFF
--- a/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
@@ -10,7 +10,7 @@ use alloy_primitives::utils::format_ether;
 
 use crate::{
     backtest::{
-        execute::{backtest_prepare_ctx_for_block_from_building_context, BacktestBlockInput},
+        execute::{backtest_prepare_orders_from_building_context, BacktestBlockInput},
         OrdersWithTimestamp,
     },
     building::{builders::BacktestSimulateBlockInput, BlockBuildingContext},
@@ -86,10 +86,8 @@ where
     orders_source.print_custom_stats(provider_factory.clone())?;
 
     let ctx = orders_source.create_block_building_context()?;
-    let BacktestBlockInput {
-        ctx, sim_orders, ..
-    } = backtest_prepare_ctx_for_block_from_building_context(
-        ctx,
+    let BacktestBlockInput { sim_orders, .. } = backtest_prepare_orders_from_building_context(
+        ctx.clone(),
         available_orders.clone(),
         provider_factory.clone(),
         &config.base_config().sbundle_mergeable_signers(),

--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -51,20 +51,18 @@ pub struct BlockBacktestValue {
 
 #[derive(Debug)]
 pub struct BacktestBlockInput {
-    pub ctx: BlockBuildingContext,
     pub sim_orders: Vec<Arc<SimulatedOrder>>,
     pub sim_errors: Vec<OrderErr>,
 }
 
-pub fn backtest_prepare_ctx_for_block<P>(
-    block_data: BlockData,
+pub fn backtest_get_block_building_context_for_block<P>(
+    block_data: &BlockData,
     provider: P,
     chain_spec: Arc<ChainSpec>,
     blocklist: BlockList,
-    sbundle_mergeabe_signers: &[Address],
     builder_signer: Signer,
     evm_caching_enable: bool,
-) -> eyre::Result<BacktestBlockInput>
+) -> eyre::Result<BlockBuildingContext>
 where
     P: StateProviderFactory + Clone + 'static,
 {
@@ -73,7 +71,7 @@ where
         block_data.winning_bid_trace.parent_hash,
     );
     let ctx = BlockBuildingContext::from_onchain_block(
-        block_data.onchain_block,
+        block_data.onchain_block.clone(),
         chain_spec.clone(),
         None,
         blocklist,
@@ -83,19 +81,14 @@ where
         Arc::from(provider.root_hasher(parent_num_hash)?),
         evm_caching_enable,
     );
-    backtest_prepare_ctx_for_block_from_building_context(
-        ctx,
-        block_data.available_orders,
-        provider,
-        sbundle_mergeabe_signers,
-    )
+    Ok(ctx)
 }
 
-pub fn backtest_prepare_ctx_for_block_from_building_context<P>(
+pub fn backtest_prepare_orders_from_building_context<P>(
     ctx: BlockBuildingContext,
     available_orders: Vec<OrdersWithTimestamp>,
     provider: P,
-    sbundle_mergeabe_signers: &[Address],
+    sbundle_mergeable_signers: &[Address],
 ) -> eyre::Result<BacktestBlockInput>
 where
     P: StateProviderFactory + Clone + 'static,
@@ -110,13 +103,12 @@ where
 
     // Apply bundle merging as in live building.
     let order_store = Rc::new(RefCell::new(SimulatedOrderStore::new()));
-    let mut merger = MultiShareBundleMerger::new(sbundle_mergeabe_signers, order_store.clone());
+    let mut merger = MultiShareBundleMerger::new(sbundle_mergeable_signers, order_store.clone());
     for sim_order in sim_orders {
         merger.insert_order(Arc::new(sim_order));
     }
     let sim_orders = order_store.borrow().get_orders();
     Ok(BacktestBlockInput {
-        ctx,
         sim_orders,
         sim_errors,
     })
@@ -130,6 +122,37 @@ pub fn backtest_simulate_block<P, ConfigType>(
     builders_names: Vec<String>,
     config: &ConfigType,
     blocklist: BlockList,
+    sbundle_mergeable_signers: &[Address],
+) -> eyre::Result<BlockBacktestValue>
+where
+    P: StateProviderFactory + Clone + 'static,
+    ConfigType: LiveBuilderConfig,
+{
+    let ctx = backtest_get_block_building_context_for_block(
+        &block_data,
+        provider.clone(),
+        chain_spec,
+        blocklist,
+        config.base_config().coinbase_signer()?,
+        config.base_config().evm_caching_enable,
+    )?;
+
+    backtest_simulate_block_with_context(
+        ctx,
+        block_data,
+        provider,
+        builders_names,
+        config,
+        sbundle_mergeable_signers,
+    )
+}
+
+pub fn backtest_simulate_block_with_context<P, ConfigType>(
+    ctx: BlockBuildingContext,
+    block_data: BlockData,
+    provider: P,
+    builders_names: Vec<String>,
+    config: &ConfigType,
     sbundle_mergeabe_signers: &[Address],
 ) -> eyre::Result<BlockBacktestValue>
 where
@@ -137,17 +160,13 @@ where
     ConfigType: LiveBuilderConfig,
 {
     let BacktestBlockInput {
-        ctx,
         sim_orders,
         sim_errors,
-    } = backtest_prepare_ctx_for_block(
-        block_data.clone(),
+    } = backtest_prepare_orders_from_building_context(
+        ctx.clone(),
+        block_data.available_orders,
         provider.clone(),
-        chain_spec.clone(),
-        blocklist,
         sbundle_mergeabe_signers,
-        config.base_config().coinbase_signer()?,
-        config.base_config().evm_caching_enable,
     )?;
 
     let filtered_orders_blocklist_count = sim_errors

--- a/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/cli/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         cli::LiveBuilderConfig,
     },
     provider::StateProviderFactory,
+    utils::ProviderFactoryReopener,
 };
 use alloy_primitives::utils::format_ether;
 use clap::Parser;
@@ -68,6 +69,9 @@ where
         HistoricalDataStorage::new_from_path(&config.base_config().backtest_fetch_output_file)
             .await?;
     let provider = config.base_config().create_reth_provider_factory(true)?;
+    // this sets testing mode to true so we can skip consistency checks
+    let provider =
+        ProviderFactoryReopener::new_from_existing(provider.provider_factory_unchecked(), None)?;
     let csv_writer = cli
         .csv
         .map(|path| -> io::Result<_> { CSVResultWriter::new(path) })

--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -22,6 +22,7 @@ use crate::{
 use ahash::{HashMap, HashSet};
 use alloy_primitives::{utils::format_ether, Address, B256, I256, U256};
 pub use cli::run_backtest_redistribute;
+use itertools::Itertools;
 use rayon::prelude::*;
 use reth_chainspec::ChainSpec;
 use serde::{Deserialize, Serialize};
@@ -410,7 +411,21 @@ where
             simplified_orders.push(SimplifiedOrder::new_from_order(&available_order.order));
         }
     }
-    Ok(restore_landed_orders(block_txs, simplified_orders))
+    let result = restore_landed_orders(block_txs, simplified_orders);
+    {
+        for (order, result) in result.iter().sorted_by_key(|(o, _)| *o) {
+            trace!(
+            ?order,
+                   total_coinbase_profit = format_ether(result.total_coinbase_profit),
+                   unique_coinbase_profit = format_ether(result.unique_coinbase_profit),
+                   error = ?result.error,
+                   tx_hashes = ?result.tx_hashes,
+                   overlapping_txs = ?result.overlapping_txs,
+                   "Restored landed order"
+                )
+        }
+    }
+    Ok(result)
 }
 
 #[derive(Debug)]
@@ -849,7 +864,7 @@ fn apply_redistribution_formula(
                 .get(id)
                 .expect("order is not restored");
             if let Some(error) = &restored_landed_order.error {
-                warn!(identity = ?address, order = ?id, err = ?error, "Landed order is not properly recovered");
+                error!(identity = ?address, order = ?id, err = ?error, "Landed order is not properly recovered");
                 continue;
             }
             debug!(identity = ?address, order = ?id, "Landed order is properly recovered");

--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -3,7 +3,7 @@ mod redistribution_algo;
 
 use crate::{
     backtest::{
-        execute::backtest_simulate_block,
+        execute::backtest_get_block_building_context_for_block,
         redistribute::redistribution_algo::{
             IncludedOrderData, RedistributionCalculator, RedistributionIdentityData,
             RedistributionResult,
@@ -14,6 +14,7 @@ use crate::{
         },
         BlockData, BuiltBlockData, OrdersWithTimestamp,
     },
+    building::BlockBuildingContext,
     live_builder::{block_list_provider::BlockList, cli::LiveBuilderConfig},
     primitives::{Order, OrderId},
     provider::StateProviderFactory,
@@ -34,7 +35,7 @@ use std::{
 use tracing::{debug, error, info, info_span, trace, warn};
 use uuid::Uuid;
 
-use super::OrderFilteredReason;
+use super::{execute::backtest_simulate_block_with_context, OrderFilteredReason};
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -160,32 +161,42 @@ where
         distribute_to_mempool_txs,
     );
 
+    let ctx = backtest_get_block_building_context_for_block(
+        &block_data,
+        provider.clone(),
+        config.base_config().chain_spec()?,
+        blocklist.clone(),
+        config.base_config().coinbase_signer()?,
+        config.base_config().evm_caching_enable,
+    )?;
+
     let time_preparation_s = start.elapsed().as_millis() as f64 / 1000.0;
     let start = Instant::now();
 
     let results_without_exclusion = calculate_backtest_without_exclusion(
+        ctx.clone(),
         provider.clone(),
         config,
         block_data.clone(),
-        blocklist.clone(),
     )?;
 
     let time_no_exclusion_s = start.elapsed().as_millis() as f64 / 1000.0;
     let start = Instant::now();
 
     let exclusion_results = calculate_backtest_identity_and_order_exclusion(
+        ctx.clone(),
         provider.clone(),
         config,
         block_data.clone(),
         &available_orders,
         &results_without_exclusion,
-        blocklist.clone(),
     )?;
 
     let time_single_exclusion_s = start.elapsed().as_millis() as f64 / 1000.0;
     let start = Instant::now();
 
     let exclusion_results = calc_joint_exclusion_results(
+        ctx.clone(),
         provider.clone(),
         config,
         block_data.clone(),
@@ -193,7 +204,6 @@ where
         &results_without_exclusion,
         exclusion_results,
         distribute_to_mempool_txs,
-        blocklist.clone(),
     )?;
 
     let time_joint_exclusion_s = start.elapsed().as_millis() as f64 / 1000.0;
@@ -614,10 +624,10 @@ impl ResultsWithoutExclusion {
 }
 
 fn calculate_backtest_without_exclusion<P, ConfigType>(
+    ctx: BlockBuildingContext,
     provider: P,
     config: &ConfigType,
     block_data: BlockData,
-    blocklist: BlockList,
 ) -> eyre::Result<ResultsWithoutExclusion>
 where
     P: StateProviderFactory + Clone + 'static,
@@ -629,6 +639,7 @@ where
         new_orders_included: orders_included,
         ..
     } = calc_profit_after_exclusion(
+        ctx.clone(),
         provider.clone(),
         config,
         &block_data,
@@ -638,7 +649,6 @@ where
             orders_excluded_before: vec![],
             profit_before: U256::ZERO,
         },
-        blocklist,
     )?;
     Ok(ResultsWithoutExclusion {
         profit,
@@ -679,12 +689,12 @@ impl ExclusionResults {
 }
 
 fn calculate_backtest_identity_and_order_exclusion<P, ConfigType>(
+    ctx: BlockBuildingContext,
     provider: P,
     config: &ConfigType,
     block_data: BlockData,
     available_orders: &AvailableOrders,
     results_without_exclusion: &ResultsWithoutExclusion,
-    blocklist: BlockList,
 ) -> eyre::Result<ExclusionResults>
 where
     P: StateProviderFactory + Clone + 'static,
@@ -710,11 +720,11 @@ where
             .map(|(id, exclusions)| {
                 trace!(order = ?id, excluding = ?exclusions, "Excluding orders for landed order");
                 calc_profit_after_exclusion(
+                    ctx.clone(),
                     provider.clone(),
                     config,
                     &block_data,
                     results_without_exclusion.exclusion_input(exclusions),
-                    blocklist.clone(),
                 )
                 .map(|ok| (id, ok))
             })
@@ -732,11 +742,11 @@ where
                 .clone();
             trace!(identity = ?address, excluding = ?orders, "Excluding orders for identity");
             calc_profit_after_exclusion(
+                ctx.clone(),
                 provider.clone(),
                 config,
                 &block_data,
                 results_without_exclusion.exclusion_input(orders),
-                blocklist.clone(),
             )
             .map(|ok| (address, ok))
         })
@@ -751,6 +761,7 @@ where
 
 #[allow(clippy::too_many_arguments)]
 fn calc_joint_exclusion_results<P, ConfigType>(
+    ctx: BlockBuildingContext,
     provider: P,
     config: &ConfigType,
     block_data: BlockData,
@@ -758,7 +769,6 @@ fn calc_joint_exclusion_results<P, ConfigType>(
     results_without_exclusion: &ResultsWithoutExclusion,
     mut exclusion_results: ExclusionResults,
     distribute_to_mempool_txs: bool,
-    blocklist: BlockList,
 ) -> eyre::Result<ExclusionResults>
 where
     P: StateProviderFactory + Clone + 'static,
@@ -821,11 +831,11 @@ where
             let orders = orders1.iter().chain(orders2.iter()).cloned().collect();
             trace!(?address1, ?address2, excluding = ?orders, "Calculating joint contribution");
             calc_profit_after_exclusion(
+                ctx.clone(),
                 provider.clone(),
                 config,
                 &block_data,
                 results_without_exclusion.exclusion_input(orders),
-                blocklist.clone(),
             )
             .map(|ok| ((address1, address2), ok))
         })
@@ -1089,11 +1099,11 @@ struct ExclusionResult {
 
 /// calculate block profit excluding some orders
 fn calc_profit_after_exclusion<P, ConfigType>(
+    ctx: BlockBuildingContext,
     provider: P,
     config: &ConfigType,
     block_data: &BlockData,
     exclusion_input: ExclusionInput,
-    blocklist: BlockList,
 ) -> eyre::Result<ExclusionResult>
 where
     P: StateProviderFactory + Clone + 'static,
@@ -1118,14 +1128,12 @@ where
         exclusion_input.orders_excluded_before.into_iter().collect();
 
     let base_config = config.base_config();
-
-    let result = backtest_simulate_block(
+    let result = backtest_simulate_block_with_context(
+        ctx,
         block_data_with_excluded,
         provider.clone(),
-        base_config.chain_spec()?,
         base_config.backtest_builders.clone(),
         config,
-        blocklist,
         &base_config.sbundle_mergeable_signers(),
     )?
     .builder_outputs

--- a/crates/rbuilder/src/backtest/restore_landed_orders/find_landed_orders.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/find_landed_orders.rs
@@ -174,6 +174,7 @@ pub struct LandedOrderData {
     pub unique_coinbase_profit: I256,
     pub error: Option<OrderIdentificationError>,
     pub overlapping_txs: Vec<(OrderId, B256)>,
+    pub tx_hashes: Vec<B256>,
 }
 
 #[derive(Debug, Clone, thiserror::Error, Eq, PartialEq)]
@@ -195,6 +196,7 @@ impl LandedOrderData {
         unique_coinbase_profit: I256,
         error: Option<OrderIdentificationError>,
         overlapping_txs: Vec<(OrderId, B256)>,
+        tx_hashes: Vec<B256>,
     ) -> Self {
         LandedOrderData {
             order,
@@ -202,6 +204,7 @@ impl LandedOrderData {
             unique_coinbase_profit,
             error,
             overlapping_txs,
+            tx_hashes,
         }
     }
 }
@@ -239,6 +242,12 @@ pub fn restore_landed_orders(
     block_txs: Vec<ExecutedBlockTx>,
     orders: Vec<SimplifiedOrder>,
 ) -> HashMap<OrderId, LandedOrderData> {
+    let tx_to_index: HashMap<B256, usize> = block_txs
+        .iter()
+        .enumerate()
+        .map(|(idx, tx)| (tx.hash, idx))
+        .collect();
+
     let executed_block_data = ExecutedBlockData::new_from_txs(block_txs);
 
     let mut result = HashMap::default();
@@ -258,7 +267,14 @@ pub fn restore_landed_orders(
             Err(e) => {
                 result.insert(
                     order.id,
-                    LandedOrderData::new(order.id, I256::ZERO, I256::ZERO, Some(e), Vec::new()),
+                    LandedOrderData::new(
+                        order.id,
+                        I256::ZERO,
+                        I256::ZERO,
+                        Some(e),
+                        Vec::new(),
+                        Vec::new(),
+                    ),
                 );
             }
         }
@@ -274,7 +290,9 @@ pub fn restore_landed_orders(
                 I256::ZERO,
                 None,
                 Vec::new(),
+                Vec::new(),
             ));
+            entry.tx_hashes.push(tx);
             let profit = if *kickback == 0 {
                 profit
             } else {
@@ -300,6 +318,9 @@ pub fn restore_landed_orders(
 
     for landed_data in result.values_mut() {
         landed_data.overlapping_txs.sort_by_key(|(d, _)| *d);
+        landed_data
+            .tx_hashes
+            .sort_by_key(|tx| tx_to_index.get(tx).unwrap());
     }
 
     result
@@ -490,11 +511,32 @@ mod tests {
 
         let results = vec![
             // bundle 1 with 1 tx
-            LandedOrderData::new(order_id(0xb1), i256(12), i256(12), None, vec![]),
+            LandedOrderData::new(
+                order_id(0xb1),
+                i256(12),
+                i256(12),
+                None,
+                vec![],
+                vec![hash(2)],
+            ),
             // bundle 2 with 2/3 landed txs
-            LandedOrderData::new(order_id(0xb2), i256(13 + 14), i256(13 + 14), None, vec![]),
+            LandedOrderData::new(
+                order_id(0xb2),
+                i256(13 + 14),
+                i256(13 + 14),
+                None,
+                vec![],
+                vec![hash(3), hash(33)],
+            ),
             // bundle with simple kickback
-            LandedOrderData::new(order_id(0xb3), i256(15 + 2), i256(15 + 2), None, vec![]),
+            LandedOrderData::new(
+                order_id(0xb3),
+                i256(15 + 2),
+                i256(15 + 2),
+                None,
+                vec![],
+                vec![hash(5), hash(6)],
+            ),
         ];
         assert_result(executed_block, orders, results);
     }
@@ -540,6 +582,7 @@ mod tests {
                 i256(0x11 + 0x12),
                 None,
                 vec![(order_id(0xb2), hash(0xaa))],
+                vec![hash(0x11), hash(0xaa), hash(0x12)],
             ),
             LandedOrderData::new(
                 order_id(0xb2),
@@ -547,6 +590,7 @@ mod tests {
                 i256(0x21 + 0x22),
                 None,
                 vec![(order_id(0xb1), hash(0xaa))],
+                vec![hash(0x21), hash(0xaa), hash(0x22)],
             ),
         ];
         assert_result(executed_block, orders, results);
@@ -597,6 +641,7 @@ mod tests {
                 i256(0),
                 None,
                 vec![(order_id(0xb2), hash(0x00)), (order_id(0xb3), hash(0x00))],
+                vec![hash(0x00)],
             ),
             LandedOrderData::new(
                 order_id(0xb2),
@@ -604,6 +649,7 @@ mod tests {
                 i256(100),
                 None,
                 vec![(order_id(0xb1), hash(0x00)), (order_id(0xb3), hash(0x00))],
+                vec![hash(0x00), hash(0x02)],
             ),
             LandedOrderData::new(
                 order_id(0xb3),
@@ -611,6 +657,7 @@ mod tests {
                 i256(400),
                 None,
                 vec![(order_id(0xb1), hash(0x00)), (order_id(0xb2), hash(0x00))],
+                vec![hash(0x00), hash(0x03)],
             ),
         ];
         assert_result(executed_block, orders, results);
@@ -672,12 +719,14 @@ mod tests {
                 i256(0),
                 Some(OrderIdentificationError::TxReverted(hash(0x01))),
                 vec![],
+                vec![],
             ),
             LandedOrderData::new(
                 order_id(0xb2),
                 i256(0),
                 i256(0),
                 Some(OrderIdentificationError::TxNotFound(hash(0xAA))),
+                vec![],
                 vec![],
             ),
             LandedOrderData::new(
@@ -686,6 +735,7 @@ mod tests {
                 i256(0),
                 Some(OrderIdentificationError::TxIsIncorrectPosition(hash(0x02))),
                 vec![],
+                vec![],
             ),
             LandedOrderData::new(
                 order_id(0xb4),
@@ -693,12 +743,14 @@ mod tests {
                 i256(0),
                 Some(OrderIdentificationError::TxIsIncorrectPosition(hash(0x02))),
                 vec![],
+                vec![],
             ),
             LandedOrderData::new(
                 order_id(0xb5),
                 i256(0),
                 i256(0),
                 Some(OrderIdentificationError::TxReverted(hash(0x01))),
+                vec![],
                 vec![],
             ),
         ];
@@ -730,6 +782,7 @@ mod tests {
             i256(0x11 + 0x13),
             None,
             vec![],
+            vec![hash(0x11), hash(0x13)],
         )];
         assert_result(executed_block, orders, results);
     }
@@ -780,6 +833,7 @@ mod tests {
                 i256(0x4 + 10 / 2),
                 None,
                 vec![(order_id(0xb1), hash(0x2))],
+                vec![hash(0x2), hash(0x4), hash(0x5)],
             ),
             LandedOrderData::new(
                 order_id(0xb1),
@@ -787,6 +841,7 @@ mod tests {
                 i256(0x1 + 0x3),
                 None,
                 vec![(order_id(0xb0), hash(0x2))],
+                vec![hash(0x1), hash(0x2), hash(0x3)],
             ),
         ];
         assert_result(executed_block, orders, results);
@@ -824,8 +879,22 @@ mod tests {
         ];
 
         let results = vec![
-            LandedOrderData::new(order_id(0xb0), i256(10 / 2), i256(10 / 2), None, vec![]),
-            LandedOrderData::new(order_id(0xb1), i256(0x2), i256(0x2), None, vec![]),
+            LandedOrderData::new(
+                order_id(0xb0),
+                i256(10 / 2),
+                i256(10 / 2),
+                None,
+                vec![],
+                vec![hash(0x1)],
+            ),
+            LandedOrderData::new(
+                order_id(0xb1),
+                i256(0x2),
+                i256(0x2),
+                None,
+                vec![],
+                vec![hash(0x2)],
+            ),
         ];
         assert_result(executed_block, orders, results);
     }
@@ -850,6 +919,7 @@ mod tests {
             i256(0x1),
             None,
             vec![],
+            vec![hash(0x1)],
         )];
         assert_result(executed_block, orders, results);
     }

--- a/crates/rbuilder/src/primitives/serialize.rs
+++ b/crates/rbuilder/src/primitives/serialize.rs
@@ -174,7 +174,7 @@ pub struct RawBundle {
 
 #[derive(Error, Debug)]
 pub enum RawBundleConvertError {
-    #[error("Failed to decode transaction, idx: {0}, error: {0}")]
+    #[error("Failed to decode transaction, idx: {0}, error: {1}")]
     FailedToDecodeTransaction(usize, TxWithBlobsCreateError),
     #[error("Incorrect replacement data")]
     IncorrectReplacementData,


### PR DESCRIPTION
## 📝 Summary

* more logs
* reuse BlockBuildingContext for the whole redistribution calculation (it contains shared caches)
* remove reopener from redistribution (causes false positive errors)
* fix error message fields

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
