### PR TITLE
fix: ensure DA transaction throttling uses params that are set

### DIFF
--- a/crates/op-rbuilder/src/integration/integration_test.rs
+++ b/crates/op-rbuilder/src/integration/integration_test.rs
@@ -438,7 +438,9 @@ mod tests {
             .await?;
 
         // check there's 10 flashblocks log lines (2000ms / 200ms)
-        op_rbuilder.find_log_line("Building flashblock 9").await?;
+        op_rbuilder
+            .find_log_line("Building flashblock idx=9")
+            .await?;
 
         // Process websocket messages
         let timeout_duration = Duration::from_secs(10);
@@ -571,7 +573,9 @@ mod tests {
             .await?;
 
         // check there's no more than 10 flashblocks log lines (2000ms / 200ms)
-        op_rbuilder.find_log_line("Building flashblock 9").await?;
+        op_rbuilder
+            .find_log_line("Building flashblock idx=9")
+            .await?;
         op_rbuilder
             .find_log_line("Skipping flashblock reached target=10 idx=10")
             .await?;

--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -1,14 +1,14 @@
 use clap::Parser;
 use monitoring::Monitoring;
-use reth::providers::CanonStateSubscriptions;
-use reth_optimism_cli::{chainspec::OpChainSpecParser, Cli};
-use reth_optimism_node::node::OpAddOnsBuilder;
-use reth_optimism_node::OpNode;
-
 #[cfg(feature = "flashblocks")]
 use payload_builder::CustomOpPayloadBuilder;
 #[cfg(not(feature = "flashblocks"))]
 use payload_builder_vanilla::CustomOpPayloadBuilder;
+use reth::providers::CanonStateSubscriptions;
+use reth_optimism_cli::{chainspec::OpChainSpecParser, Cli};
+use reth_optimism_node::node::OpAddOnsBuilder;
+use reth_optimism_node::OpNode;
+use reth_optimism_payload_builder::config::{OpBuilderConfig, OpDAConfig};
 use reth_transaction_pool::TransactionPool;
 
 /// CLI argument parsing.
@@ -35,10 +35,13 @@ fn main() {
             let rollup_args = builder_args.rollup_args;
 
             let op_node = OpNode::new(rollup_args.clone());
+            let builder_config = OpBuilderConfig::new(OpDAConfig::default());
+
             let handle = builder
                 .with_types::<OpNode>()
                 .with_components(op_node.components().payload(CustomOpPayloadBuilder::new(
                     builder_args.builder_signer,
+                    builder_config.clone(),
                     builder_args.flashblocks_ws_url,
                     builder_args.chain_block_time,
                     builder_args.flashblock_block_time,
@@ -47,6 +50,7 @@ fn main() {
                     OpAddOnsBuilder::default()
                         .with_sequencer(rollup_args.sequencer.clone())
                         .with_enable_tx_conditional(rollup_args.enable_tx_conditional)
+                        .with_da_config(builder_config.da_config)
                         .build(),
                 )
                 .on_node_started(move |ctx| {

--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -513,12 +513,10 @@ where
 
                     tracing::info!(
                         target: "payload_builder",
-                        "Building flashblock idx={} target_gas={} gas_used={} taget_da={} da_used={}",
+                        "Building flashblock idx={} target_gas={} taget_da={}",
                         flashblock_count,
                         total_gas_per_batch,
-                        info.cumulative_gas_used,
                         total_da_per_batch.unwrap_or(0),
-                        info.cumulative_da_bytes_used
                     );
 
                     let flashblock_build_start_time = Instant::now();
@@ -596,6 +594,15 @@ where
                                 .payload_num_tx
                                 .record(info.executed_transactions.len() as f64);
 
+                            tracing::info!(
+                                target: "payload_builder",
+                                "Built flashblock idx={} target_gas={} gas_used={} taget_da={} da_used={}", flashblock_count,
+                                total_gas_per_batch,
+                                info.cumulative_gas_used,
+                                total_da_per_batch.unwrap_or(0),
+                                info.cumulative_da_bytes_used
+                            );
+
                             best_payload.set(new_payload.clone());
                             // Update bundle_state for next iteration
                             bundle_state = new_bundle_state;
@@ -604,7 +611,6 @@ where
                                 total_da_per_batch = Some(total_da_per_batch.unwrap() + da_limit);
                             }
                             flashblock_count += 1;
-                            tracing::info!(target: "payload_builder", "Flashblock {} built", flashblock_count);
                         }
                     }
                 }

--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -437,8 +437,14 @@ where
         }
 
         let gas_per_batch = ctx.block_gas_limit() / self.flashblocks_per_block;
-
         let mut total_gas_per_batch = gas_per_batch;
+
+        let da_per_batch = if let Some(da_limit) = ctx.da_config.max_da_block_size() {
+            Some(da_limit / self.flashblocks_per_block)
+        } else {
+            None
+        };
+        let mut total_da_per_batch = da_per_batch;
 
         let mut flashblock_count = 0;
         // Create a channel to coordinate flashblock building
@@ -505,12 +511,14 @@ where
                         continue;
                     }
 
-                    // Continue with flashblock building
                     tracing::info!(
                         target: "payload_builder",
-                        "Building flashblock {} {}",
+                        "Building flashblock idx={} target_gas={} gas_used={} taget_da={} da_used={}",
                         flashblock_count,
                         total_gas_per_batch,
+                        info.cumulative_gas_used,
+                        total_da_per_batch.unwrap_or(0),
+                        info.cumulative_da_bytes_used
                     );
 
                     let flashblock_build_start_time = Instant::now();
@@ -537,6 +545,7 @@ where
                         &mut db,
                         best_txs,
                         total_gas_per_batch.min(ctx.block_gas_limit()),
+                        total_da_per_batch,
                     )?;
                     ctx.metrics
                         .payload_tx_simulation_duration
@@ -591,6 +600,9 @@ where
                             // Update bundle_state for next iteration
                             bundle_state = new_bundle_state;
                             total_gas_per_batch += gas_per_batch;
+                            if let Some(da_limit) = da_per_batch {
+                                total_da_per_batch = Some(total_da_per_batch.unwrap() + da_limit);
+                            }
                             flashblock_count += 1;
                             tracing::info!(target: "payload_builder", "Flashblock {} built", flashblock_count);
                         }
@@ -1144,6 +1156,7 @@ where
             Transaction: PoolTransaction<Consensus = OpTransactionSigned>,
         >,
         batch_gas_limit: u64,
+        block_da_limit: Option<u64>,
     ) -> Result<Option<()>, PayloadBuilderError>
     where
         DB: Database<Error = ProviderError>,
@@ -1153,7 +1166,7 @@ where
         let mut num_txs_simulated = 0;
         let mut num_txs_simulated_success = 0;
         let mut num_txs_simulated_fail = 0;
-
+        let tx_da_limit = self.da_config.max_da_tx_size();
         let mut evm = self.evm_config.evm_with_env(&mut *db, self.evm_env.clone());
 
         while let Some(tx) = best_txs.next(()) {
@@ -1166,7 +1179,7 @@ where
             }
 
             // ensure we still have capacity for this transaction
-            if info.is_tx_over_limits(tx.inner(), batch_gas_limit, None, None) {
+            if info.is_tx_over_limits(tx.inner(), batch_gas_limit, tx_da_limit, block_da_limit) {
                 // we can't fit this transaction into the block, so we need to mark it as
                 // invalid which also removes all dependent transaction from
                 // the iterator before we can continue

--- a/crates/op-rbuilder/src/payload_builder.rs
+++ b/crates/op-rbuilder/src/payload_builder.rs
@@ -37,6 +37,7 @@ use reth_optimism_consensus::{calculate_receipt_root_no_memo_optimism, isthmus};
 use reth_optimism_evm::{OpEvmConfig, OpNextBlockEnvAttributes};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_node::OpEngineTypes;
+use reth_optimism_payload_builder::config::{OpBuilderConfig, OpDAConfig};
 use reth_optimism_payload_builder::{
     error::OpPayloadBuilderError,
     payload::{OpBuiltPayload, OpPayloadBuilderAttributes},
@@ -96,6 +97,7 @@ struct FlashblocksMetadata<N: NodePrimitives> {
 pub struct CustomOpPayloadBuilder {
     #[expect(dead_code)]
     builder_signer: Option<Signer>,
+    builder_config: OpBuilderConfig,
     flashblocks_ws_url: String,
     chain_block_time: u64,
     flashblock_block_time: u64,
@@ -104,12 +106,14 @@ pub struct CustomOpPayloadBuilder {
 impl CustomOpPayloadBuilder {
     pub fn new(
         builder_signer: Option<Signer>,
+        builder_config: OpBuilderConfig,
         flashblocks_ws_url: String,
         chain_block_time: u64,
         flashblock_block_time: u64,
     ) -> Self {
         Self {
             builder_signer,
+            builder_config,
             flashblocks_ws_url,
             chain_block_time,
             flashblock_block_time,
@@ -139,6 +143,7 @@ where
     ) -> eyre::Result<Self::PayloadBuilder> {
         Ok(OpPayloadBuilder::new(
             OpEvmConfig::optimism(ctx.chain_spec()),
+            self.builder_config,
             pool,
             ctx.provider().clone(),
             self.flashblocks_ws_url.clone(),
@@ -226,6 +231,8 @@ pub struct OpPayloadBuilder<Pool, Client> {
     pub pool: Pool,
     /// Node client
     pub client: Client,
+    /// Settings for the builder, e.g. DA settings.
+    pub config: OpBuilderConfig,
     /// Channel sender for publishing messages
     pub tx: mpsc::UnboundedSender<String>,
     /// chain block time
@@ -242,6 +249,7 @@ impl<Pool, Client> OpPayloadBuilder<Pool, Client> {
     /// `OpPayloadBuilder` constructor.
     pub fn new(
         evm_config: OpEvmConfig,
+        builder_config: OpBuilderConfig,
         pool: Pool,
         client: Client,
         flashblocks_ws_url: String,
@@ -259,6 +267,7 @@ impl<Pool, Client> OpPayloadBuilder<Pool, Client> {
 
         Self {
             evm_config,
+            config: builder_config,
             pool,
             client,
             tx,
@@ -380,6 +389,7 @@ where
         let ctx = OpPayloadBuilderCtx {
             evm_config: self.evm_config.clone(),
             chain_spec: self.client.chain_spec(),
+            da_config: self.config.da_config.clone(),
             config,
             evm_env,
             block_env_attributes,
@@ -873,6 +883,8 @@ impl<T: PoolTransaction> OpPayloadTransactions<T> for () {
 pub struct OpPayloadBuilderCtx<ChainSpec> {
     /// The type that knows how to perform system calls and configure the evm.
     pub evm_config: OpEvmConfig,
+    /// The DA config for the payload builder
+    pub da_config: OpDAConfig,
     /// The chainspec
     pub chain_spec: Arc<ChainSpec>,
     /// How to build the payload.

--- a/crates/op-rbuilder/src/payload_builder_vanilla.rs
+++ b/crates/op-rbuilder/src/payload_builder_vanilla.rs
@@ -76,6 +76,7 @@ const TOTAL_COST_FLOOR_PER_TOKEN: u64 = 10;
 #[non_exhaustive]
 pub struct CustomOpPayloadBuilder {
     builder_signer: Option<Signer>,
+    config: OpBuilderConfig,
     #[cfg(feature = "flashblocks")]
     flashblocks_ws_url: String,
     #[cfg(feature = "flashblocks")]
@@ -88,12 +89,14 @@ impl CustomOpPayloadBuilder {
     #[cfg(feature = "flashblocks")]
     pub fn new(
         builder_signer: Option<Signer>,
+        config: OpBuilderConfig,
         flashblocks_ws_url: String,
         chain_block_time: u64,
         flashblock_block_time: u64,
     ) -> Self {
         Self {
             builder_signer,
+            config,
             flashblocks_ws_url,
             chain_block_time,
             flashblock_block_time,
@@ -103,11 +106,15 @@ impl CustomOpPayloadBuilder {
     #[cfg(not(feature = "flashblocks"))]
     pub fn new(
         builder_signer: Option<Signer>,
+        config: OpBuilderConfig,
         _flashblocks_ws_url: String,
         _chain_block_time: u64,
         _flashblock_block_time: u64,
     ) -> Self {
-        Self { builder_signer }
+        Self {
+            builder_signer,
+            config,
+        }
     }
 }
 
@@ -135,6 +142,7 @@ where
         Ok(OpPayloadBuilderVanilla::new(
             OpEvmConfig::optimism(ctx.chain_spec()),
             self.builder_signer,
+            self.config,
             pool,
             ctx.provider().clone(),
         ))
@@ -237,18 +245,9 @@ impl<Pool, Client> OpPayloadBuilderVanilla<Pool, Client> {
     pub fn new(
         evm_config: OpEvmConfig,
         builder_signer: Option<Signer>,
-        pool: Pool,
-        client: Client,
-    ) -> Self {
-        Self::with_builder_config(evm_config, builder_signer, pool, client, Default::default())
-    }
-
-    pub fn with_builder_config(
-        evm_config: OpEvmConfig,
-        builder_signer: Option<Signer>,
-        pool: Pool,
-        client: Client,
         config: OpBuilderConfig,
+        pool: Pool,
+        client: Client,
     ) -> Self {
         Self {
             pool,


### PR DESCRIPTION
## 📝 Summary

* Ensure the builders share the same `OpDAConfig` that the RPC endpoint does. 
* For Flashblocks builder, consider the DA param values

## 💡 Motivation and Context

Prior to this PR, I believe setting throttling via the RPC would not have any impact as an unrelated DAConfig object is created [here](https://github.com/flashbots/rbuilder/blob/develop/crates/op-rbuilder/src/payload_builder_vanilla.rs#L243). Part of the work to fix: https://github.com/flashbots/rbuilder/issues/613

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
