### PR TITLE
Migrate to new Rust Random API

### DIFF
--- a/crates/op-rbuilder/src/generator.rs
+++ b/crates/op-rbuilder/src/generator.rs
@@ -420,7 +420,7 @@ mod tests {
     use super::*;
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::U256;
-    use rand::thread_rng;
+    use rand::rng;
     use reth::tasks::TokioTaskExecutor;
     use reth_chain_state::ExecutedBlockWithTrieUpdates;
     use reth_node_api::NodePrimitives;
@@ -607,7 +607,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_payload_generator() -> eyre::Result<()> {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let client = MockEthProvider::default();
         let executor = TokioTaskExecutor::default();


### PR DESCRIPTION
## 📝 Summary
This small PR fixes a deprecation warning by updating the usage of `thread_rng()` to `rng()` from the rand crate.

## 💡 Motivation and Context
The `rand::thread_rng()` function has been deprecated in favor of the simplified `rand::rng()` in newer versions of the rand crate. This change aligns the code with the latest API and eliminates compiler warnings:
```rust
warning: use of deprecated function `rand::thread_rng`: renamed to `rng`
   --> crates/op-rbuilder/src/generator.rs:423:15
    |
423 |     use rand::thread_rng;
    |               ^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated function `rand::thread_rng`: renamed to `rng`
   --> crates/op-rbuilder/src/generator.rs:610:23
    |
610 |         let mut rng = thread_rng();
    |                       ^^^^^^^^^^
```
See more details [here](https://rust-random.github.io/rand/rand/fn.thread_rng.html).

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
