### PR TITLE
Cache bloom filters

### DIFF
--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     live_builder::{block_list_provider::BlockList, cli::LiveBuilderConfig},
     primitives::{Order, OrderId},
     provider::StateProviderFactory,
-    utils::{signed_uint_delta, u256decimal_serde_helper},
+    utils::{elapsed_s, signed_uint_delta, u256decimal_serde_helper},
 };
 use ahash::{HashMap, HashSet};
 use alloy_primitives::{utils::format_ether, Address, B256, I256, U256};
@@ -170,7 +170,7 @@ where
         config.base_config().evm_caching_enable,
     )?;
 
-    let time_preparation_s = start.elapsed().as_millis() as f64 / 1000.0;
+    let time_preparation_s = elapsed_s(start);
     let start = Instant::now();
 
     let results_without_exclusion = calculate_backtest_without_exclusion(
@@ -180,7 +180,7 @@ where
         block_data.clone(),
     )?;
 
-    let time_no_exclusion_s = start.elapsed().as_millis() as f64 / 1000.0;
+    let time_no_exclusion_s = elapsed_s(start);
     let start = Instant::now();
 
     let exclusion_results = calculate_backtest_identity_and_order_exclusion(
@@ -192,7 +192,7 @@ where
         &results_without_exclusion,
     )?;
 
-    let time_single_exclusion_s = start.elapsed().as_millis() as f64 / 1000.0;
+    let time_single_exclusion_s = elapsed_s(start);
     let start = Instant::now();
 
     let exclusion_results = calc_joint_exclusion_results(
@@ -206,7 +206,7 @@ where
         distribute_to_mempool_txs,
     )?;
 
-    let time_joint_exclusion_s = start.elapsed().as_millis() as f64 / 1000.0;
+    let time_joint_exclusion_s = elapsed_s(start);
     let start = Instant::now();
 
     let calculated_redistribution_result = apply_redistribution_formula(
@@ -237,7 +237,7 @@ where
         .map(|o| o.redistribution_value_received)
         .sum::<U256>();
 
-    let time_result_s = start.elapsed().as_millis() as f64 / 1000.0;
+    let time_result_s = elapsed_s(start);
 
     let time_total_s = time_preparation_s
         + time_no_exclusion_s

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -114,7 +114,7 @@ async fn main() -> eyre::Result<()> {
                 let build_time = build_time.elapsed();
 
                 let finalize_time = Instant::now();
-                let finalized_block = partial_block.finalize(&mut state, &ctx, &mut local_ctx)?;
+                let finalized_block = partial_block.finalize(state, &ctx, &mut local_ctx)?;
                 let finalize_time = finalize_time.elapsed();
 
                 debug!(

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     primitives::{SimValue, SimulatedOrder},
     telemetry::{self, add_block_fill_time, add_order_simulation_time},
-    utils::{check_block_hash_reader_health, HistoricalBlockError},
+    utils::{check_block_hash_reader_health, elapsed_ms, HistoricalBlockError},
 };
 
 use super::Block;
@@ -408,7 +408,7 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
         self.built_block_trace
             .verify_bundle_consistency(&self.building_ctx.blocklist)?;
 
-        let finalize_prep_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let finalize_prep_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
         let sim_gas_used = self.partial_block.tracer.used_gas;
@@ -432,8 +432,8 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
                 }
             };
 
-        let finalize_block_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
-        let finalize_time_ms = start_time.elapsed().as_micros() as f64 / 1000.0;
+        let finalize_block_time_ms = elapsed_ms(step_start);
+        let finalize_time_ms = elapsed_ms(start_time);
         trace!(
             finalize_time_ms,
             finalize_prep_time_ms,

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -401,18 +401,22 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
             return Err(BlockBuildingHelperError::PayoutTxNotAllowed);
         }
         let start_time = Instant::now();
+        let step_start = Instant::now();
 
         self.finalize_block_execution(local_ctx, payout_tx_value)?;
         // This could be moved outside of this func (pre finalize) since I don´t think the payout tx can change much.
         self.built_block_trace
             .verify_bundle_consistency(&self.building_ctx.blocklist)?;
 
+        let finalize_prep_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let step_start = Instant::now();
+
         let sim_gas_used = self.partial_block.tracer.used_gas;
         let block_number = self.building_context().block();
         let finalized_block =
             match self
                 .partial_block
-                .finalize(&mut self.block_state, &self.building_ctx, local_ctx)
+                .finalize(self.block_state, &self.building_ctx, local_ctx)
             {
                 Ok(finalized_block) => finalized_block,
                 Err(err) => {
@@ -427,6 +431,15 @@ impl BlockBuildingHelper for BlockBuildingHelperFromProvider {
                     return Err(BlockBuildingHelperError::FinalizeError(err));
                 }
             };
+
+        let finalize_block_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let finalize_time_ms = start_time.elapsed().as_micros() as f64 / 1000.0;
+        trace!(
+            finalize_time_ms,
+            finalize_prep_time_ms,
+            finalize_block_time_ms,
+            "Block building helper finalized block"
+        );
         self.built_block_trace.update_orders_sealed_at();
         self.built_block_trace.root_hash_time = finalized_block.root_hash_time;
         self.built_block_trace.finalize_time = start_time.elapsed();

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -21,6 +21,7 @@ use crate::{
         BlockBuildingContext, ThreadBlockBuildingContext,
     },
     telemetry::mark_builder_considers_order,
+    utils::elapsed_ms,
 };
 
 /// Assembles block building results from the best orderings of order groups.
@@ -139,7 +140,7 @@ impl BlockBuildingResultAssembler {
                     trace!(
                         run_id = self.run_id,
                         version = version,
-                        time_ms = time_start.elapsed().as_millis(),
+                        time_ms = elapsed_ms(time_start),
                         profit = format_ether(value),
                         "Parallel builder built new block",
                     );

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
@@ -15,8 +15,8 @@ use super::{
     simulation_cache::SharedSimulationCache, ConflictGroup, ConflictResolutionResultPerGroup,
     ConflictTask, GroupId, ResolutionResult, TaskPriority,
 };
-use crate::building::BlockBuildingContext;
 use crate::provider::StateProviderFactory;
+use crate::{building::BlockBuildingContext, utils::elapsed_ms};
 
 pub type TaskQueue = Arc<SegQueue<ConflictTask>>;
 
@@ -83,18 +83,18 @@ where
                             match group_result_sender.send((task_id, result)) {
                                 Ok(_) => {
                                     trace!(
-                                        task_id = %task_id,
-                                        time_taken_ms = %task_start.elapsed().as_millis(),
-                                        "Conflict resolving: successfully sent group result"
-                                    );
+                                                        task_id = %task_id,
+                                    time_taken_ms = %elapsed_ms(task_start),
+                                                        "Conflict resolving: successfully sent group result"
+                                                    );
                                 }
                                 Err(err) => {
                                     warn!(
-                                        task_id = %task_id,
-                                        error = ?err,
-                                        time_taken_ms = %task_start.elapsed().as_millis(),
-                                        "Conflict resolving: failed to send group result"
-                                    );
+                                                        task_id = %task_id,
+                                                        error = ?err,
+                                    time_taken_ms = %elapsed_ms(task_start),
+                                                        "Conflict resolving: failed to send group result"
+                                                    );
                                     return;
                                 }
                             }

--- a/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
@@ -35,6 +35,7 @@ use crate::{
         LiveBuilderInput,
     },
     provider::StateProviderFactory,
+    utils::elapsed_ms,
 };
 
 use self::{
@@ -269,7 +270,7 @@ fn run_order_intake(
                 trace!(
                     new_orders_count = len,
                     groups_count = conflict_finder.get_order_groups().len(),
-                    time_taken_ms = %time_start.elapsed().as_millis(),
+                    time_taken_ms = %elapsed_ms(time_start),
                     "Order intake: added new orders and processing groups"
                 );
                 conflict_task_generator.process_groups(conflict_finder.get_order_groups());

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     provider::RootHasher,
     roothash::RootHashError,
     utils::{
-        a2r_withdrawal, default_cfg_env,
+        a2r_withdrawal, default_cfg_env, elapsed_ms,
         receipts::{calculate_receipt_root_and_block_logs_bloom, BloomCache},
         timestamp_as_u64, Signer,
     },
@@ -743,7 +743,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         let (requests, withdrawals_root) = self.process_requests(&mut state, ctx, local_ctx)?;
         let block_number = ctx.evm_env.block_env.number;
 
-        let request_processsing_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let request_processsing_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
         let requests_hash = requests.as_ref().map(|requests| requests.requests_hash());
@@ -756,7 +756,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             vec![requests.clone().unwrap_or_default()],
         );
 
-        let exec_outcome_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let exec_outcome_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
         let (receipts_root, logs_bloom) = calculate_receipt_root_and_block_logs_bloom(
@@ -764,20 +764,20 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             &mut local_ctx.bloom_cache,
         );
 
-        let bloom_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let bloom_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
         // calculate the state root
         let state_root = ctx.root_hasher.state_root(&execution_outcome)?;
         let root_hash_time = step_start.elapsed();
 
-        let root_hash_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let root_hash_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
         // create the block header
         let transactions_root = proofs::calculate_transaction_root(&self.executed_tx);
 
-        let transactions_root_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let transactions_root_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
         // double check blocked txs
@@ -809,7 +809,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             (None, None)
         };
 
-        let blobs_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let blobs_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
         let header = Header {
@@ -861,9 +861,9 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             execution_requests: requests.map(|er| er.take()).unwrap_or_default(),
         };
 
-        let block_seal_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let block_seal_time_ms = elapsed_ms(step_start);
 
-        let total_time_ms = start.elapsed().as_micros() as f64 / 1000.0;
+        let total_time_ms = elapsed_ms(start);
 
         trace!(
             total_time_ms,

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -3,7 +3,11 @@ use crate::{
     primitives::{Order, OrderId, SimValue, SimulatedOrder, TransactionSignedEcRecoveredWithBlobs},
     provider::RootHasher,
     roothash::RootHashError,
-    utils::{a2r_withdrawal, default_cfg_env, timestamp_as_u64, Signer},
+    utils::{
+        a2r_withdrawal, default_cfg_env,
+        receipts::{calculate_receipt_root_and_block_logs_bloom, BloomCache},
+        timestamp_as_u64, Signer,
+    },
 };
 use alloy_consensus::{Header, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::{
@@ -49,6 +53,7 @@ use std::{
 };
 use thiserror::Error;
 use time::OffsetDateTime;
+use tracing::trace;
 use tx_sim_cache::TxExecutionCache;
 
 pub mod block_orders;
@@ -335,6 +340,7 @@ impl BlockBuildingContext {
 #[derive(Debug, Clone, Default)]
 pub struct ThreadBlockBuildingContext {
     pub cached_reads: LocalCachedReads,
+    pub bloom_cache: BloomCache,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -727,15 +733,22 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
     #[allow(clippy::too_many_arguments)]
     pub fn finalize(
         self,
-        state: &mut BlockState,
+        mut state: BlockState,
         ctx: &BlockBuildingContext,
         local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<FinalizeResult, FinalizeError> {
-        let (requests, withdrawals_root) = self.process_requests(state, ctx, local_ctx)?;
-        let bundle = state.clone_bundle();
+        let start = Instant::now();
+
+        let step_start = Instant::now();
+        let (requests, withdrawals_root) = self.process_requests(&mut state, ctx, local_ctx)?;
         let block_number = ctx.evm_env.block_env.number;
 
+        let request_processsing_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let step_start = Instant::now();
+
         let requests_hash = requests.as_ref().map(|requests| requests.requests_hash());
+
+        let (bundle, _) = state.into_parts();
         let execution_outcome = ExecutionOutcome::new(
             bundle,
             vec![self.receipts],
@@ -743,21 +756,29 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             vec![requests.clone().unwrap_or_default()],
         );
 
-        // @TODO: Check ethereum_receipts_root since it could fail on Op. Check reth crates/optimism/payload/src/builder.rs?
-        let receipts_root = execution_outcome
-            .ethereum_receipts_root(block_number)
-            .expect("Number is in range");
-        let logs_bloom = execution_outcome
-            .block_logs_bloom(block_number)
-            .expect("Number is in range");
+        let exec_outcome_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let step_start = Instant::now();
+
+        let (receipts_root, logs_bloom) = calculate_receipt_root_and_block_logs_bloom(
+            execution_outcome.receipts_by_block(block_number),
+            &mut local_ctx.bloom_cache,
+        );
+
+        let bloom_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let step_start = Instant::now();
 
         // calculate the state root
-        let start = Instant::now();
         let state_root = ctx.root_hasher.state_root(&execution_outcome)?;
-        let root_hash_time = start.elapsed();
+        let root_hash_time = step_start.elapsed();
+
+        let root_hash_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let step_start = Instant::now();
 
         // create the block header
         let transactions_root = proofs::calculate_transaction_root(&self.executed_tx);
+
+        let transactions_root_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let step_start = Instant::now();
 
         // double check blocked txs
         for tx_with_blob in &self.executed_tx {
@@ -787,6 +808,9 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         } else {
             (None, None)
         };
+
+        let blobs_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+        let step_start = Instant::now();
 
         let header = Header {
             parent_hash: ctx.attributes.parent,
@@ -830,13 +854,30 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
                 withdrawals,
             },
         };
-
-        Ok(FinalizeResult {
+        let result = FinalizeResult {
             sealed_block: block.seal_slow(),
             txs_blob_sidecars,
             root_hash_time,
             execution_requests: requests.map(|er| er.take()).unwrap_or_default(),
-        })
+        };
+
+        let block_seal_time_ms = step_start.elapsed().as_micros() as f64 / 1000.0;
+
+        let total_time_ms = start.elapsed().as_micros() as f64 / 1000.0;
+
+        trace!(
+            total_time_ms,
+            exec_outcome_time_ms,
+            bloom_time_ms,
+            request_processsing_time_ms,
+            root_hash_time_ms,
+            transactions_root_time_ms,
+            blobs_time_ms,
+            block_seal_time_ms,
+            "Partial block finalized block"
+        );
+
+        Ok(result)
     }
 
     pub fn pre_block_call(

--- a/crates/rbuilder/src/live_builder/block_output/bidding/sequential_sealer_bid_maker.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding/sequential_sealer_bid_maker.rs
@@ -1,12 +1,18 @@
 use crate::{
-    building::ThreadBlockBuildingContext,
+    building::{
+        builders::block_building_helper::{
+            BlockBuildingHelper, BlockBuildingHelperError, FinalizeBlockResult,
+        },
+        ThreadBlockBuildingContext,
+    },
     live_builder::block_output::relay_submit::BlockBuildingSink,
 };
+use alloy_primitives::U256;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
-use tracing::error;
+use tracing::{error, info};
 
 use super::interfaces::{Bid, BidMaker};
 
@@ -56,15 +62,25 @@ impl PendingBid {
 impl SequentialSealerBidMaker {
     pub fn new(sink: Arc<dyn BlockBuildingSink>, cancel: CancellationToken) -> Self {
         let pending_bid = Arc::new(PendingBid::new());
+        let (sender, receiver) = flume::unbounded();
         let mut sealing_process = SequentialSealerBidMakerProcess {
             sink,
             cancel,
             pending_bid: pending_bid.clone(),
+            worker_tasks: sender,
         };
 
         tokio::task::spawn(async move {
             sealing_process.run().await;
         });
+
+        std::thread::Builder::new()
+            .name("finalize_worker".into())
+            .spawn(move || {
+                run_finalize_worker(receiver);
+            })
+            .expect("spawn finalize_worker");
+
         Self { pending_bid }
     }
 }
@@ -75,6 +91,7 @@ struct SequentialSealerBidMakerProcess {
     sink: Arc<dyn BlockBuildingSink>,
     cancel: CancellationToken,
     pending_bid: Arc<PendingBid>,
+    worker_tasks: flume::Sender<FinalizeTask>,
 }
 
 impl SequentialSealerBidMakerProcess {
@@ -95,33 +112,81 @@ impl SequentialSealerBidMakerProcess {
             let block = bid.block();
             let block_number = block.building_context().block();
             let builder_name = block.builder_name().to_string();
-            match tokio::task::spawn_blocking(move || {
-                // @todo better use of the local context
-                // finalize is not state intensive and it will still used shared cache from the context
-                let mut local_ctx = ThreadBlockBuildingContext::default();
-                block.finalize_block(&mut local_ctx, payout_tx_val, seen_competition_bid)
-            })
-            .await
-            {
-                Ok(finalize_res) => match finalize_res {
-                    Ok(res) => self.sink.new_block(res.block),
-                    Err(err) => {
-                        if err.is_critical() {
-                            error!(
-                                builder_name,
-                                block = block_number,
-                                ?err,
-                                "Error on finalize_block on SequentialSealerBidMaker"
-                            )
-                        }
+
+            let (result_sender, result_receiver) = flume::unbounded();
+            let task = FinalizeTask {
+                block,
+                payout_tx_val,
+                seen_competition_bid,
+                result_sender,
+            };
+            match self.worker_tasks.send_async(task).await {
+                Ok(()) => {}
+                Err(err) => {
+                    error!(
+                        ?err,
+                        "Error sending finalize_block task to the worker thread"
+                    );
+                    return;
+                }
+            }
+            let finalize_res = match result_receiver.recv_async().await {
+                Ok(ok) => ok,
+                Err(err) => {
+                    error!(
+                        ?err,
+                        "Error receiving finalize_block task from the worker thread"
+                    );
+                    return;
+                }
+            };
+
+            match finalize_res {
+                Ok(res) => self.sink.new_block(res.block),
+                Err(err) => {
+                    if err.is_critical() {
+                        error!(
+                            builder_name,
+                            block = block_number,
+                            ?err,
+                            "Error on finalize_block on SequentialSealerBidMaker"
+                        )
                     }
-                },
-                Err(err) => error!(
-                    block = block_number,
-                    ?err,
-                    "Error on join finalize_block on SequentialSealerBidMaker"
-                ),
+                }
             }
         }
     }
+}
+
+struct FinalizeTask {
+    block: Box<dyn BlockBuildingHelper>,
+    payout_tx_val: Option<U256>,
+    seen_competition_bid: Option<U256>,
+
+    result_sender: flume::Sender<Result<FinalizeBlockResult, BlockBuildingHelperError>>,
+}
+
+// run finalize worken in a separate thread so we can keep local ctx
+fn run_finalize_worker(tasks: flume::Receiver<FinalizeTask>) {
+    let mut local_ctx = ThreadBlockBuildingContext::default();
+    loop {
+        let FinalizeTask {
+            block,
+            payout_tx_val,
+            seen_competition_bid,
+            result_sender,
+        } = match tasks.recv() {
+            Ok(task) => task,
+            Err(flume::RecvError::Disconnected) => {
+                break;
+            }
+        };
+
+        let result = block.finalize_block(&mut local_ctx, payout_tx_val, seen_competition_bid);
+        result_sender.send(result).unwrap_or_default();
+    }
+    info!(
+        bloom_cache_len = local_ctx.bloom_cache.len(),
+        "Bloom caching"
+    );
 }

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -16,7 +16,7 @@ use crate::{
         inc_relay_accepted_submissions, inc_subsidized_blocks, inc_too_many_req_relay_errors,
         mark_submission_start_time,
     },
-    utils::error_storage::store_error_event,
+    utils::{duration_ms, error_storage::store_error_event},
 };
 use ahash::HashMap;
 use alloy_primitives::{utils::format_ether, U256};
@@ -237,8 +237,8 @@ async fn run_submit_to_relays_job(
             txs = block.sealed_block.body().transactions.len(),
             bundles,
             builder_name = block.builder_name,
-            fill_time_ms = block.trace.fill_time.as_micros() as f64 / 1000.0,
-            finalize_time_ms = block.trace.finalize_time.as_micros() as f64 / 1000.0,
+            fill_time_ms = duration_ms(block.trace.fill_time),
+            finalize_time_ms = duration_ms(block.trace.finalize_time),
         );
         info!(
             parent: &submission_span,

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     building::BuiltBlockTrace,
     live_builder::block_list_provider::{blocklist_hash, BlockList},
     primitives::mev_boost::MevBoostRelayID,
-    utils::build_info::Version,
+    utils::{build_info::Version, duration_ms},
 };
 use alloy_primitives::{utils::Unit, U256};
 use bigdecimal::num_traits::Pow;
@@ -420,10 +420,10 @@ pub fn add_finalized_block_metrics(
 
     BLOCK_FINALIZE_TIME
         .with_label_values(&[])
-        .observe(built_block_trace.finalize_time.as_micros() as f64 / 1000.0);
+        .observe(duration_ms(built_block_trace.finalize_time));
     BLOCK_ROOT_HASH_TIME
         .with_label_values(&[])
-        .observe(built_block_trace.root_hash_time.as_micros() as f64 / 1000.0);
+        .observe(duration_ms(built_block_trace.root_hash_time));
 
     BLOCK_BUILT_TXS
         .with_label_values(&[builder_name])
@@ -456,13 +456,13 @@ pub fn add_block_fill_time(
     }
     BLOCK_FILL_TIME
         .with_label_values(&[builder_name])
-        .observe(duration.as_micros() as f64 / 1000.0);
+        .observe(duration_ms(duration));
 }
 
 pub fn add_block_validation_time(duration: Duration) {
     BLOCK_VALIDATION_TIME
         .with_label_values(&[])
-        .observe(duration.as_millis() as f64);
+        .observe(duration_ms(duration));
 }
 
 pub fn inc_active_slots() {
@@ -478,7 +478,7 @@ pub fn inc_initiated_submissions(optimistic: bool, sent_to_slow_relays: bool) {
 pub fn add_relay_submit_time(relay: &MevBoostRelayID, duration: Duration) {
     RELAY_SUBMIT_TIME
         .with_label_values(&[relay.as_str()])
-        .observe(duration.as_millis() as f64);
+        .observe(duration_ms(duration));
 }
 
 pub fn inc_relay_accepted_submissions(relay: &MevBoostRelayID, optimistic: bool) {
@@ -490,7 +490,7 @@ pub fn inc_relay_accepted_submissions(relay: &MevBoostRelayID, optimistic: bool)
 pub fn add_txfetcher_time_to_query(duration: Duration) {
     TXFETCHER_TRANSACTION_QUERY_TIME
         .with_label_values(&[])
-        .observe(duration.as_millis() as f64);
+        .observe(duration_ms(duration));
 
     TXFETCHER_TRANSACTION_COUNTER.inc();
 }
@@ -560,7 +560,7 @@ fn sim_status(success: bool) -> &'static str {
 pub fn add_order_simulation_time(duration: Duration, builder_name: &str, success: bool) {
     ORDER_SIMULATION_TIME
         .with_label_values(&[builder_name, sim_status(success)])
-        .observe(duration.as_micros() as f64 / 1000.0);
+        .observe(duration_ms(duration));
 }
 
 pub fn mark_submission_start_time(block_sealed_at: OffsetDateTime) {

--- a/crates/rbuilder/src/utils/mod.rs
+++ b/crates/rbuilder/src/utils/mod.rs
@@ -1,5 +1,7 @@
 //! a2r prefix = alloy to reth conversion
 
+use std::time::{Duration, Instant};
+
 use crate::primitives::{
     serialize::{RawTx, TxEncoding},
     TransactionSignedEcRecoveredWithBlobs,
@@ -217,6 +219,21 @@ pub fn format_offset_datetime_rfc3339(datetime: &OffsetDateTime) -> String {
     datetime
         .format(&Rfc3339)
         .expect("failed to format datetime")
+}
+
+#[inline]
+pub fn elapsed_ms(start: Instant) -> f64 {
+    duration_ms(start.elapsed())
+}
+
+#[inline]
+pub fn elapsed_s(start: Instant) -> f64 {
+    duration_ms(start.elapsed()) / 1000.0
+}
+
+#[inline]
+pub fn duration_ms(duration: Duration) -> f64 {
+    duration.as_micros() as f64 / 1000.0
 }
 
 #[cfg(test)]

--- a/crates/rbuilder/src/utils/mod.rs
+++ b/crates/rbuilder/src/utils/mod.rs
@@ -38,6 +38,7 @@ mod tx_signer;
 pub use tx_signer::Signer;
 
 pub mod provider_head_state;
+pub mod receipts;
 pub mod tracing;
 
 #[cfg(test)]

--- a/crates/rbuilder/src/utils/receipts.rs
+++ b/crates/rbuilder/src/utils/receipts.rs
@@ -1,0 +1,128 @@
+use ahash::HashMap;
+use alloy_consensus::{proofs::calculate_receipt_root, ReceiptWithBloom};
+use alloy_primitives::{Bloom, B256};
+use reth::primitives::Receipt;
+use reth_primitives::Log;
+
+pub type BloomCache = HashMap<Log, Bloom>;
+
+/// Speed up bloom filter calculation for block finalization using caching.
+pub fn calculate_receipt_root_and_block_logs_bloom(
+    receipts: &[Receipt],
+    cache: &mut BloomCache,
+) -> (B256, Bloom) {
+    let mut block_logs_bloom = Bloom::ZERO;
+
+    let mut receipts_with_blooms = Vec::with_capacity(receipts.len());
+
+    for receipt in receipts {
+        let mut current_receipt_bloom = Bloom::ZERO;
+
+        for log in &receipt.logs {
+            let log_bloom = if let Some(log_bloom) = cache.get(log) {
+                *log_bloom
+            } else {
+                let mut current_log_bloom = Bloom::ZERO;
+                current_log_bloom.accrue_log(log);
+
+                cache.insert(log.clone(), current_log_bloom);
+
+                current_log_bloom
+            };
+            current_receipt_bloom.accrue_bloom(&log_bloom);
+        }
+
+        block_logs_bloom.accrue_bloom(&current_receipt_bloom);
+
+        receipts_with_blooms.push(ReceiptWithBloom {
+            receipt,
+            logs_bloom: current_receipt_bloom,
+        });
+    }
+
+    let receipts_root = calculate_receipt_root(&receipts_with_blooms);
+
+    (receipts_root, block_logs_bloom)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::TxReceipt;
+    use alloy_consensus::TxType;
+    use alloy_primitives::{address, fixed_bytes};
+    use reth_primitives::{logs_bloom, Log, LogData};
+
+    use super::*;
+
+    #[test]
+    fn test_cached_blooms() {
+        let receipts = vec![
+            Receipt {
+                tx_type: TxType::Eip1559,
+                success: true,
+                cumulative_gas_used: 1000,
+                logs: vec![
+                    Log {
+                        address: address!("87179882e0F1C1F99c585A8eE12d60eA0c89bc0C"),
+                        data: LogData::new_unchecked(
+                            vec![fixed_bytes!(
+                                "5aeac5d808a2f7646502234d71ead4d4c0fea41ad8d015b46b8c6db262fdbbee"
+                            )],
+                            Default::default(),
+                        ),
+                    },
+                    Log {
+                        address: address!("87179882e0F1C1F99c585A8eE12d60eA0c89bc0C"),
+                        data: LogData::new_unchecked(vec![], Default::default()),
+                    },
+                ],
+            },
+            Receipt {
+                tx_type: TxType::Eip4844,
+                success: false,
+                cumulative_gas_used: 2000,
+                logs: vec![Log {
+                    address: address!("8E1f4CbAe96647baac384124537ff7CD8e503DEC"),
+                    data: LogData::new_unchecked(vec![], Default::default()),
+                }],
+            },
+            Receipt {
+                tx_type: TxType::Eip2930,
+                success: false,
+                cumulative_gas_used: 3000,
+                logs: vec![Log {
+                    address: address!("87179882e0F1C1F99c585A8eE12d60eA0c89bc0C"),
+                    data: LogData::new_unchecked(
+                        vec![
+                            fixed_bytes!(
+                                "5aeac5d808a2f7646502234d71ead4d4c0fea41ad8d015b46b8c6db262fdbbee"
+                            ),
+                            fixed_bytes!(
+                                "6e3998bc71f04fd0e13216663edad9293abbac1e552ba5118584f9a709c8ce32"
+                            ),
+                            fixed_bytes!(
+                                "05cdbda6faff1f78c9d22d4bd461527a032d091a5c2e96dcbb131cbb53d58cb8"
+                            ),
+                        ],
+                        Default::default(),
+                    ),
+                }],
+            },
+        ];
+
+        let expected_receipt_root = Receipt::calculate_receipt_root_no_memo(&receipts);
+        let expected_logs_bloom = logs_bloom(receipts.iter().flat_map(|r| r.logs()));
+
+        let mut cache = BloomCache::default();
+        let (got_receipt_root, got_logs_bloom) =
+            calculate_receipt_root_and_block_logs_bloom(&receipts, &mut cache);
+        assert_eq!(expected_receipt_root, got_receipt_root);
+        assert_eq!(expected_logs_bloom, got_logs_bloom);
+
+        // call second time to check caching
+        let (got_receipt_root, got_logs_bloom) =
+            calculate_receipt_root_and_block_logs_bloom(&receipts, &mut cache);
+        assert_eq!(expected_receipt_root, got_receipt_root);
+        assert_eq!(expected_logs_bloom, got_logs_bloom);
+    }
+}

--- a/crates/test-relay/src/metrics.rs
+++ b/crates/test-relay/src/metrics.rs
@@ -2,8 +2,9 @@ use ctor::ctor;
 use lazy_static::lazy_static;
 use metrics_macros::register_metrics;
 use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, Opts, Registry};
-use rbuilder::telemetry::{
-    exponential_buckets_range, gather_prometheus_metrics, linear_buckets_range,
+use rbuilder::{
+    telemetry::{exponential_buckets_range, gather_prometheus_metrics, linear_buckets_range},
+    utils::duration_ms,
 };
 use std::{net::SocketAddr, time::Duration};
 use warp::{reject::Rejection, reply::Reply, Filter};
@@ -97,13 +98,13 @@ pub fn add_winning_bid(builder: &str, advantage: f64) {
 pub fn add_payload_processing_time(duration: Duration) {
     PAYLOAD_PROCESSING_TIME
         .with_label_values(&[])
-        .observe(duration.as_micros() as f64 / 1000.0);
+        .observe(duration_ms(duration));
 }
 
 pub fn add_payload_validation_time(duration: Duration) {
     PAYLOAD_VALIDATION_TIME
         .with_label_values(&[])
-        .observe(duration.as_micros() as f64 / 1000.0);
+        .observe(duration_ms(duration));
 }
 
 pub fn spawn_metrics_server(address: SocketAddr) {


### PR DESCRIPTION
## 📝 Summary

Currently finalize time is often 30% bigger than root hash time but ideally it should be really close. 

One of the reasons is that we calculate bloom filters every single finalize which can be expensive operation, this PR introduces caching for bloom filters.

It also moves finalize to a separate thread so it can persist local thread cache for the slot finalization and in addition the thread is not named which makes profiling easier. 

This shaves up to 5ms in the worst case from finalize but its a good start for faster finalization

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
