### PR TITLE
Revert revert protection in op-rbuilder

### DIFF
--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -1206,6 +1206,7 @@ where
                 num_txs_simulated_success += 1;
             } else {
                 num_txs_simulated_fail += 1;
+                trace!(target: "payload_builder", ?tx, "reverted transaction");
             }
 
             // add gas used by the transaction to cumulative gas used, before creating the receipt

--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -1206,10 +1206,6 @@ where
                 num_txs_simulated_success += 1;
             } else {
                 num_txs_simulated_fail += 1;
-                trace!(target: "payload_builder", ?tx, "skipping reverted transaction");
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
-                info.invalid_tx_hashes.insert(tx.tx_hash());
-                continue;
             }
 
             // add gas used by the transaction to cumulative gas used, before creating the receipt


### PR DESCRIPTION
## 📝 Summary
The builder block building times always slowly increase to a very high number on Base Sepolia, suspecting revert protection is causing failed txs to get backed up, which causes slow down in op-rbuilder block building.

```
# HELP reth_op_rbuilder_payload_num_tx_simulated_fail Number of transactions in the payload that failed simulation
# TYPE reth_op_rbuilder_payload_num_tx_simulated_fail summary
reth_op_rbuilder_payload_num_tx_simulated_fail{quantile="0"} 77
reth_op_rbuilder_payload_num_tx_simulated_fail{quantile="0.5"} 3198.061173550786
reth_op_rbuilder_payload_num_tx_simulated_fail{quantile="0.9"} 3223.1035892442424
reth_op_rbuilder_payload_num_tx_simulated_fail{quantile="0.95"} 3223.748274430612
reth_op_rbuilder_payload_num_tx_simulated_fail{quantile="0.99"} 3226.973635127358
reth_op_rbuilder_payload_num_tx_simulated_fail{quantile="0.999"} 3226.973635127358
reth_op_rbuilder_payload_num_tx_simulated_fail{quantile="1"} 3228
reth_op_rbuilder_payload_num_tx_simulated_fail_sum 64118848
reth_op_rbuilder_payload_num_tx_simulated_fail_count 21069

# HELP reth_op_rbuilder_payload_tx_simulation_duration Duration of payload simulation of all transactions
# TYPE reth_op_rbuilder_payload_tx_simulation_duration summary
reth_op_rbuilder_payload_tx_simulation_duration{quantile="0"} 0.018329514
reth_op_rbuilder_payload_tx_simulation_duration{quantile="0.5"} 0.49002444205448686
reth_op_rbuilder_payload_tx_simulation_duration{quantile="0.9"} 0.5026304818952316
reth_op_rbuilder_payload_tx_simulation_duration{quantile="0.95"} 0.5079867028401951
reth_op_rbuilder_payload_tx_simulation_duration{quantile="0.99"} 0.553164415015488
reth_op_rbuilder_payload_tx_simulation_duration{quantile="0.999"} 0.553164415015488
reth_op_rbuilder_payload_tx_simulation_duration{quantile="1"} 0.555461782
reth_op_rbuilder_payload_tx_simulation_duration_sum 9654.159540928
reth_op_rbuilder_payload_tx_simulation_duration_count 25870

# HELP reth_op_rbuilder_flashblock_build_duration Flashblock build duration
# TYPE reth_op_rbuilder_flashblock_build_duration summary
reth_op_rbuilder_flashblock_build_duration{quantile="0"} 0.055144161
reth_op_rbuilder_flashblock_build_duration{quantile="0.5"} 0.5166962986266059
reth_op_rbuilder_flashblock_build_duration{quantile="0.9"} 0.5348868728374531
reth_op_rbuilder_flashblock_build_duration{quantile="0.95"} 0.5672812838109652
reth_op_rbuilder_flashblock_build_duration{quantile="0.99"} 0.583272957920482
reth_op_rbuilder_flashblock_build_duration{quantile="0.999"} 0.583272957920482
reth_op_rbuilder_flashblock_build_duration{quantile="1"} 0.60984729
reth_op_rbuilder_flashblock_build_duration_sum 9081.926654393968
reth_op_rbuilder_flashblock_build_duration_count 21065

# HELP reth_op_rbuilder_payload_num_tx_simulated_success Number of transactions in the payload that were successfully simulated
# TYPE reth_op_rbuilder_payload_num_tx_simulated_success summary
reth_op_rbuilder_payload_num_tx_simulated_success{quantile="0"} 1
reth_op_rbuilder_payload_num_tx_simulated_success{quantile="0.5"} 11.000052032263987
reth_op_rbuilder_payload_num_tx_simulated_success{quantile="0.9"} 20.999528921206892
reth_op_rbuilder_payload_num_tx_simulated_success{quantile="0.95"} 24.001108231483542
reth_op_rbuilder_payload_num_tx_simulated_success{quantile="0.99"} 29.00012111115082
reth_op_rbuilder_payload_num_tx_simulated_success{quantile="0.999"} 29.00012111115082
reth_op_rbuilder_payload_num_tx_simulated_success{quantile="1"} 60
reth_op_rbuilder_payload_num_tx_simulated_success_sum 136029
reth_op_rbuilder_payload_num_tx_simulated_success_count 21069
```


<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
