### PR TITLE
Add usage of jemalloc in op-rbuilder when feature is enabled + improve debug-fast profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ unarray.opt-level = 3
 [profile.debug-fast]
 inherits = "release"
 debug = true
+lto = "thin"
 
 [profile.maxperf]
 inherits = "release"

--- a/crates/op-rbuilder/src/main.rs
+++ b/crates/op-rbuilder/src/main.rs
@@ -29,6 +29,11 @@ mod tester;
 mod tx_signer;
 use monitor_tx_pool::monitor_tx_pool;
 
+// Prefer jemalloc for performance reasons.
+#[cfg(all(feature = "jemalloc", unix))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 fn main() {
     Cli::<OpChainSpecParser, args::OpRbuilderArgs>::parse()
         .run(|builder, builder_args| async move {


### PR DESCRIPTION
## 📝 Summary
Adding `lto = "thin"` for debug fast profile sped up my build time from 5 min to 4 min
Enabled jemalloc in op-rbuilder
## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
