### PR TITLE
docs: Update comment for independent_bid_threshold

### DIFF
--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -104,7 +104,7 @@ pub struct SubmissionConfig {
 
     pub optimistic_config: Option<OptimisticConfig>,
     pub bid_observer: Box<dyn BidObserver + Send + Sync>,
-    /// Bids above this value will only go to fast relays.
+    /// Bids above this value will only go to independent relays.
     pub independent_bid_threshold: U256,
 }
 


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

This PR fixes an inaccurate comment in `crates/rbuilder/src/live_builder/block_output/relay_submit.rs`.
The comment for `independent_bid_threshold` previously stated that bids exceeding this threshold would be sent only to "fast relays".
This has been corrected to "independent relays" to accurately reflect the existing code logic.

## 💡 Motivation and Context

related issue: https://github.com/flashbots/rbuilder/issues/612

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
