### PR TITLE
Fix metrics emission

### DIFF
--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -384,7 +384,7 @@ where
             evm_env,
             block_env_attributes,
             cancel,
-            metrics: Default::default(),
+            metrics: self.metrics.clone(),
         };
 
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
@@ -418,7 +418,7 @@ where
                 "No transaction pool, skipping transaction pool processing",
             );
 
-            self.metrics
+            ctx.metrics
                 .total_block_built_duration
                 .record(block_build_start_time.elapsed());
 


### PR DESCRIPTION
## 📝 Summary
For some reason `ctx.metrics` doesn't work for us but only `self.metrics`, noticing the ctx uses default, trying by passing in `self.metrics.clone()` instead.

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
