### PR TITLE
Refactoring unifying tx+receipt+gas into a struct TransactionExecutionInfo.

### DIFF
--- a/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
@@ -142,7 +142,7 @@ where
                         format_ether(order_result.coinbase_profit),
                     );
                     if let Order::Bundle(_) | Order::ShareBundle(_) = order_result.order {
-                        for tx in &order_result.txs {
+                        for tx in order_result.tx_infos.iter().map(|info| &info.tx) {
                             println!("      ↳ {:?}", tx.hash());
                         }
 

--- a/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
@@ -90,7 +90,7 @@ where
         )?;
         let coinbase_profit = signed_uint_delta(coinbase_balance_after, coinbase_balance_before);
 
-        cumulative_gas_used += result.gas_used;
+        cumulative_gas_used += result.tx_info.gas_used;
         cumulative_blob_gas_used += result.blob_gas_used;
 
         let mut conflicting_txs: HashMap<B256, Vec<SlotKey>> = HashMap::default();
@@ -121,7 +121,7 @@ where
 
         results.push(ExecutedTxs {
             tx: tx.into_internal_tx_unsecure(),
-            receipt: result.receipt,
+            receipt: result.tx_info.receipt,
             coinbase_profit,
             conflicting_txs,
         })

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -107,7 +107,7 @@ async fn main() -> eyre::Result<()> {
                                 format!("Failed to commit tx: {} {:?}", idx, tx.hash())
                             })?
                     };
-                    cumulative_gas_used += result.gas_used;
+                    cumulative_gas_used += result.tx_info.gas_used;
                     cumulative_blob_gas_used += result.blob_gas_used;
                 }
 

--- a/crates/rbuilder/src/building/built_block_trace.rs
+++ b/crates/rbuilder/src/building/built_block_trace.rs
@@ -40,8 +40,6 @@ impl Default for BuiltBlockTrace {
 pub enum BuiltBlockTraceError {
     #[error("More than one order is included with the same replacement data: {0:?}")]
     DuplicateReplacementData(OrderReplacementKey),
-    #[error("Included order had different number of txs and receipts")]
-    DifferentTxsAndReceipts,
     #[error("Included order had tx from or to blocked address")]
     BlockedAddress,
     #[error(
@@ -105,18 +103,18 @@ impl BuiltBlockTrace {
         let mut executed_tx_hashes_scratchpad = Vec::new();
 
         for res in &self.included_orders {
-            if res.txs.len() != res.receipts.len() {
-                return Err(BuiltBlockTraceError::DifferentTxsAndReceipts);
-            }
-
             let executed_tx_hashes = {
                 executed_tx_hashes_scratchpad.clear();
                 &mut executed_tx_hashes_scratchpad
             };
-            for (tx, receipt) in res.txs.iter().zip(res.receipts.iter()) {
-                executed_tx_hashes.push((tx.hash(), receipt.success));
-                if blocklist.contains(&tx.signer())
-                    || tx.to().map(|to| blocklist.contains(&to)).unwrap_or(false)
+            for tx_info in &res.tx_infos {
+                executed_tx_hashes.push((tx_info.tx.hash(), tx_info.receipt.success));
+                if blocklist.contains(&tx_info.tx.signer())
+                    || tx_info
+                        .tx
+                        .to()
+                        .map(|to| blocklist.contains(&to))
+                        .unwrap_or(false)
                 {
                     return Err(BuiltBlockTraceError::BlockedAddress);
                 }
@@ -162,7 +160,7 @@ impl BuiltBlockTrace {
     pub fn transactions_hash(&self) -> u64 {
         let mut hasher = AHasher::default();
         for execution_result in &self.included_orders {
-            for tx in &execution_result.txs {
+            for tx in execution_result.tx_infos.iter().map(|info| &info.tx) {
                 let tx_hash = tx.hash();
                 hasher.write(tx_hash.as_slice());
             }

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -26,7 +26,7 @@ use evm::EthCachedEvmFactory;
 use jsonrpsee::core::Serialize;
 use reth::{
     payload::PayloadId,
-    primitives::{Block, Receipt, SealedBlock},
+    primitives::{Block, SealedBlock},
     providers::ExecutionOutcome,
 };
 use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks};
@@ -409,10 +409,8 @@ pub struct PartialBlock<Tracer: SimulationTracer> {
     pub blob_gas_used: u64,
     /// Updated after each order.
     pub coinbase_profit: U256,
-    /// Txs belonging to successfully executed orders.
-    pub executed_tx: Vec<TransactionSignedEcRecoveredWithBlobs>,
-    /// Receipts belonging to successfully executed orders.
-    pub receipts: Vec<Receipt>,
+    /// Tx execution info belonging to successfully executed orders.
+    pub executed_tx_infos: Vec<TransactionExecutionInfo>,
     pub tracer: Tracer,
 }
 
@@ -422,11 +420,10 @@ pub struct ExecutionResult {
     pub inplace_sim: SimValue,
     pub gas_used: u64,
     pub order: Order,
-    pub txs: Vec<TransactionSignedEcRecoveredWithBlobs>,
+    pub tx_infos: Vec<TransactionExecutionInfo>,
     /// Patch to get the executed OrderIds for merged sbundles (see: [`BundleOk::original_order_ids`],[`ShareBundleMerger`] )
     /// Fully dropped orders (TxRevertBehavior::AllowedExcluded allows it!) are not included.
     pub original_order_ids: Vec<OrderId>,
-    pub receipts: Vec<Receipt>,
     pub nonces_updated: Vec<(Address, u64)>,
     pub paid_kickbacks: Vec<(Address, U256)>,
 }
@@ -527,8 +524,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             gas_reserved: self.gas_reserved,
             blob_gas_used: self.blob_gas_used,
             coinbase_profit: self.coinbase_profit,
-            executed_tx: self.executed_tx,
-            receipts: self.receipts,
+            executed_tx_infos: self.executed_tx_infos,
             tracer,
         }
     }
@@ -593,16 +589,14 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         self.gas_used += ok_result.gas_used;
         self.blob_gas_used += ok_result.blob_gas_used;
         self.coinbase_profit += ok_result.coinbase_profit;
-        self.executed_tx.extend(ok_result.txs.clone());
-        self.receipts.extend(ok_result.receipts.clone());
+        self.executed_tx_infos.extend(ok_result.tx_infos.clone());
         Ok(Ok(ExecutionResult {
             coinbase_profit: ok_result.coinbase_profit,
             inplace_sim: inplace_sim_result,
             gas_used: ok_result.gas_used,
             order: order.order.clone(),
-            txs: ok_result.txs,
+            tx_infos: ok_result.tx_infos,
             original_order_ids: ok_result.original_order_ids,
-            receipts: ok_result.receipts,
             nonces_updated: ok_result.nonces_updated,
             paid_kickbacks: ok_result.paid_kickbacks,
         }))
@@ -655,14 +649,13 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
         let exec_result = fork.commit_tx(&tx, self.gas_used, 0, self.blob_gas_used)?;
         let ok_result = exec_result?;
-        if !ok_result.receipt.success {
+        if !ok_result.tx_info.receipt.success {
             return Err(InsertPayoutTxErr::PayoutTxReverted);
         }
 
-        self.gas_used += ok_result.gas_used;
+        self.gas_used += ok_result.tx_info.gas_used;
         self.blob_gas_used += ok_result.blob_gas_used;
-        self.executed_tx.push(ok_result.tx);
-        self.receipts.push(ok_result.receipt);
+        self.executed_tx_infos.push(ok_result.tx_info);
 
         Ok(())
     }
@@ -682,9 +675,11 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             .is_prague_active_at_timestamp(ctx.attributes.timestamp())
         {
             // Collect all EIP-6110 deposits
-            let deposit_requests =
-                eip6110::parse_deposits_from_receipts(&ctx.chain_spec, &self.receipts)
-                    .map_err(BlockExecutionError::Validation)?;
+            let deposit_requests = eip6110::parse_deposits_from_receipts(
+                &ctx.chain_spec,
+                self.executed_tx_infos.iter().map(|info| &info.receipt),
+            )
+            .map_err(BlockExecutionError::Validation)?;
 
             let mut requests = Requests::default();
             if !deposit_requests.is_empty() {
@@ -751,7 +746,11 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         let (bundle, _) = state.into_parts();
         let execution_outcome = ExecutionOutcome::new(
             bundle,
-            vec![self.receipts],
+            vec![self
+                .executed_tx_infos
+                .iter()
+                .map(|info| info.receipt.clone())
+                .collect()],
             block_number,
             vec![requests.clone().unwrap_or_default()],
         );
@@ -775,13 +774,19 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         let step_start = Instant::now();
 
         // create the block header
-        let transactions_root = proofs::calculate_transaction_root(&self.executed_tx);
+        let transactions_root = proofs::calculate_transaction_root(
+            &self
+                .executed_tx_infos
+                .iter()
+                .map(|info| &info.tx)
+                .collect::<Vec<_>>(),
+        );
 
         let transactions_root_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
         // double check blocked txs
-        for tx_with_blob in &self.executed_tx {
+        for tx_with_blob in self.executed_tx_infos.iter().map(|info| &info.tx) {
             if ctx.blocklist.contains(&tx_with_blob.signer()) {
                 return Err(FinalizeError::Other(eyre::eyre!(
                     "To from blocked address."
@@ -799,7 +804,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             .chain_spec
             .is_cancun_active_at_timestamp(ctx.attributes.timestamp)
         {
-            for tx_with_blob in &self.executed_tx {
+            for tx_with_blob in self.executed_tx_infos.iter().map(|info| &info.tx) {
                 if !tx_with_blob.blobs_sidecar.blobs.is_empty() {
                     txs_blob_sidecars.push(tx_with_blob.blobs_sidecar.clone());
                 }
@@ -846,9 +851,9 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             header,
             body: BlockBody {
                 transactions: self
-                    .executed_tx
+                    .executed_tx_infos
                     .into_iter()
-                    .map(|t| t.into_internal_tx_unsecure().into_inner())
+                    .map(|t| t.tx.into_internal_tx_unsecure().into_inner())
                     .collect(),
                 ommers: vec![],
                 withdrawals,
@@ -906,8 +911,7 @@ impl PartialBlock<()> {
             gas_reserved: 0,
             blob_gas_used: 0,
             coinbase_profit: U256::ZERO,
-            executed_tx: Vec::new(),
-            receipts: Vec::new(),
+            executed_tx_infos: Vec::new(),
             tracer: (),
         }
     }

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -181,19 +181,25 @@ where
         &mut self.db
     }
 }
-
+/// Common data used by TransactionOk/BundleOk
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionExecutionInfo {
+    pub tx: TransactionSignedEcRecoveredWithBlobs,
+    pub receipt: Receipt,
+    pub gas_used: u64,
+    /// On loss capped to 0
+    pub coinbase_profit: U256,
+}
 #[derive(Debug, Clone)]
 pub struct TransactionOk {
     pub exec_result: ExecutionResult,
-    pub gas_used: u64,
     pub cumulative_gas_used: u64,
     pub blob_gas_used: u64,
     pub cumulative_blob_gas_used: u64,
-    pub tx: TransactionSignedEcRecoveredWithBlobs,
+    pub tx_info: TransactionExecutionInfo,
     /// nonces_updates is nonce after tx was applied.
     /// account nonce was 0, tx was included, nonce is 1. => nonce_updated.1 == 1
     pub nonce_updated: (Address, u64),
-    pub receipt: Receipt,
 }
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
@@ -214,10 +220,9 @@ pub struct BundleOk {
     pub cumulative_gas_used: u64,
     pub blob_gas_used: u64,
     pub cumulative_blob_gas_used: u64,
-    pub txs: Vec<TransactionSignedEcRecoveredWithBlobs>,
+    pub tx_infos: Vec<TransactionExecutionInfo>,
     /// nonces_updates has a set of deduplicated final nonces of the txs in the order
     pub nonces_updated: Vec<(Address, u64)>,
-    pub receipts: Vec<Receipt>,
     pub paid_kickbacks: Vec<(Address, U256)>,
     /// Only for sbundles we accumulate ShareBundleInner::original_order_id that executed ok.
     /// Its original use is for only one level or orders with original_order_id but if nesting happens the parent order original_order_id goes before its children (pre-order DFS)
@@ -276,12 +281,11 @@ pub struct OrderOk {
     pub cumulative_gas_used: u64,
     pub blob_gas_used: u64,
     pub cumulative_blob_gas_used: u64,
-    pub txs: Vec<TransactionSignedEcRecoveredWithBlobs>,
+    pub tx_infos: Vec<TransactionExecutionInfo>,
     /// Patch to get the executed OrderIds for merged sbundles (see: [`BundleOk::original_order_ids`],[`ShareBundleMerger`] )
     pub original_order_ids: Vec<OrderId>,
     /// nonces_updates has a set of deduplicated final nonces of the txs in the order
     pub nonces_updated: Vec<(Address, u64)>,
-    pub receipts: Vec<Receipt>,
     pub paid_kickbacks: Vec<(Address, U256)>,
     pub used_state_trace: Option<UsedStateTrace>,
 }
@@ -368,6 +372,19 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         self.rollbacks = rollback_point.rollobacks;
     }
 
+    fn coinbase_balance(&mut self) -> Result<U256, ProviderError> {
+        self.state.balance(
+            self.ctx.evm_env.block_env.beneficiary,
+            &self.ctx.shared_cached_reads,
+            &mut self.local_ctx.cached_reads,
+        )
+    }
+
+    /// If current balance < initial balance returns 0.
+    fn saturating_coinbase_delta(&mut self, initial_balance: U256) -> Result<U256, ProviderError> {
+        Ok(self.coinbase_balance()?.saturating_sub(initial_balance))
+    }
+
     /// Helper func that executes f and rollbacks on Ok(Err).
     /// For CriticalCommitOrderError we don't rollback since it's a critical unrecoverable failure
     /// Use like this:
@@ -400,6 +417,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         gas_reserved: u64,
         mut cumulative_blob_gas_used: u64,
     ) -> Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError> {
+        let coinbase_balance_before = self.coinbase_balance()?;
         // Use blobs.len() instead of checking for tx type just in case in the future some other new txs have blobs
         let blob_gas_used = tx_with_blobs.blobs_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB;
         if cumulative_blob_gas_used + blob_gas_used > self.ctx.max_blob_gas_per_block() {
@@ -511,6 +529,8 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
 
         db.as_mut().commit(res.state);
         db.as_mut().merge_transitions(BundleRetention::Reverts);
+        // This allows calling saturating_coinbase_delta. @Pending: this should be a scope/child function.
+        drop(db);
         self.rollbacks += 1;
 
         // add gas used by the transaction to cumulative gas used, before creating the receipt
@@ -528,13 +548,16 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
 
         Ok(Ok(TransactionOk {
             exec_result: res.result,
-            gas_used,
             blob_gas_used,
             cumulative_blob_gas_used,
             cumulative_gas_used,
-            tx: tx_with_blobs.clone(),
+            tx_info: TransactionExecutionInfo {
+                tx: tx_with_blobs.clone(),
+                receipt,
+                gas_used,
+                coinbase_profit: self.saturating_coinbase_delta(coinbase_balance_before)?,
+            },
             nonce_updated: (tx.signer(), tx.nonce() + 1),
-            receipt,
         }))
     }
 
@@ -584,13 +607,12 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
     }
 
     fn accumulate_tx_execution(transaction_ok: TransactionOk, bundle_ok: &mut BundleOk) {
-        bundle_ok.gas_used += transaction_ok.gas_used;
+        bundle_ok.gas_used += transaction_ok.tx_info.gas_used;
         bundle_ok.cumulative_gas_used = transaction_ok.cumulative_gas_used;
         bundle_ok.blob_gas_used += transaction_ok.blob_gas_used;
         bundle_ok.cumulative_blob_gas_used = transaction_ok.cumulative_blob_gas_used;
-        bundle_ok.txs.push(transaction_ok.tx);
+        bundle_ok.tx_infos.push(transaction_ok.tx_info);
         update_nonce_list(&mut bundle_ok.nonces_updated, transaction_ok.nonce_updated);
-        bundle_ok.receipts.push(transaction_ok.receipt);
     }
 
     fn estimate_refund_payout_tx(
@@ -665,7 +687,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         )?;
         match res {
             Ok(res) => {
-                if !res.receipt.success {
+                if !res.tx_info.receipt.success {
                     return Ok(Err(BundleErr::FailedToCommitPayoutTx {
                         to,
                         gas_limit: payout.gas_limit,
@@ -702,19 +724,13 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             cumulative_gas_used,
             blob_gas_used: 0,
             cumulative_blob_gas_used,
-            txs: Vec::new(),
+            tx_infos: Vec::new(),
             nonces_updated: Vec::new(),
-            receipts: Vec::new(),
             paid_kickbacks: Vec::new(),
             original_order_ids: Vec::new(),
         };
         for tx_with_blobs in &bundle.txs {
             let tx_hash = tx_with_blobs.hash();
-            let coinbase_balance_before = self.state.balance(
-                self.ctx.evm_env.block_env.beneficiary,
-                &self.ctx.shared_cached_reads,
-                &mut self.local_ctx.cached_reads,
-            )?;
             let rollback_point = self.rollback_point();
             let result = self.commit_tx(
                 tx_with_blobs,
@@ -724,7 +740,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             )?;
             match result {
                 Ok(res) => {
-                    if !res.receipt.success {
+                    if !res.tx_info.receipt.success {
                         if bundle.dropping_tx_hashes.contains(&tx_hash) {
                             self.rollback(rollback_point);
                             continue;
@@ -733,19 +749,8 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                             return Ok(Err(BundleErr::TransactionReverted(tx_hash)));
                         }
                     }
-
-                    let coinbase_profit = {
-                        let coinbase_balance_after = self.state.balance(
-                            self.ctx.evm_env.block_env.beneficiary,
-                            &self.ctx.shared_cached_reads,
-                            &mut self.local_ctx.cached_reads,
-                        )?;
-                        coinbase_balance_after.checked_sub(coinbase_balance_before)
-                    };
-                    if let Some(profit) = coinbase_profit {
-                        if bundle.is_tx_refundable(&tx_hash) {
-                            refundable_profit += profit;
-                        }
+                    if !res.tx_info.coinbase_profit.is_zero() && bundle.is_tx_refundable(&tx_hash) {
+                        refundable_profit += res.tx_info.coinbase_profit;
                     }
                     Self::accumulate_tx_execution(res, &mut insert);
                 }
@@ -882,17 +887,12 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             cumulative_gas_used,
             blob_gas_used: 0,
             cumulative_blob_gas_used,
-            txs: Vec::new(),
+            tx_infos: Vec::new(),
             nonces_updated: Vec::new(),
-            receipts: Vec::new(),
             paid_kickbacks: Vec::new(),
             original_order_ids: Vec::new(),
         };
-        let coinbase_balance_before = self.state.balance(
-            self.ctx.evm_env.block_env.beneficiary,
-            &self.ctx.shared_cached_reads,
-            &mut self.local_ctx.cached_reads,
-        )?;
+        let coinbase_balance_before = self.coinbase_balance()?;
         let refundable_elements = bundle
             .refund
             .iter()
@@ -905,11 +905,6 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                 ShareBundleBody::Tx(sbundle_tx) => {
                     let rollback_point = self.rollback_point();
                     let tx = &sbundle_tx.tx;
-                    let coinbase_balance_before = self.state.balance(
-                        self.ctx.evm_env.block_env.beneficiary,
-                        &self.ctx.shared_cached_reads,
-                        &mut self.local_ctx.cached_reads,
-                    )?;
                     let result = self.commit_tx(
                         tx,
                         insert.cumulative_gas_used,
@@ -918,7 +913,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     )?;
                     match result {
                         Ok(res) => {
-                            if !res.receipt.success {
+                            if !res.tx_info.receipt.success {
                                 match sbundle_tx.revert_behavior {
                                     crate::primitives::TxRevertBehavior::NotAllowed => {
                                         return Ok(Err(BundleErr::TransactionReverted(tx.hash())));
@@ -930,19 +925,10 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                                     }
                                 }
                             }
-
-                            let coinbase_profit = {
-                                let coinbase_balance_after = self.state.balance(
-                                    self.ctx.evm_env.block_env.beneficiary,
-                                    &self.ctx.shared_cached_reads,
-                                    &mut self.local_ctx.cached_reads,
-                                )?;
-                                coinbase_balance_after.checked_sub(coinbase_balance_before)
-                            };
-                            if let Some(profit) = coinbase_profit {
-                                if !refundable_elements.contains_key(&idx) {
-                                    refundable_profit += profit;
-                                }
+                            if !res.tx_info.coinbase_profit.is_zero()
+                                && !refundable_elements.contains_key(&idx)
+                            {
+                                refundable_profit += res.tx_info.coinbase_profit;
                             }
                             Self::accumulate_tx_execution(res, &mut insert);
                         }
@@ -967,7 +953,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     match inner_res {
                         Ok(res) => {
                             if let Some(original_order_id) = inner_bundle.original_order_id {
-                                if !res.bundle_ok.txs.is_empty() {
+                                if !res.bundle_ok.tx_infos.is_empty() {
                                     // We only consider this order executed if something was so we exclude 100% dropped bundles.
                                     insert.original_order_ids.push(original_order_id);
                                 }
@@ -986,12 +972,11 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                             insert.blob_gas_used += res.bundle_ok.blob_gas_used;
                             insert.cumulative_blob_gas_used =
                                 res.bundle_ok.cumulative_blob_gas_used;
-                            insert.txs.extend(res.bundle_ok.txs);
+                            insert.tx_infos.extend(res.bundle_ok.tx_infos);
                             update_nonce_list_with_updates(
                                 &mut insert.nonces_updated,
                                 res.bundle_ok.nonces_updated,
                             );
-                            insert.receipts.extend(res.bundle_ok.receipts);
 
                             for (addr, reserve) in res.payouts_promissed {
                                 inner_payouts
@@ -1048,16 +1033,9 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             payouts_promised.insert(to, payout);
         }
 
-        let coinbase_diff_before_payouts = {
-            let coinbase_balance_after = self.state.balance(
-                self.ctx.evm_env.block_env.beneficiary,
-                &self.ctx.shared_cached_reads,
-                &mut self.local_ctx.cached_reads,
-            )?;
-            coinbase_balance_after
-                .checked_sub(coinbase_balance_before)
-                .unwrap_or_default()
-        };
+        let coinbase_diff_before_payouts = self
+            .saturating_coinbase_delta(coinbase_balance_before)
+            .unwrap_or_default();
         let total_payouts_promissed = payouts_promised
             .values()
             .map(|v| v.total_refundable_value)
@@ -1105,11 +1083,6 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         cumulative_blob_gas_used: u64,
         allow_tx_skip: bool,
     ) -> Result<Result<OrderOk, OrderErr>, CriticalCommitOrderError> {
-        let coinbase_balance_before = self.state.balance(
-            self.ctx.evm_env.block_env.beneficiary,
-            &self.ctx.shared_cached_reads,
-            &mut self.local_ctx.cached_reads,
-        )?;
         match order {
             Order::Tx(tx) => {
                 let res = self.commit_tx(
@@ -1119,34 +1092,23 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     cumulative_blob_gas_used,
                 )?;
                 match res {
-                    Ok(ok) => {
-                        // Builder does not sign txs in this code path, so allow negative coinbase
-                        // profit.
-                        let coinbase_balance_after = self.state.balance(
-                            self.ctx.evm_env.block_env.beneficiary,
-                            &self.ctx.shared_cached_reads,
-                            &mut self.local_ctx.cached_reads,
-                        )?;
-                        let coinbase_profit =
-                            coinbase_balance_after.saturating_sub(coinbase_balance_before);
-                        Ok(Ok(OrderOk {
-                            coinbase_profit,
-                            gas_used: ok.gas_used,
-                            cumulative_gas_used: ok.cumulative_gas_used,
-                            blob_gas_used: ok.blob_gas_used,
-                            cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
-                            txs: vec![ok.tx],
-                            nonces_updated: vec![ok.nonce_updated],
-                            receipts: vec![ok.receipt],
-                            paid_kickbacks: Vec::new(),
-                            used_state_trace: self.get_used_state_trace(),
-                            original_order_ids: Vec::new(),
-                        }))
-                    }
+                    Ok(ok) => Ok(Ok(OrderOk {
+                        coinbase_profit: ok.tx_info.coinbase_profit,
+                        gas_used: ok.tx_info.gas_used,
+                        cumulative_gas_used: ok.cumulative_gas_used,
+                        blob_gas_used: ok.blob_gas_used,
+                        cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
+                        tx_infos: vec![ok.tx_info],
+                        nonces_updated: vec![ok.nonce_updated],
+                        paid_kickbacks: Vec::new(),
+                        used_state_trace: self.get_used_state_trace(),
+                        original_order_ids: Vec::new(),
+                    })),
                     Err(err) => Ok(Err(err.into())),
                 }
             }
             Order::Bundle(bundle) => {
+                let coinbase_balance_before = self.coinbase_balance()?;
                 let res = self.commit_bundle(
                     bundle,
                     cumulative_gas_used,
@@ -1154,35 +1116,10 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     cumulative_blob_gas_used,
                     allow_tx_skip,
                 )?;
-                match res {
-                    Ok(ok) => {
-                        // Builder does not sign txs in this code path, so allow negative coinbase
-                        // profit.
-                        let coinbase_balance_after = self.state.balance(
-                            self.ctx.evm_env.block_env.beneficiary,
-                            &self.ctx.shared_cached_reads,
-                            &mut self.local_ctx.cached_reads,
-                        )?;
-                        let coinbase_profit =
-                            coinbase_balance_after.saturating_sub(coinbase_balance_before);
-                        Ok(Ok(OrderOk {
-                            coinbase_profit,
-                            gas_used: ok.gas_used,
-                            cumulative_gas_used: ok.cumulative_gas_used,
-                            blob_gas_used: ok.blob_gas_used,
-                            cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
-                            txs: ok.txs,
-                            nonces_updated: ok.nonces_updated,
-                            receipts: ok.receipts,
-                            paid_kickbacks: ok.paid_kickbacks,
-                            used_state_trace: self.get_used_state_trace(),
-                            original_order_ids: ok.original_order_ids,
-                        }))
-                    }
-                    Err(err) => Ok(Err(err.into())),
-                }
+                self.bundle_to_order_result(res, coinbase_balance_before)
             }
             Order::ShareBundle(bundle) => {
+                let coinbase_balance_before = self.coinbase_balance()?;
                 let res = self.commit_share_bundle(
                     bundle,
                     cumulative_gas_used,
@@ -1190,41 +1127,55 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     cumulative_blob_gas_used,
                     allow_tx_skip,
                 )?;
-                match res {
-                    Ok(ok) => {
-                        let coinbase_balance_after = self.state.balance(
-                            self.ctx.evm_env.block_env.beneficiary,
-                            &self.ctx.shared_cached_reads,
-                            &mut self.local_ctx.cached_reads,
-                        )?;
-                        // Builder does sign txs in this code path, so do not allow negative coinbase
-                        // profit.
-                        let coinbase_profit = match coinbase_profit(
-                            coinbase_balance_before,
-                            coinbase_balance_after,
-                        ) {
-                            Ok(profit) => profit,
-                            Err(err) => {
-                                return Ok(Err(err));
-                            }
-                        };
-                        Ok(Ok(OrderOk {
-                            coinbase_profit,
-                            gas_used: ok.gas_used,
-                            cumulative_gas_used: ok.cumulative_gas_used,
-                            blob_gas_used: ok.blob_gas_used,
-                            cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
-                            txs: ok.txs,
-                            nonces_updated: ok.nonces_updated,
-                            receipts: ok.receipts,
-                            paid_kickbacks: ok.paid_kickbacks,
-                            used_state_trace: self.get_used_state_trace(),
-                            original_order_ids: ok.original_order_ids,
-                        }))
-                    }
-                    Err(err) => Ok(Err(err.into())),
-                }
+                self.bundle_to_order_result(res, coinbase_balance_before)
             }
+        }
+    }
+
+    fn bundle_to_order_result(
+        &mut self,
+        bundle_result: Result<BundleOk, BundleErr>,
+        coinbase_balance_before: U256,
+    ) -> Result<Result<OrderOk, OrderErr>, CriticalCommitOrderError> {
+        match bundle_result {
+            Ok(ok) => {
+                // Builder does sign txs in this code path, so do not allow negative coinbase
+                // profit.
+                let coinbase_profit =
+                    match self.coinbase_profit_when_refunds(coinbase_balance_before)? {
+                        Ok(profit) => profit,
+                        Err(err) => return Ok(Err(err)),
+                    };
+
+                Ok(Ok(OrderOk {
+                    coinbase_profit,
+                    gas_used: ok.gas_used,
+                    cumulative_gas_used: ok.cumulative_gas_used,
+                    blob_gas_used: ok.blob_gas_used,
+                    cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
+                    tx_infos: ok.tx_infos,
+                    nonces_updated: ok.nonces_updated,
+                    paid_kickbacks: ok.paid_kickbacks,
+                    used_state_trace: self.get_used_state_trace(),
+                    original_order_ids: ok.original_order_ids,
+                }))
+            }
+            Err(err) => Ok(Err(err.into())),
+        }
+    }
+
+    /// Returns the delta balance if >= 0 or error if negative since in contexts where we add refund txs we could lose money.
+    fn coinbase_profit_when_refunds(
+        &mut self,
+        initial_balance: U256,
+    ) -> Result<Result<U256, OrderErr>, CriticalCommitOrderError> {
+        let coinbase_balance_after = self.coinbase_balance()?;
+        if coinbase_balance_after >= initial_balance {
+            Ok(Ok(coinbase_balance_after - initial_balance))
+        } else {
+            Ok(Err(OrderErr::NegativeProfit(
+                initial_balance - coinbase_balance_after,
+            )))
         }
     }
 }
@@ -1243,19 +1194,6 @@ impl<'a, 'c, 'd> PartialBlockFork<'a, '_, 'c, 'd, ()> {
             tracer: None,
             tmp_used_state_tracer: Default::default(),
         }
-    }
-}
-
-fn coinbase_profit(
-    coinbase_balance_before: U256,
-    coinbase_balance_after: U256,
-) -> Result<U256, OrderErr> {
-    if coinbase_balance_after >= coinbase_balance_before {
-        Ok(coinbase_balance_after - coinbase_balance_before)
-    } else {
-        Err(OrderErr::NegativeProfit(
-            coinbase_balance_before - coinbase_balance_after,
-        ))
     }
 }
 

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -20,7 +20,7 @@ use crate::{
 use ahash::HashSet;
 use alloy_consensus::{constants::KECCAK_EMPTY, Transaction};
 use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, I256, U256};
 use itertools::Itertools;
 use reth::revm::database::StateProviderDatabase;
 use reth_errors::ProviderError;
@@ -187,8 +187,8 @@ pub struct TransactionExecutionInfo {
     pub tx: TransactionSignedEcRecoveredWithBlobs,
     pub receipt: Receipt,
     pub gas_used: u64,
-    /// On loss capped to 0
-    pub coinbase_profit: U256,
+    /// coinbase balance after tx - before.
+    pub coinbase_profit: I256,
 }
 #[derive(Debug, Clone)]
 pub struct TransactionOk {
@@ -276,6 +276,8 @@ pub enum BundleErr {
 
 #[derive(Debug, Clone)]
 pub struct OrderOk {
+    /// Profit used for sorting orders on building algorithms.
+    /// Real profit for s/bundles (they fail on negative profit) and capped to 0 for txs with negative profit.
     pub coinbase_profit: U256,
     pub gas_used: u64,
     pub cumulative_gas_used: u64,
@@ -335,6 +337,9 @@ pub enum CriticalCommitOrderError {
     Reth(#[from] ProviderError),
     #[error("EVM error: {0}")]
     EVM(#[from] EVMError<ProviderError>),
+    /// This could happen if we can't fit a balance in a I256 (unlikely/impossible since the ETH total supply is several orders of magnitude bellow I256::max)
+    #[error("BigIntConversionError error: {0}")]
+    BigIntConversionError(#[from] alloy_primitives::BigIntConversionError),
 }
 
 /// For all funcs allow_tx_skip means:
@@ -417,7 +422,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         gas_reserved: u64,
         mut cumulative_blob_gas_used: u64,
     ) -> Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError> {
-        let coinbase_balance_before = self.coinbase_balance()?;
+        let coinbase_balance_before = I256::try_from(self.coinbase_balance()?)?;
         // Use blobs.len() instead of checking for tx type just in case in the future some other new txs have blobs
         let blob_gas_used = tx_with_blobs.blobs_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB;
         if cumulative_blob_gas_used + blob_gas_used > self.ctx.max_blob_gas_per_block() {
@@ -545,7 +550,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             cumulative_gas_used,
             logs: res.result.logs().to_vec(),
         };
-
+        let coinbase_balance_after = I256::try_from(self.coinbase_balance()?)?;
         Ok(Ok(TransactionOk {
             exec_result: res.result,
             blob_gas_used,
@@ -555,7 +560,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                 tx: tx_with_blobs.clone(),
                 receipt,
                 gas_used,
-                coinbase_profit: self.saturating_coinbase_delta(coinbase_balance_before)?,
+                coinbase_profit: coinbase_balance_after - coinbase_balance_before,
             },
             nonce_updated: (tx.signer(), tx.nonce() + 1),
         }))
@@ -749,8 +754,10 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                             return Ok(Err(BundleErr::TransactionReverted(tx_hash)));
                         }
                     }
-                    if !res.tx_info.coinbase_profit.is_zero() && bundle.is_tx_refundable(&tx_hash) {
-                        refundable_profit += res.tx_info.coinbase_profit;
+                    if res.tx_info.coinbase_profit.is_positive()
+                        && bundle.is_tx_refundable(&tx_hash)
+                    {
+                        refundable_profit += res.tx_info.coinbase_profit.unsigned_abs();
                     }
                     Self::accumulate_tx_execution(res, &mut insert);
                 }
@@ -925,10 +932,10 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                                     }
                                 }
                             }
-                            if !res.tx_info.coinbase_profit.is_zero()
+                            if res.tx_info.coinbase_profit.is_positive()
                                 && !refundable_elements.contains_key(&idx)
                             {
-                                refundable_profit += res.tx_info.coinbase_profit;
+                                refundable_profit += res.tx_info.coinbase_profit.unsigned_abs();
                             }
                             Self::accumulate_tx_execution(res, &mut insert);
                         }
@@ -1092,18 +1099,25 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     cumulative_blob_gas_used,
                 )?;
                 match res {
-                    Ok(ok) => Ok(Ok(OrderOk {
-                        coinbase_profit: ok.tx_info.coinbase_profit,
-                        gas_used: ok.tx_info.gas_used,
-                        cumulative_gas_used: ok.cumulative_gas_used,
-                        blob_gas_used: ok.blob_gas_used,
-                        cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
-                        tx_infos: vec![ok.tx_info],
-                        nonces_updated: vec![ok.nonce_updated],
-                        paid_kickbacks: Vec::new(),
-                        used_state_trace: self.get_used_state_trace(),
-                        original_order_ids: Vec::new(),
-                    })),
+                    Ok(ok) => {
+                        let coinbase_profit = if ok.tx_info.coinbase_profit.is_positive() {
+                            ok.tx_info.coinbase_profit.unsigned_abs()
+                        } else {
+                            U256::ZERO
+                        };
+                        Ok(Ok(OrderOk {
+                            coinbase_profit,
+                            gas_used: ok.tx_info.gas_used,
+                            cumulative_gas_used: ok.cumulative_gas_used,
+                            blob_gas_used: ok.blob_gas_used,
+                            cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
+                            tx_infos: vec![ok.tx_info],
+                            nonces_updated: vec![ok.nonce_updated],
+                            paid_kickbacks: Vec::new(),
+                            used_state_trace: self.get_used_state_trace(),
+                            original_order_ids: Vec::new(),
+                        }))
+                    }
                     Err(err) => Ok(Err(err.into())),
                 }
             }

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -246,9 +246,9 @@ fn bundle_revert_tests(
         current_slot_value + 100,
     )?;
     let result = test_setup.commit_order_ok();
-    assert_eq!(result.receipts.len(), 2);
-    assert!(result.receipts[0].success);
-    assert!(!result.receipts[1].success);
+    assert_eq!(result.tx_infos.len(), 2);
+    assert!(result.tx_infos[0].receipt.success);
+    assert!(!result.tx_infos[1].receipt.success);
 
     // this bundle has 2 txs one ok other has incorrect nonce
     begin_bundle(test_setup);
@@ -260,8 +260,8 @@ fn bundle_revert_tests(
         current_slot_value,
     )?;
     let result = test_setup.commit_order_ok();
-    assert_eq!(result.receipts.len(), 1);
-    assert!(result.receipts[0].success);
+    assert_eq!(result.tx_infos.len(), 1);
+    assert!(result.tx_infos[0].receipt.success);
 
     // for share bundle also try nested bundles
     if share_bundle {

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -357,6 +357,26 @@ fn test_bundle_ok_refunds() -> eyre::Result<()> {
 }
 
 #[test]
+fn test_bundle_ok_inner_tx_profits() -> eyre::Result<()> {
+    let target_block = 11;
+    let mut test_setup = TestSetup::gen_test_setup(BlockArgs::default().number(target_block))?;
+    let profits = [100_000u64, 200_000u64, 10u64];
+    let mut tx_hashes = Vec::default();
+    test_setup.begin_bundle_order(target_block);
+    for (index, profit) in profits.iter().enumerate() {
+        tx_hashes.push(test_setup.add_send_to_coinbase_tx(NamedAddr::User(index), *profit)?);
+    }
+    let result = test_setup.commit_order_ok();
+    let executed_profits = result
+        .tx_infos
+        .iter()
+        .map(|info| u64::try_from(info.coinbase_profit).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(profits, executed_profits.as_slice());
+    Ok(())
+}
+
+#[test]
 fn test_mev_share_ok_refunds() -> eyre::Result<()> {
     let target_block = 11;
     let mut test_setup = TestSetup::gen_test_setup(BlockArgs::default().number(target_block))?;

--- a/crates/rbuilder/src/live_builder/building/unfinished_block_building_sink_muxer.rs
+++ b/crates/rbuilder/src/live_builder/building/unfinished_block_building_sink_muxer.rs
@@ -104,7 +104,7 @@ mod tests {
         },
         primitives::{AccountNonce, Order},
     };
-    use alloy_primitives::U256;
+    use alloy_primitives::{I256, U256};
 
     use super::BestBlockState;
 
@@ -141,7 +141,7 @@ mod tests {
                         tx,
                         receipt: Default::default(),
                         gas_used: 0,
-                        coinbase_profit: U256::ZERO,
+                        coinbase_profit: I256::ZERO,
                     }],
                     original_order_ids: Default::default(),
                     nonces_updated: Default::default(),

--- a/crates/rbuilder/src/live_builder/building/unfinished_block_building_sink_muxer.rs
+++ b/crates/rbuilder/src/live_builder/building/unfinished_block_building_sink_muxer.rs
@@ -100,7 +100,7 @@ mod tests {
                 block_building_helper::BiddableUnfinishedBlock,
                 mock_block_building_helper::MockBlockBuildingHelper,
             },
-            ExecutionResult,
+            ExecutionResult, TransactionExecutionInfo,
         },
         primitives::{AccountNonce, Order},
     };
@@ -137,9 +137,13 @@ mod tests {
                     inplace_sim: Default::default(),
                     gas_used: Default::default(),
                     order: Order::Tx(order),
-                    txs: vec![tx],
+                    tx_infos: vec![TransactionExecutionInfo {
+                        tx,
+                        receipt: Default::default(),
+                        gas_used: 0,
+                        coinbase_profit: U256::ZERO,
+                    }],
                     original_order_ids: Default::default(),
-                    receipts: Default::default(),
                     nonces_updated: Default::default(),
                     paid_kickbacks: Default::default(),
                 });


### PR DESCRIPTION
## 📝 Summary

In a few places we had a vector of tx and a brother vector of receipt matching one the txs.
I put both in a new struct TransactionExecutionInfo and I also moved there gas and added profit.
Some copy paste was removed.

## 💡 Motivation and Context

Nicer code and it will allow better checks on bundle execution due to the new per tx profit info.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
