### PR TITLE
Non mempool profit

### DIFF
--- a/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
@@ -207,7 +207,7 @@ fn print_simulated_orders(
 ) {
     println!("Simulated orders: ({} total)", sim_orders.len());
     let mut sorted_orders = sim_orders.to_owned();
-    sorted_orders.sort_by_key(|order| order.sim_value.coinbase_profit);
+    sorted_orders.sort_by_key(|order| order.sim_value.full_profit_info().coinbase_profit());
     sorted_orders.reverse();
     for order in sorted_orders {
         let order_timestamp = order_and_timestamp
@@ -221,8 +221,8 @@ fn print_simulated_orders(
             "{:>74} slot_time_ms: {:>8}, gas: {:>8} profit: {}",
             order.order.id().to_string(),
             slot_time_ms,
-            order.sim_value.gas_used,
-            format_ether(order.sim_value.coinbase_profit),
+            order.sim_value.gas_used(),
+            format_ether(order.sim_value.full_profit_info().coinbase_profit()),
         );
     }
     println!();

--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -184,13 +184,13 @@ where
         let mut count = 0;
         let mut amount = U256::ZERO;
         for sim in &sim_orders {
-            if sim.sim_value.paid_kickbacks.is_empty() {
+            if sim.sim_value.paid_kickbacks().is_empty() {
                 continue;
             }
             count += 1;
             amount += sim
                 .sim_value
-                .paid_kickbacks
+                .paid_kickbacks()
                 .iter()
                 .map(|(_, v)| v)
                 .sum::<U256>();
@@ -198,7 +198,7 @@ where
         (count, amount)
     };
 
-    let simulated_total_gas = sim_orders.iter().map(|o| o.sim_value.gas_used).sum();
+    let simulated_total_gas = sim_orders.iter().map(|o| o.sim_value.gas_used()).sum();
     let mut builder_outputs = Vec::new();
 
     for building_algorithm_name in builders_names {

--- a/crates/rbuilder/src/building/block_orders/order_priority.rs
+++ b/crates/rbuilder/src/building/block_orders/order_priority.rs
@@ -68,19 +68,23 @@ struct OrderMevGasPricePriorityCmp {}
 impl OrderMevGasPricePriorityCmp {
     #[inline]
     fn eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
-        a.sim_value.mev_gas_price == b.sim_value.mev_gas_price
+        a.sim_value.full_profit_info().mev_gas_price()
+            == b.sim_value.full_profit_info().mev_gas_price()
     }
 
     #[inline]
     fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
-        a.sim_value.mev_gas_price.cmp(&b.sim_value.mev_gas_price)
+        a.sim_value
+            .full_profit_info()
+            .mev_gas_price()
+            .cmp(&b.sim_value.full_profit_info().mev_gas_price())
     }
 }
 #[inline]
 fn simulation_too_low_gas_price(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool {
     new_sim_value_too_low(
-        original_sim_value.mev_gas_price,
-        new_sim_value.mev_gas_price,
+        original_sim_value.full_profit_info().mev_gas_price(),
+        new_sim_value.full_profit_info().mev_gas_price(),
     )
 }
 
@@ -89,21 +93,23 @@ struct OrderMaxProfitPriorityCmp {}
 impl OrderMaxProfitPriorityCmp {
     #[inline]
     fn eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
-        a.sim_value.coinbase_profit == b.sim_value.coinbase_profit
+        a.sim_value.full_profit_info().coinbase_profit()
+            == b.sim_value.full_profit_info().coinbase_profit()
     }
 
     #[inline]
     fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
         a.sim_value
-            .coinbase_profit
-            .cmp(&b.sim_value.coinbase_profit)
+            .full_profit_info()
+            .coinbase_profit()
+            .cmp(&b.sim_value.full_profit_info().coinbase_profit())
     }
 }
 #[inline]
 fn simulation_too_low_profit(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool {
     new_sim_value_too_low(
-        original_sim_value.coinbase_profit,
-        new_sim_value.coinbase_profit,
+        original_sim_value.full_profit_info().coinbase_profit(),
+        new_sim_value.full_profit_info().coinbase_profit(),
     )
 }
 

--- a/crates/rbuilder/src/building/block_orders/share_bundle_merger.rs
+++ b/crates/rbuilder/src/building/block_orders/share_bundle_merger.rs
@@ -321,7 +321,7 @@ impl<SinkType: SimulatedOrderSink> ShareBundleMerger<SinkType> {
             return None;
         }
         let mut user_kickback = U256::ZERO;
-        for (_, kickback) in &sim_order.sim_value.paid_kickbacks {
+        for (_, kickback) in sim_order.sim_value.paid_kickbacks() {
             user_kickback += kickback;
         }
         Some(BrokenDownShareBundle {

--- a/crates/rbuilder/src/building/block_orders/test_context.rs
+++ b/crates/rbuilder/src/building/block_orders/test_context.rs
@@ -161,15 +161,12 @@ impl<TestedSinkType: SimulatedOrderSink> TestContext<TestedSinkType> {
         coinbase_profit: u64,
         mev_gas_price: u64,
     ) -> Arc<SimulatedOrder> {
-        let sim_value = SimValue {
-            coinbase_profit: U256::from(coinbase_profit),
-            mev_gas_price: U256::from(mev_gas_price),
-            paid_kickbacks: vec![(
-                Self::default_refund_recipient(),
-                U256::from(int_percentage(coinbase_profit, DEFAULT_REFUND)),
-            )],
-            ..Default::default()
-        };
+        let sim_value =
+            SimValue::new_test_no_gas(U256::from(coinbase_profit), U256::from(mev_gas_price))
+                .with_kickbacks(vec![(
+                    Self::default_refund_recipient(),
+                    U256::from(int_percentage(coinbase_profit, DEFAULT_REFUND)),
+                )]);
         Arc::new(SimulatedOrder {
             order,
             sim_value,

--- a/crates/rbuilder/src/building/block_orders/test_data_generator.rs
+++ b/crates/rbuilder/src/building/block_orders/test_data_generator.rs
@@ -24,11 +24,9 @@ impl TestDataGenerator {
         coinbase_profit: u64,
         mev_gas_price: u64,
     ) -> Arc<SimulatedOrder> {
-        let sim_value = SimValue {
-            coinbase_profit: U256::from(coinbase_profit),
-            mev_gas_price: U256::from(mev_gas_price),
-            ..Default::default()
-        };
+        let sim_value =
+            SimValue::new_test_no_gas(U256::from(coinbase_profit), U256::from(mev_gas_price));
+
         Arc::new(SimulatedOrder {
             order,
             sim_value,

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -269,7 +269,7 @@ impl OrderingBuilderContext {
         while let Some(sim_order) = block_orders.pop_order() {
             // @Todo we drop such bundles instead of failing simulation for them
             // because share bundle merging depends on allowing no txs bundles into the block
-            if sim_order.sim_value.gas_used == 0 {
+            if sim_order.sim_value.gas_used() == 0 {
                 continue;
             }
 
@@ -408,16 +408,8 @@ mod tests {
 
     #[test]
     fn test_simulation_too_low_max_profit() {
-        let sim_result = &SimValue {
-            coinbase_profit: U256::from(100),
-            mev_gas_price: U256::from(0),
-            ..Default::default()
-        };
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(94),
-            mev_gas_price: U256::from(0),
-            ..Default::default()
-        };
+        let sim_result = &SimValue::new_test_no_gas(U256::from(100), U256::from(0));
+        let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(94), U256::from(0));
 
         // Lower than 95% of the original value
         assert!(
@@ -425,21 +417,13 @@ mod tests {
         );
 
         // Equal to original value
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(100),
-            mev_gas_price: U256::from(0),
-            ..Default::default()
-        };
+        let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(100), U256::from(0));
         assert!(
             simulation_too_low::<OrderMaxProfitPriority>(sim_result, inplace_sim_result).is_ok()
         );
 
         // Higher than original value
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(105),
-            mev_gas_price: U256::from(0),
-            ..Default::default()
-        };
+        let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(105), U256::from(0));
         assert!(
             simulation_too_low::<OrderMaxProfitPriority>(sim_result, inplace_sim_result).is_ok()
         );
@@ -447,42 +431,22 @@ mod tests {
 
     #[test]
     fn test_simulation_too_low_mev_gas_price() {
-        let sim_result = &SimValue {
-            coinbase_profit: U256::from(0),
-            mev_gas_price: U256::from(100),
-            gas_used: 100,
-            ..Default::default()
-        };
-
+        let sim_result = &SimValue::new_test_no_gas(U256::from(0), U256::from(100));
         // Lower than 95% of the original value
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(0),
-            mev_gas_price: U256::from(94),
-            gas_used: 94,
-            ..Default::default()
-        };
+        let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(0), U256::from(94));
+
         assert!(
             simulation_too_low::<OrderMevGasPricePriority>(sim_result, inplace_sim_result).is_err()
         );
 
         // Equal to original value
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(0),
-            mev_gas_price: U256::from(100),
-            gas_used: 105,
-            ..Default::default()
-        };
+        let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(0), U256::from(100));
         assert!(
             simulation_too_low::<OrderMevGasPricePriority>(sim_result, inplace_sim_result).is_ok()
         );
 
         // Higher than original value
-        let inplace_sim_result = &SimValue {
-            coinbase_profit: U256::from(0),
-            mev_gas_price: U256::from(105),
-            gas_used: 105,
-            ..Default::default()
-        };
+        let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(0), U256::from(105));
         assert!(
             simulation_too_low::<OrderMevGasPricePriority>(sim_result, inplace_sim_result).is_ok()
         );

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -347,7 +347,7 @@ impl BlockBuildingResultAssembler {
                 .any(|(order_idx, _)| {
                     !order_group.orders[*order_idx]
                         .sim_value
-                        .paid_kickbacks
+                        .paid_kickbacks()
                         .is_empty()
                 })
         })

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolvers.rs
@@ -402,8 +402,8 @@ fn generate_greedy_sequence(task: &ConflictTask, reverse: bool) -> Vec<Vec<usize
     };
 
     vec![
-        create_sequence(|sim_order| sim_order.sim_value.coinbase_profit),
-        create_sequence(|sim_order| sim_order.sim_value.mev_gas_price),
+        create_sequence(|sim_order| sim_order.sim_value.full_profit_info().coinbase_profit()),
+        create_sequence(|sim_order| sim_order.sim_value.full_profit_info().mev_gas_price()),
     ]
 }
 
@@ -429,7 +429,7 @@ fn generate_length_based_sequence(task: &ConflictTask) -> Vec<Vec<usize>> {
             (
                 idx,
                 order.order.list_txs().len(),
-                order.sim_value.coinbase_profit,
+                order.sim_value.full_profit_info().coinbase_profit(),
             )
         })
         .collect();
@@ -513,11 +513,7 @@ mod tests {
                 );
             }
 
-            let sim_value = SimValue {
-                coinbase_profit,
-                mev_gas_price,
-                ..Default::default()
-            };
+            let sim_value = SimValue::new_test_no_gas(coinbase_profit, mev_gas_price);
 
             let bundle = Bundle {
                 block: Some(0),

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_task_generator.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_task_generator.rs
@@ -180,8 +180,17 @@ impl ConflictTaskGenerator {
     /// * `group` - The `ConflictGroup` to process.
     fn process_single_order_group(&mut self, group_id: GroupId, group: &ConflictGroup) {
         let sequence_of_orders = ResolutionResult {
-            total_profit: group.orders[0].sim_value.coinbase_profit,
-            sequence_of_orders: vec![(0, group.orders[0].sim_value.coinbase_profit)],
+            total_profit: group.orders[0]
+                .sim_value
+                .full_profit_info()
+                .coinbase_profit(),
+            sequence_of_orders: vec![(
+                0,
+                group.orders[0]
+                    .sim_value
+                    .full_profit_info()
+                    .coinbase_profit(),
+            )],
         };
         // We ignore the error since it means "receiver disconnected" and we expect the caller will detect the cancellation and stop calling us.
         let _ = self
@@ -271,7 +280,7 @@ impl ConflictTaskGenerator {
     fn sum_top_n_profits(&self, orders: &[Arc<SimulatedOrder>], n: usize) -> U256 {
         orders
             .iter()
-            .map(|o| o.sim_value.coinbase_profit)
+            .map(|o| o.sim_value.full_profit_info().coinbase_profit())
             .sorted_by(|a, b| b.cmp(a))
             .take(n)
             .sum()
@@ -464,10 +473,7 @@ mod tests {
                     .insert(write.clone(), self.create_b256());
             }
 
-            let sim_value = SimValue {
-                coinbase_profit,
-                ..Default::default()
-            };
+            let sim_value = SimValue::new_test_no_gas(coinbase_profit, U256::ZERO);
 
             Arc::new(SimulatedOrder {
                 order: Order::Tx(MempoolTx {

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -979,7 +979,7 @@ mod test {
     /// Create a bundle with 2 txs, one from mempool and the other not.
     /// sim_value.non_mempool_profit_info().coinbase_profit() should only sum the profit for the second.
     #[test]
-    fn test_create_sim_value_non_mempool_coinbase_profit() {
+    fn test_create_sim_value_bundle_non_mempool_coinbase_profit() {
         let detector = MempoolTxsDetector::new();
         let mut data_gen = TestDataGenerator::default();
         let tx1 = data_gen.create_tx_with_blobs_nonce(Default::default());
@@ -1024,6 +1024,46 @@ mod test {
         assert_eq!(
             sim_value.non_mempool_profit_info().coinbase_profit(),
             profit_2.unsigned_abs()
+        );
+    }
+
+    /// Create a tx from mempool.
+    /// sim_value.non_mempool_profit_info().coinbase_profit() should be the same as full_profit_info = tx profit
+    #[test]
+    fn test_create_sim_value_tx_non_mempool_coinbase_profit() {
+        let detector = MempoolTxsDetector::new();
+        let mut data_gen = TestDataGenerator::default();
+        let tx = data_gen.create_tx_with_blobs_nonce(Default::default());
+        let order = Order::Tx(MempoolTx {
+            tx_with_blobs: tx.clone(),
+        });
+        detector.add_tx(&order);
+        let profit = I256::unchecked_from(1000);
+        let order_ok = OrderOk {
+            coinbase_profit: profit.unsigned_abs(),
+            gas_used: Default::default(),
+            cumulative_gas_used: Default::default(),
+            blob_gas_used: Default::default(),
+            cumulative_blob_gas_used: Default::default(),
+            tx_infos: vec![TransactionExecutionInfo {
+                tx,
+                receipt: Default::default(),
+                gas_used: Default::default(),
+                coinbase_profit: profit,
+            }],
+            original_order_ids: Default::default(),
+            nonces_updated: Default::default(),
+            paid_kickbacks: Default::default(),
+            used_state_trace: Default::default(),
+        };
+        let sim_value = create_sim_value(&order, &order_ok, &detector);
+        assert_eq!(
+            sim_value.non_mempool_profit_info().coinbase_profit(),
+            profit.unsigned_abs()
+        );
+        assert_eq!(
+            sim_value.non_mempool_profit_info().coinbase_profit(),
+            sim_value.full_profit_info().coinbase_profit(),
         );
     }
 }

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -22,7 +22,7 @@ use alloy_eips::{
     merge::BEACON_NONCE,
 };
 use alloy_evm::{block::system_calls::SystemCaller, env::EvmEnv, eth::eip6110};
-use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_primitives::{utils::format_ether, Address, Bytes, B256, I256, U256};
 use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
 use cached_reads::{LocalCachedReads, SharedCachedReads};
 use evm::EthCachedEvmFactory;
@@ -56,7 +56,7 @@ use std::{
 };
 use thiserror::Error;
 use time::OffsetDateTime;
-use tracing::trace;
+use tracing::{error, trace};
 use tx_sim_cache::TxExecutionCache;
 
 pub mod block_orders;
@@ -937,7 +937,16 @@ pub fn create_sim_value(order_ok: &OrderOk, mempool_detector: &MempoolTxsDetecto
         .iter()
         .filter(|tx_info| !mempool_detector.is_mempool(&tx_info.tx))
         .map(|tx_info| tx_info.coinbase_profit)
-        .sum::<U256>();
+        .sum::<I256>();
+    let non_mempool_coinbase_profit = if non_mempool_coinbase_profit.is_positive() {
+        non_mempool_coinbase_profit.unsigned_abs()
+    } else {
+        error!(
+            non_mempool_coinbase_profit = format_ether(non_mempool_coinbase_profit),
+            "Non mempool orders have always positive profit, how did we got a negative value????"
+        );
+        U256::ZERO
+    };
 
     for tx_info in &order_ok.tx_infos {
         if !mempool_detector.is_mempool(&tx_info.tx) {}
@@ -952,7 +961,7 @@ pub fn create_sim_value(order_ok: &OrderOk, mempool_detector: &MempoolTxsDetecto
 }
 #[cfg(test)]
 mod test {
-    use alloy_primitives::U256;
+    use alloy_primitives::I256;
 
     use crate::{
         live_builder::order_input::mempool_txs_detector::MempoolTxsDetector,
@@ -972,8 +981,8 @@ mod test {
             tx_with_blobs: tx1.clone(),
         }));
         let tx2 = data_gen.create_tx_with_blobs_nonce(Default::default());
-        let profit_1 = U256::from(1000);
-        let profit_2 = U256::from(10000);
+        let profit_1 = I256::unchecked_from(1000);
+        let profit_2 = I256::unchecked_from(10000);
         let order_ok = OrderOk {
             coinbase_profit: Default::default(),
             gas_used: Default::default(),
@@ -1002,7 +1011,7 @@ mod test {
         let sim_value = create_sim_value(&order_ok, &detector);
         assert_eq!(
             sim_value.non_mempool_profit_info().coinbase_profit(),
-            profit_2
+            profit_2.unsigned_abs()
         );
     }
 }

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -578,7 +578,8 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             }
         };
 
-        let inplace_sim_result = create_sim_value(&ok_result, &ctx.mempool_tx_detector);
+        let inplace_sim_result =
+            create_sim_value(&order.order, &ok_result, &ctx.mempool_tx_detector);
 
         match result_filter(&inplace_sim_result) {
             Ok(()) => {}
@@ -931,26 +932,31 @@ pub enum FillOrdersError {
     PayoutTxErr(#[from] InsertPayoutTxErr),
 }
 
-pub fn create_sim_value(order_ok: &OrderOk, mempool_detector: &MempoolTxsDetector) -> SimValue {
-    let non_mempool_coinbase_profit = order_ok
-        .tx_infos
-        .iter()
-        .filter(|tx_info| !mempool_detector.is_mempool(&tx_info.tx))
-        .map(|tx_info| tx_info.coinbase_profit)
-        .sum::<I256>();
-    let non_mempool_coinbase_profit = if non_mempool_coinbase_profit.is_positive() {
-        non_mempool_coinbase_profit.unsigned_abs()
+pub fn create_sim_value(
+    order: &Order,
+    order_ok: &OrderOk,
+    mempool_detector: &MempoolTxsDetector,
+) -> SimValue {
+    let non_mempool_coinbase_profit = if let Order::Tx(_) = order {
+        // We don't filter for mempool txs.
+        order_ok.coinbase_profit
     } else {
-        error!(
+        let non_mempool_coinbase_profit = order_ok
+            .tx_infos
+            .iter()
+            .filter(|tx_info| !mempool_detector.is_mempool(&tx_info.tx))
+            .map(|tx_info| tx_info.coinbase_profit)
+            .sum::<I256>();
+        if non_mempool_coinbase_profit.is_positive() {
+            non_mempool_coinbase_profit.unsigned_abs()
+        } else {
+            error!(
             non_mempool_coinbase_profit = format_ether(non_mempool_coinbase_profit),
-            "Non mempool orders have always positive profit, how did we got a negative value????"
-        );
-        U256::ZERO
+            "Non mempool orders have always positive profit, how did we got a negative value????");
+            U256::ZERO
+        }
     };
 
-    for tx_info in &order_ok.tx_infos {
-        if !mempool_detector.is_mempool(&tx_info.tx) {}
-    }
     SimValue::new(
         order_ok.coinbase_profit,
         non_mempool_coinbase_profit,
@@ -1008,7 +1014,13 @@ mod test {
             paid_kickbacks: Default::default(),
             used_state_trace: Default::default(),
         };
-        let sim_value = create_sim_value(&order_ok, &detector);
+        // dummy bundle just to let know create_sim_value this is a bundle.
+        let dummy_bundle = Order::Bundle(data_gen.create_bundle(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        ));
+        let sim_value = create_sim_value(&dummy_bundle, &order_ok, &detector);
         assert_eq!(
             sim_value.non_mempool_profit_info().coinbase_profit(),
             profit_2.unsigned_abs()

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -932,6 +932,9 @@ pub enum FillOrdersError {
     PayoutTxErr(#[from] InsertPayoutTxErr),
 }
 
+/// Create the sim value from the order_ok.
+/// non_mempool_coinbase_profit for s/bundles will filter tx profit.
+/// non_mempool_coinbase_profitm for txs is the same as full_coinbase_profit.
 pub fn create_sim_value(
     order: &Order,
     order_ok: &OrderOk,

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -955,7 +955,7 @@ pub fn create_sim_value(
         } else {
             error!(
             non_mempool_coinbase_profit = format_ether(non_mempool_coinbase_profit),
-            "Non mempool orders have always positive profit, how did we got a negative value????");
+            "Non mempool orders have always positive profit but a negative value was found on a OrderOk");
             U256::ZERO
         }
     };

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -1,5 +1,8 @@
 use crate::{
-    live_builder::{block_list_provider::BlockList, payload_events::InternalPayloadId},
+    live_builder::{
+        block_list_provider::BlockList, order_input::mempool_txs_detector::MempoolTxsDetector,
+        payload_events::InternalPayloadId,
+    },
     primitives::{Order, OrderId, SimValue, SimulatedOrder, TransactionSignedEcRecoveredWithBlobs},
     provider::RootHasher,
     roothash::RootHashError,
@@ -104,6 +107,7 @@ pub struct BlockBuildingContext {
     pub payload_id: InternalPayloadId,
     pub shared_cached_reads: Arc<SharedCachedReads>,
     pub tx_execution_cache: Arc<TxExecutionCache>,
+    pub mempool_tx_detector: Arc<MempoolTxsDetector>,
 }
 
 impl BlockBuildingContext {
@@ -193,6 +197,7 @@ impl BlockBuildingContext {
             shared_cached_reads: Default::default(),
             tx_execution_cache: Arc::new(TxExecutionCache::new(evm_caching_enable)),
             max_blob_gas_per_block,
+            mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
         })
     }
 
@@ -289,6 +294,7 @@ impl BlockBuildingContext {
             shared_cached_reads: Default::default(),
             tx_execution_cache: Arc::new(TxExecutionCache::new(evm_caching_enable)),
             max_blob_gas_per_block,
+            mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
         }
     }
 
@@ -444,6 +450,7 @@ pub enum InsertPayoutTxErr {
     NoSigner,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ExecutionError {
     #[error("Order error: {0}")]
@@ -548,7 +555,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         state: &mut BlockState,
         result_filter: &dyn Fn(&SimValue) -> Result<(), ExecutionError>,
     ) -> Result<Result<ExecutionResult, ExecutionError>, CriticalCommitOrderError> {
-        if ctx.builder_signer.is_none() && !order.sim_value.paid_kickbacks.is_empty() {
+        if ctx.builder_signer.is_none() && !order.sim_value.paid_kickbacks().is_empty() {
             // Return here to avoid wasting time on a call to fork.commit_order that 99% will fail
             return Ok(Err(ExecutionError::OrderError(OrderErr::Bundle(
                 BundleErr::NoSigner,
@@ -571,12 +578,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             }
         };
 
-        let inplace_sim_result = SimValue::new(
-            ok_result.coinbase_profit,
-            ok_result.gas_used,
-            ok_result.blob_gas_used,
-            ok_result.paid_kickbacks.clone(),
-        );
+        let inplace_sim_result = create_sim_value(&ok_result, &ctx.mempool_tx_detector);
 
         match result_filter(&inplace_sim_result) {
             Ok(()) => {}
@@ -927,4 +929,80 @@ pub enum FillOrdersError {
     CriticalCommitOrderError(#[from] CriticalCommitOrderError),
     #[error("Payout tx error: {0}")]
     PayoutTxErr(#[from] InsertPayoutTxErr),
+}
+
+pub fn create_sim_value(order_ok: &OrderOk, mempool_detector: &MempoolTxsDetector) -> SimValue {
+    let non_mempool_coinbase_profit = order_ok
+        .tx_infos
+        .iter()
+        .filter(|tx_info| !mempool_detector.is_mempool(&tx_info.tx))
+        .map(|tx_info| tx_info.coinbase_profit)
+        .sum::<U256>();
+
+    for tx_info in &order_ok.tx_infos {
+        if !mempool_detector.is_mempool(&tx_info.tx) {}
+    }
+    SimValue::new(
+        order_ok.coinbase_profit,
+        non_mempool_coinbase_profit,
+        order_ok.gas_used,
+        order_ok.blob_gas_used,
+        order_ok.paid_kickbacks.clone(),
+    )
+}
+#[cfg(test)]
+mod test {
+    use alloy_primitives::U256;
+
+    use crate::{
+        live_builder::order_input::mempool_txs_detector::MempoolTxsDetector,
+        primitives::{MempoolTx, Order, TestDataGenerator},
+    };
+
+    use super::{create_sim_value, OrderOk, TransactionExecutionInfo};
+
+    /// Create a bundle with 2 txs, one from mempool and the other not.
+    /// sim_value.non_mempool_profit_info().coinbase_profit() should only sum the profit for the second.
+    #[test]
+    fn test_create_sim_value_non_mempool_coinbase_profit() {
+        let detector = MempoolTxsDetector::new();
+        let mut data_gen = TestDataGenerator::default();
+        let tx1 = data_gen.create_tx_with_blobs_nonce(Default::default());
+        detector.add_tx(&Order::Tx(MempoolTx {
+            tx_with_blobs: tx1.clone(),
+        }));
+        let tx2 = data_gen.create_tx_with_blobs_nonce(Default::default());
+        let profit_1 = U256::from(1000);
+        let profit_2 = U256::from(10000);
+        let order_ok = OrderOk {
+            coinbase_profit: Default::default(),
+            gas_used: Default::default(),
+            cumulative_gas_used: Default::default(),
+            blob_gas_used: Default::default(),
+            cumulative_blob_gas_used: Default::default(),
+            tx_infos: vec![
+                TransactionExecutionInfo {
+                    tx: tx1,
+                    receipt: Default::default(),
+                    gas_used: Default::default(),
+                    coinbase_profit: profit_1,
+                },
+                TransactionExecutionInfo {
+                    tx: tx2,
+                    receipt: Default::default(),
+                    gas_used: Default::default(),
+                    coinbase_profit: profit_2,
+                },
+            ],
+            original_order_ids: Default::default(),
+            nonces_updated: Default::default(),
+            paid_kickbacks: Default::default(),
+            used_state_trace: Default::default(),
+        };
+        let sim_value = create_sim_value(&order_ok, &detector);
+        assert_eq!(
+            sim_value.non_mempool_profit_info().coinbase_profit(),
+            profit_2
+        );
+    }
 }

--- a/crates/rbuilder/src/building/sim.rs
+++ b/crates/rbuilder/src/building/sim.rs
@@ -1,10 +1,12 @@
 use super::{
+    create_sim_value,
     tracers::{AccumulatorSimulationTracer, SimulationTracer},
     OrderErr, PartialBlockFork, ThreadBlockBuildingContext,
 };
 use crate::{
     building::{BlockBuildingContext, BlockState, CriticalCommitOrderError},
-    primitives::{Order, OrderId, SimValue, SimulatedOrder},
+    live_builder::order_input::mempool_txs_detector::MempoolTxsDetector,
+    primitives::{Order, OrderId, SimulatedOrder},
     provider::StateProviderFactory,
     telemetry::{add_order_simulation_time, mark_order_pending_nonce},
     utils::NonceCache,
@@ -233,9 +235,16 @@ impl SimTree {
                             .expect("we never delete sims")
                             .simulated_order
                             .sim_value
-                            .coinbase_profit
+                            .full_profit_info()
+                            .coinbase_profit()
                     };
-                    if result.simulated_order.sim_value.coinbase_profit > current_sim_profit {
+                    if result
+                        .simulated_order
+                        .sim_value
+                        .full_profit_info()
+                        .coinbase_profit()
+                        > current_sim_profit
+                    {
                         entry.insert(result.id);
                     }
                 }
@@ -409,7 +418,8 @@ pub fn simulate_order(
     let mut tracer = AccumulatorSimulationTracer::new();
     let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut tracer);
     let rollback_point = fork.rollback_point();
-    let sim_res = simulate_order_using_fork(parent_orders, order, &mut fork);
+    let sim_res =
+        simulate_order_using_fork(parent_orders, order, &mut fork, &ctx.mempool_tx_detector);
     fork.rollback(rollback_point);
     let sim_res = sim_res?;
     Ok(OrderSimResultWithGas {
@@ -423,6 +433,7 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
     parent_orders: Vec<Order>,
     order: Order,
     fork: &mut PartialBlockFork<'_, '_, '_, '_, Tracer>,
+    mempool_tx_detector: &MempoolTxsDetector,
 ) -> Result<OrderSimResult, CriticalCommitOrderError> {
     let start = Instant::now();
     // simulate parents
@@ -449,12 +460,7 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
 
     match result {
         Ok(res) => {
-            let sim_value = SimValue::new(
-                res.coinbase_profit,
-                res.gas_used,
-                res.blob_gas_used,
-                res.paid_kickbacks,
-            );
+            let sim_value = create_sim_value(&res, mempool_tx_detector);
             let new_nonces = res.nonces_updated.into_iter().collect::<Vec<_>>();
             Ok(OrderSimResult::Success(
                 SimulatedOrder {

--- a/crates/rbuilder/src/building/sim.rs
+++ b/crates/rbuilder/src/building/sim.rs
@@ -460,7 +460,7 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
 
     match result {
         Ok(res) => {
-            let sim_value = create_sim_value(&res, mempool_tx_detector);
+            let sim_value = create_sim_value(&order, &res, mempool_tx_detector);
             let new_nonces = res.nonces_updated.into_iter().collect::<Vec<_>>();
             Ok(OrderSimResult::Success(
                 SimulatedOrder {

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -30,6 +30,7 @@ use super::{
     simulation::{OrderSimulationPool, SimulatedOrderCommand},
 };
 
+/// Struct to connect the pipeline for block building.
 #[derive(Debug)]
 pub struct BlockBuildingPool<P> {
     provider: P,
@@ -99,10 +100,16 @@ where
         let (orders_for_block, sink) = OrdersForBlock::new_with_sink();
         // add OrderReplacementManager to manage replacements and cancellations
         let order_replacement_manager = OrderReplacementManager::new(Box::new(sink));
+
+        let mempool_txs_detector_sniffer =
+            order_input::mempool_txs_detector::ReplaceableOrderStreamSniffer::new(
+                Box::new(order_replacement_manager),
+                block_ctx.mempool_tx_detector.clone(),
+            );
         // sink removal is automatic via OrderSink::is_alive false
         let _block_sub = self.orderpool_subscriber.add_sink(
             block_ctx.evm_env.block_env.number,
-            Box::new(order_replacement_manager),
+            Box::new(mempool_txs_detector_sniffer),
         );
 
         let simulations_for_block = self.order_simulation_pool.spawn_simulation_job(
@@ -175,8 +182,6 @@ where
                 &sbundle_merger_selected_signers,
             )
         });
-
-        //        tokio::spawn();
     }
 }
 

--- a/crates/rbuilder/src/live_builder/order_input/mempool_txs_detector.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mempool_txs_detector.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use ahash::HashSet;
+use ahash::RandomState;
 use alloy_primitives::TxHash;
-use parking_lot::Mutex;
+use dashmap::DashSet;
 
 use crate::primitives::{
     BundleReplacementData, Order, ShareBundleReplacementKey, TransactionSignedEcRecoveredWithBlobs,
@@ -50,7 +50,7 @@ impl ReplaceableOrderSink for ReplaceableOrderStreamSniffer {
 /// Current implementation is super simple, it just checks the tx hash against a set of hashes.
 #[derive(Debug)]
 pub struct MempoolTxsDetector {
-    mempool_txs: Mutex<HashSet<TxHash>>,
+    mempool_txs: DashSet<TxHash, RandomState>,
 }
 
 impl MempoolTxsDetector {
@@ -62,14 +62,12 @@ impl MempoolTxsDetector {
 
     pub fn add_tx(&self, order: &Order) {
         if let Order::Tx(mempool_tx) = order {
-            self.mempool_txs
-                .lock()
-                .insert(mempool_tx.tx_with_blobs.hash());
+            self.mempool_txs.insert(mempool_tx.tx_with_blobs.hash());
         }
     }
 
     pub fn is_mempool(&self, tx: &TransactionSignedEcRecoveredWithBlobs) -> bool {
-        self.mempool_txs.lock().contains(&tx.hash())
+        self.mempool_txs.contains(&tx.hash())
     }
 }
 

--- a/crates/rbuilder/src/live_builder/order_input/mempool_txs_detector.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mempool_txs_detector.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use ahash::HashSet;
+use alloy_primitives::TxHash;
+use parking_lot::Mutex;
+
+use crate::primitives::{
+    BundleReplacementData, Order, ShareBundleReplacementKey, TransactionSignedEcRecoveredWithBlobs,
+};
+
+use super::replaceable_order_sink::ReplaceableOrderSink;
+
+/// Get's in the middle of a ReplaceableOrder stream a feeds a MempoolTxsDetector.
+#[derive(Debug)]
+pub struct ReplaceableOrderStreamSniffer {
+    detector: Arc<MempoolTxsDetector>,
+    sink: Box<dyn ReplaceableOrderSink>,
+}
+
+impl ReplaceableOrderStreamSniffer {
+    pub fn new(sink: Box<dyn ReplaceableOrderSink>, detector: Arc<MempoolTxsDetector>) -> Self {
+        Self { detector, sink }
+    }
+
+    pub fn detector(&self) -> Arc<MempoolTxsDetector> {
+        self.detector.clone()
+    }
+}
+
+impl ReplaceableOrderSink for ReplaceableOrderStreamSniffer {
+    fn insert_order(&mut self, order: Order) -> bool {
+        self.detector.add_tx(&order);
+        self.sink.insert_order(order)
+    }
+
+    fn remove_bundle(&mut self, replacement_data: BundleReplacementData) -> bool {
+        self.sink.remove_bundle(replacement_data)
+    }
+
+    fn remove_sbundle(&mut self, key: ShareBundleReplacementKey) -> bool {
+        self.sink.remove_sbundle(key)
+    }
+
+    fn is_alive(&self) -> bool {
+        self.sink.is_alive()
+    }
+}
+
+/// Given a TransactionSignedEcRecoveredWithBlobs answers if the tx is from the mempool or not.
+/// Current implementation is super simple, it just checks the tx hash against a set of hashes.
+#[derive(Debug)]
+pub struct MempoolTxsDetector {
+    mempool_txs: Mutex<HashSet<TxHash>>,
+}
+
+impl MempoolTxsDetector {
+    pub fn new() -> Self {
+        Self {
+            mempool_txs: Default::default(),
+        }
+    }
+
+    pub fn add_tx(&self, order: &Order) {
+        if let Order::Tx(mempool_tx) = order {
+            self.mempool_txs
+                .lock()
+                .insert(mempool_tx.tx_with_blobs.hash());
+        }
+    }
+
+    pub fn is_mempool(&self, tx: &TransactionSignedEcRecoveredWithBlobs) -> bool {
+        self.mempool_txs.lock().contains(&tx.hash())
+    }
+}
+
+impl Default for MempoolTxsDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -1,5 +1,6 @@
 //! order_input handles receiving new orders from the ipc mempool subscription and json rpc server
 //!
+pub mod mempool_txs_detector;
 pub mod order_replacement_manager;
 pub mod order_sink;
 pub mod orderpool;

--- a/crates/rbuilder/src/live_builder/simulation/mod.rs
+++ b/crates/rbuilder/src/live_builder/simulation/mod.rs
@@ -244,7 +244,7 @@ mod tests {
             match command {
                 SimulatedOrderCommand::Simulation(sim_order) => {
                     assert_eq!(
-                        sim_order.sim_value.coinbase_profit,
+                        sim_order.sim_value.full_profit_info().coinbase_profit(),
                         U256::from(coinbase_profit)
                     );
                 }

--- a/crates/rbuilder/src/live_builder/simulation/simulation_job.rs
+++ b/crates/rbuilder/src/live_builder/simulation/simulation_job.rs
@@ -187,7 +187,7 @@ impl SimulationJob {
         for sim_result in new_sim_results {
             trace!(order_id=?sim_result.simulated_order.order.id(),
             sim_duration_mus = sim_result.simulation_time.as_micros(),
-            profit = format_ether(sim_result.simulated_order.sim_value.coinbase_profit), "Order simulated");
+            profit = format_ether(sim_result.simulated_order.sim_value.full_profit_info().coinbase_profit()), "Order simulated");
             self.orders_simulated_ok
                 .accumulate(&sim_result.simulated_order.order);
             if let Some(repl_key) = sim_result.simulated_order.order.replacement_key() {

--- a/crates/rbuilder/src/primitives/fmt.rs
+++ b/crates/rbuilder/src/primitives/fmt.rs
@@ -63,12 +63,21 @@ pub fn write_sim_value<Buffer: Write>(
     std::fmt::write(
         buf,
         format_args!(
-            "coinbase_profit {} mev_gas_price {}",
-            sim_value.coinbase_profit, sim_value.mev_gas_price
+            "full coinbase_profit {} full mev_gas_price {}",
+            sim_value.full_profit_info().coinbase_profit(),
+            sim_value.full_profit_info().mev_gas_price()
+        ),
+    )?;
+    std::fmt::write(
+        buf,
+        format_args!(
+            "non mempool coinbase_profit {} non mempool mev_gas_price {}",
+            sim_value.non_mempool_profit_info().coinbase_profit(),
+            sim_value.non_mempool_profit_info().mev_gas_price()
         ),
     )?;
     buf.write_str(" Kickbacks ")?;
-    for kb in &sim_value.paid_kickbacks {
+    for kb in sim_value.paid_kickbacks() {
         buf.write_str(&format!("{}->{},", kb.0, kb.1))?;
     }
     buf.write_str("\n")

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -1049,26 +1049,16 @@ impl Order {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct SimValue {
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct ProfitInfo {
     /// profit as coinbase delta after executing an Order
-    pub coinbase_profit: U256,
-    pub gas_used: u64,
-    #[serde(default)]
-    pub blob_gas_used: u64,
+    coinbase_profit: U256,
     /// This is computed as coinbase_profit/gas_used so it includes not only gas tip but also payments made directly to coinbase
-    pub mev_gas_price: U256,
-    /// Kickbacks paid during simulation as (receiver, amount)
-    pub paid_kickbacks: Vec<(Address, U256)>,
+    mev_gas_price: U256,
 }
 
-impl SimValue {
-    pub fn new(
-        coinbase_profit: U256,
-        gas_used: u64,
-        blob_gas_used: u64,
-        paid_kickbacks: Vec<(Address, U256)>,
-    ) -> Self {
+impl ProfitInfo {
+    pub fn new(coinbase_profit: U256, gas_used: u64) -> Self {
         let mev_gas_price = if gas_used != 0 {
             coinbase_profit / U256::from(gas_used)
         } else {
@@ -1076,11 +1066,95 @@ impl SimValue {
         };
         Self {
             coinbase_profit,
+            mev_gas_price,
+        }
+    }
+
+    /// For testing specific values ignoring gas.
+    pub fn new_test(coinbase_profit: U256, mev_gas_price: U256) -> Self {
+        Self {
+            coinbase_profit,
+            mev_gas_price,
+        }
+    }
+
+    pub fn coinbase_profit(&self) -> U256 {
+        self.coinbase_profit
+    }
+
+    pub fn mev_gas_price(&self) -> U256 {
+        self.mev_gas_price
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct SimValue {
+    /// ProfitInfo considering profit from all txs on the s/bundles.
+    full_profit_info: ProfitInfo,
+    /// ProfitInfo considering profit only from non mempool txs on the s/bundles.
+    /// For mempool orders it should match ProfitInfo
+    non_mempool_profit_info: ProfitInfo,
+    gas_used: u64,
+    blob_gas_used: u64,
+    /// Kickbacks paid during simulation as (receiver, amount)
+    paid_kickbacks: Vec<(Address, U256)>,
+}
+
+impl SimValue {
+    pub fn new(
+        // full profit
+        full_coinbase_profit: U256,
+        // for s/bundles profit from non-mempool txs.
+        non_mempool_coinbase_profit: U256,
+        gas_used: u64,
+        blob_gas_used: u64,
+        paid_kickbacks: Vec<(Address, U256)>,
+    ) -> Self {
+        Self {
+            full_profit_info: ProfitInfo::new(full_coinbase_profit, gas_used),
+            non_mempool_profit_info: ProfitInfo::new(non_mempool_coinbase_profit, gas_used),
             gas_used,
             blob_gas_used,
-            mev_gas_price,
             paid_kickbacks,
         }
+    }
+
+    /// For testing specific coinbase_profit/mev_gas_price values ignoring gas.
+    pub fn new_test_no_gas(
+        // full profit
+        coinbase_profit: U256,
+        mev_gas_price: U256,
+    ) -> Self {
+        Self {
+            full_profit_info: ProfitInfo::new_test(coinbase_profit, mev_gas_price),
+            non_mempool_profit_info: ProfitInfo::new_test(coinbase_profit, mev_gas_price),
+            ..Default::default()
+        }
+    }
+
+    pub fn full_profit_info(&self) -> &ProfitInfo {
+        &self.full_profit_info
+    }
+
+    pub fn non_mempool_profit_info(&self) -> &ProfitInfo {
+        &self.non_mempool_profit_info
+    }
+
+    pub fn gas_used(&self) -> u64 {
+        self.gas_used
+    }
+
+    pub fn blob_gas_used(&self) -> u64 {
+        self.blob_gas_used
+    }
+
+    pub fn paid_kickbacks(&self) -> &Vec<(Address, U256)> {
+        &self.paid_kickbacks
+    }
+
+    pub fn with_kickbacks(mut self, kickbacks: Vec<(Address, U256)>) -> Self {
+        self.paid_kickbacks = kickbacks;
+        self
     }
 }
 


### PR DESCRIPTION
## 📝 Summary

SimValue now has 2 ProfitInfo instead of the single coinbase_profit/gas_used pair so now we have the full_profit_info (previous coinbase_profit/gas_used) and the new non_mempool_profit_info which excludes mempool txs profits from bundles.
Backwards compatible.
Implementation to detect mempool tx is super simple and heavily assumes that we will always see a mempool tx before a bundle including that tx:
We add a order_input::mempool_txs_detector::ReplaceableOrderStreamSniffer in the orderflow stream that updates the MempoolTxsDetector which is used on SimValue creation to filter mempool txs.

## 💡 Motivation and Context

This will give more info to block building algorithms.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [X] Added tests (if applicable)
