### PR TITLE
Sort by non mempool profit

### DIFF
--- a/crates/rbuilder/src/building/block_orders/mod.rs
+++ b/crates/rbuilder/src/building/block_orders/mod.rs
@@ -131,12 +131,15 @@ pub fn block_orders_from_sim_orders<OrderPriorityType: OrderPriority>(
 mod test {
     use crate::primitives::BundledTxInfo;
 
-    use super::{order_priority::OrderMaxProfitPriority, *};
+    use super::{
+        order_priority::{FullProfitInfoGetter, OrderMaxProfitPriority},
+        *,
+    };
     /// Helper struct for common PrioritizedOrderStore test operations
     /// Works hardcoded on Sorting::MaxProfit since it changes nothing on internal logic
     struct TestContext {
         pub data_gen: TestDataGenerator,
-        pub order_pool: PrioritizedOrderStore<OrderMaxProfitPriority>,
+        pub order_pool: PrioritizedOrderStore<OrderMaxProfitPriority<FullProfitInfoGetter>>,
     }
 
     impl TestContext {
@@ -148,7 +151,10 @@ mod test {
                 nonce.clone(),
                 TestContext {
                     data_gen,
-                    order_pool: PrioritizedOrderStore::<OrderMaxProfitPriority>::new(vec![nonce]),
+                    order_pool:
+                        PrioritizedOrderStore::<OrderMaxProfitPriority<FullProfitInfoGetter>>::new(
+                            vec![nonce],
+                        ),
                 },
             )
         }
@@ -166,9 +172,10 @@ mod test {
                 nonce_2.clone(),
                 TestContext {
                     data_gen,
-                    order_pool: PrioritizedOrderStore::<OrderMaxProfitPriority>::new(vec![
-                        nonce_1, nonce_2,
-                    ]),
+                    order_pool:
+                        PrioritizedOrderStore::<OrderMaxProfitPriority<FullProfitInfoGetter>>::new(
+                            vec![nonce_1, nonce_2],
+                        ),
                 },
             )
         }

--- a/crates/rbuilder/src/building/block_orders/order_priority.rs
+++ b/crates/rbuilder/src/building/block_orders/order_priority.rs
@@ -1,4 +1,4 @@
-use crate::primitives::{SimValue, SimulatedOrder};
+use crate::primitives::{ProfitInfo, SimValue, SimulatedOrder};
 use alloy_primitives::U256;
 use std::{cmp::Ordering, sync::Arc};
 
@@ -17,99 +17,160 @@ fn new_sim_value_too_low(original_sim: U256, new_sim: U256) -> bool {
     new_sim * U256::from(100) < (original_sim * U256::from(MIN_SIM_RESULT_PERCENTAGE))
 }
 
+/// "std::fmt::Debug + Clone + Sync + Send" should not be needed since we never really instantiate one of this (only phantom)
+/// but at some point you decide to let the f*cking compiler win and go on with you life.
+pub trait ProfitInfoGetter: std::fmt::Debug + Clone + Sync + Send {
+    fn get_profit_info(sim_value: &SimValue) -> &ProfitInfo;
+}
+
+#[derive(Debug, Clone)]
+pub struct FullProfitInfoGetter {}
+impl ProfitInfoGetter for FullProfitInfoGetter {
+    fn get_profit_info(sim_value: &SimValue) -> &ProfitInfo {
+        sim_value.full_profit_info()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NonMempoolProfitInfoGetter {}
+impl ProfitInfoGetter for NonMempoolProfitInfoGetter {
+    fn get_profit_info(sim_value: &SimValue) -> &ProfitInfo {
+        sim_value.non_mempool_profit_info()
+    }
+}
+
+/// Creates a OrderPriority named order_priority comparing using all the cmp/next_cmp and adding OrderIDCmp at the end.
+/// The created OrderPriority is generic on <ProfitInfoGetterType: ProfitInfoGetter>.
+/// Usage:
+/// create_order_priority!(NamedPriority((Cmp1,uses_getter/plain),(Cmp2,uses_getter/plain))<simulation_too_low_func>);
+/// CmpN is an struct implementing:
+/// - fn eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool
+/// - fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering
+///
+/// uses_getter: will propagate <ProfitInfoGetterType> to the type instantiation.
+/// plain:  will propagate instantiation CmpN as is.
+/// simulation_too_low_func: fn simulation_too_low_func<ProfitInfoGetterType: ProfitInfoGetter>(original_sim_value: &SimValue,new_sim_value: &SimValue).
+/// simulation_too_low_func must return true if new_sim_value (generated while building a block) is too low compared to original_sim_value (sim on top of block).
 macro_rules! create_order_priority {
-    ($order_priority:ident($cmp:ident $( , $next_cmp:ident )*)<$new_sim_value_too_low_func:ident>) => {
+    ($order_priority:ident(($cmp:ident, $cmp_needs_generic:ident) $( , ($next_cmp:ident,$next_cmp_needs_generic:ident) )*)<$new_sim_value_too_low_func:ident>) => {
         #[derive(Debug, Clone)]
-        pub struct $order_priority {
+        pub struct $order_priority <ProfitInfoGetterType: ProfitInfoGetter> {
             order: Arc<SimulatedOrder>,
+            _phantom:std::marker::PhantomData<ProfitInfoGetterType>,
         }
 
-        impl OrderPriority for $order_priority {
+        impl<ProfitInfoGetterType: ProfitInfoGetter> OrderPriority for $order_priority<ProfitInfoGetterType> {
             fn new(order: Arc<SimulatedOrder>) -> Self {
-                Self { order }
+                Self { order,_phantom: Default::default()}
             }
 
             fn simulation_too_low(
                 original_sim_value: &SimValue,
                 new_sim_value: &SimValue,
             ) -> bool {
-                $new_sim_value_too_low_func(
+                $new_sim_value_too_low_func::<ProfitInfoGetterType>(
                     original_sim_value,
                     new_sim_value,
                 )
             }
         }
 
-        impl PartialEq for $order_priority {
+        impl<ProfitInfoGetterType: ProfitInfoGetter> PartialEq for $order_priority<ProfitInfoGetterType> {
             fn eq(&self, other: &Self) -> bool {
-                $cmp::eq(&self.order, &other.order)
+                <$crate::add_getter!($cmp,$cmp_needs_generic)>::eq(&self.order, &other.order)
+                $( && <$crate::add_getter!($next_cmp,$next_cmp_needs_generic)>::eq(&self.order, &other.order) )*
+                && OrderIDCmp::eq(&self.order, &other.order)
             }
         }
 
-        impl Eq for $order_priority {}
+        impl<ProfitInfoGetterType: ProfitInfoGetter> Eq for $order_priority<ProfitInfoGetterType> {}
 
-        impl PartialOrd for $order_priority {
+        impl<ProfitInfoGetterType: ProfitInfoGetter> PartialOrd for $order_priority<ProfitInfoGetterType> {
             fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
                 Some(self.cmp(other))
             }
         }
 
-        impl Ord for $order_priority {
+        impl<ProfitInfoGetterType: ProfitInfoGetter> Ord for $order_priority<ProfitInfoGetterType> {
             fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-                $cmp::cmp(&self.order, &other.order)
-                    $( .then_with(|| $next_cmp::cmp(&self.order, &other.order)) )*
+                <$crate::add_getter!($cmp,$cmp_needs_generic)>::cmp(&self.order, &other.order)
+                    $( .then_with(|| <$crate::add_getter!($next_cmp,$next_cmp_needs_generic)>::cmp(&self.order, &other.order)) )*
+                    .then_with(||OrderIDCmp::cmp(&self.order, &other.order))
             }
         }
     };
 }
 
+// Simplified helper macro with hard-coded ProfitInfoGetterType
+#[macro_export]
+macro_rules! add_getter {
+    // If $needs_generic is "needs", apply ProfitInfoGetterType
+    ($type:ident, uses_getter) => {
+        $type<ProfitInfoGetterType>
+    };
+    // Otherwise, use the type as is
+    ($type:ident, plain) => {
+        $type
+    };
+}
+
 /// MevGasPrice
-struct OrderMevGasPricePriorityCmp {}
-impl OrderMevGasPricePriorityCmp {
+struct OrderMevGasPricePriorityCmp<ProfitInfoGetterType: ProfitInfoGetter>(
+    std::marker::PhantomData<ProfitInfoGetterType>,
+);
+
+impl<ProfitInfoGetterType: ProfitInfoGetter> OrderMevGasPricePriorityCmp<ProfitInfoGetterType> {
     #[inline]
     fn eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
-        a.sim_value.full_profit_info().mev_gas_price()
-            == b.sim_value.full_profit_info().mev_gas_price()
+        ProfitInfoGetterType::get_profit_info(&a.sim_value).mev_gas_price()
+            == ProfitInfoGetterType::get_profit_info(&b.sim_value).mev_gas_price()
     }
 
     #[inline]
     fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
-        a.sim_value
-            .full_profit_info()
+        ProfitInfoGetterType::get_profit_info(&a.sim_value)
             .mev_gas_price()
-            .cmp(&b.sim_value.full_profit_info().mev_gas_price())
+            .cmp(&ProfitInfoGetterType::get_profit_info(&b.sim_value).mev_gas_price())
     }
 }
 #[inline]
-fn simulation_too_low_gas_price(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool {
+fn simulation_too_low_gas_price<ProfitInfoGetterType: ProfitInfoGetter>(
+    original_sim_value: &SimValue,
+    new_sim_value: &SimValue,
+) -> bool {
     new_sim_value_too_low(
-        original_sim_value.full_profit_info().mev_gas_price(),
-        new_sim_value.full_profit_info().mev_gas_price(),
+        ProfitInfoGetterType::get_profit_info(original_sim_value).mev_gas_price(),
+        ProfitInfoGetterType::get_profit_info(new_sim_value).mev_gas_price(),
     )
 }
 
 /// MaxProfit
-struct OrderMaxProfitPriorityCmp {}
-impl OrderMaxProfitPriorityCmp {
+struct OrderMaxProfitPriorityCmp<ProfitInfoGetterType: ProfitInfoGetter>(
+    std::marker::PhantomData<ProfitInfoGetterType>,
+);
+
+impl<ProfitInfoGetterType: ProfitInfoGetter> OrderMaxProfitPriorityCmp<ProfitInfoGetterType> {
     #[inline]
     fn eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
-        a.sim_value.full_profit_info().coinbase_profit()
-            == b.sim_value.full_profit_info().coinbase_profit()
+        ProfitInfoGetterType::get_profit_info(&a.sim_value).coinbase_profit()
+            == ProfitInfoGetterType::get_profit_info(&b.sim_value).coinbase_profit()
     }
 
     #[inline]
     fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
-        a.sim_value
-            .full_profit_info()
+        ProfitInfoGetterType::get_profit_info(&a.sim_value)
             .coinbase_profit()
-            .cmp(&b.sim_value.full_profit_info().coinbase_profit())
+            .cmp(&ProfitInfoGetterType::get_profit_info(&b.sim_value).coinbase_profit())
     }
 }
 #[inline]
-fn simulation_too_low_profit(original_sim_value: &SimValue, new_sim_value: &SimValue) -> bool {
+fn simulation_too_low_profit<ProfitInfoGetterType: ProfitInfoGetter>(
+    original_sim_value: &SimValue,
+    new_sim_value: &SimValue,
+) -> bool {
     new_sim_value_too_low(
-        original_sim_value.full_profit_info().coinbase_profit(),
-        new_sim_value.full_profit_info().coinbase_profit(),
+        ProfitInfoGetterType::get_profit_info(original_sim_value).coinbase_profit(),
+        ProfitInfoGetterType::get_profit_info(new_sim_value).coinbase_profit(),
     )
 }
 
@@ -174,10 +235,288 @@ impl OrderIDCmp {
     fn cmp(a: &SimulatedOrder, b: &SimulatedOrder) -> Ordering {
         a.id().cmp(&b.id())
     }
+    #[inline]
+    fn eq(a: &SimulatedOrder, b: &SimulatedOrder) -> bool {
+        a.id().eq(&b.id())
+    }
 }
 
-create_order_priority!(OrderMevGasPricePriority(OrderMevGasPricePriorityCmp, OrderIDCmp)<simulation_too_low_gas_price>);
-create_order_priority!(OrderMaxProfitPriority(OrderMaxProfitPriorityCmp, OrderIDCmp)<simulation_too_low_profit>);
-create_order_priority!(OrderTypePriority(OrderTypeCmp,OrderMaxProfitPriorityCmp, OrderIDCmp)<simulation_too_low_profit>);
-create_order_priority!(OrderLengthThreeMaxProfitPriority(OrderLengthThreeCmp,OrderMaxProfitPriorityCmp, OrderIDCmp)<simulation_too_low_profit>);
-create_order_priority!(OrderLengthThreeMevGasPricePriority(OrderLengthThreeCmp,OrderMevGasPricePriorityCmp, OrderIDCmp)<simulation_too_low_profit>);
+create_order_priority!(OrderMevGasPricePriority((OrderMevGasPricePriorityCmp,uses_getter))<simulation_too_low_gas_price>);
+create_order_priority!(OrderMaxProfitPriority((OrderMaxProfitPriorityCmp,uses_getter))<simulation_too_low_profit>);
+create_order_priority!(OrderTypePriority((OrderTypeCmp,plain),(OrderMaxProfitPriorityCmp,uses_getter))<simulation_too_low_profit>);
+create_order_priority!(OrderLengthThreeMaxProfitPriority((OrderLengthThreeCmp,plain),(OrderMaxProfitPriorityCmp,uses_getter))<simulation_too_low_profit>);
+create_order_priority!(OrderLengthThreeMevGasPricePriority((OrderLengthThreeCmp,plain),(OrderMevGasPricePriorityCmp,uses_getter))<simulation_too_low_profit>);
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use alloy_primitives::U256;
+
+    use crate::{
+        building::order_priority::NonMempoolProfitInfoGetter,
+        primitives::{AccountNonce, BundledTxInfo, Order, SimValue, SimulatedOrder},
+    };
+
+    use super::{
+        FullProfitInfoGetter, OrderLengthThreeMaxProfitPriority,
+        OrderLengthThreeMevGasPricePriority, OrderMaxProfitPriority, OrderMevGasPricePriority,
+        OrderPriority, OrderTypePriority,
+    };
+
+    enum OrderType {
+        MempoolTx,
+        BundleLength1,
+        BundleLength3,
+    }
+
+    #[derive(Default)]
+    struct TestContext {
+        data_gen: crate::primitives::TestDataGenerator,
+    }
+
+    impl TestContext {
+        /// dummy
+        fn create_nonce(&mut self) -> AccountNonce {
+            AccountNonce {
+                nonce: Default::default(),
+                account: self.data_gen.base.create_address(),
+            }
+        }
+
+        /// Super dummy order only used to check the type an length.
+        fn create_order(&mut self, order_type: OrderType) -> Order {
+            let nonce = self.create_nonce();
+            match order_type {
+                OrderType::MempoolTx => self.data_gen.create_tx_order(nonce),
+                OrderType::BundleLength1 => self.data_gen.create_bundle_multi_tx_order(
+                    Default::default(),
+                    &[BundledTxInfo {
+                        nonce,
+                        optional: true,
+                    }],
+                    None,
+                ),
+                OrderType::BundleLength3 => self.data_gen.create_bundle_multi_tx_order(
+                    Default::default(),
+                    &[
+                        BundledTxInfo {
+                            nonce: nonce.clone(),
+                            optional: true,
+                        },
+                        BundledTxInfo {
+                            nonce: nonce.clone(),
+                            optional: true,
+                        },
+                        BundledTxInfo {
+                            nonce,
+                            optional: true,
+                        },
+                    ],
+                    None,
+                ),
+            }
+        }
+
+        /// Creates a SimulatedOrder with synthetic SimValue and an order of a specific type.
+        /// SimValue is not related to the real order execution (there is no chain!!).
+        fn create_sim_order(
+            &mut self,
+            full_profit: u64,
+            non_mempool_profit: u64,
+            gas: u64,
+            order_type: OrderType,
+        ) -> Arc<SimulatedOrder> {
+            Arc::new(SimulatedOrder {
+                order: self.create_order(order_type),
+                sim_value: SimValue::new_test(
+                    U256::from(full_profit),
+                    U256::from(non_mempool_profit),
+                    gas,
+                ),
+                used_state_trace: None,
+            })
+        }
+    }
+
+    const HIGH_PROFIT: u64 = 10_000;
+    const MID_PROFIT: u64 = 5_000;
+    const LOW_PROFIT: u64 = 1_000;
+    const DONT_CARE_GAS: u64 = 100;
+
+    const NORMAL_GAS: u64 = 100;
+    /// this gas makes any profit win by mev gas price (LOW_PROFIT/SUPER_LOW_GAS will win to HIGH_PROFIT/NORMAL_GAS)
+    const SUPER_LOW_GAS: u64 = 1;
+
+    fn assert_is_less<OrderPriorityType: OrderPriority>(
+        sim_order_a: &Arc<SimulatedOrder>,
+        sim_order_b: &Arc<SimulatedOrder>,
+    ) {
+        assert!(
+            OrderPriorityType::new(sim_order_a.clone())
+                < OrderPriorityType::new(sim_order_b.clone())
+        );
+    }
+
+    /// Check some orders involving NonMempoolProfitInfoGetter/FullProfitInfoGetter
+    #[test]
+    fn price_info_getter() {
+        let mut ctx = TestContext::default();
+        let sim_full_high_non_mempool_low =
+            ctx.create_sim_order(HIGH_PROFIT, LOW_PROFIT, DONT_CARE_GAS, OrderType::MempoolTx);
+        let sim_non_mempool_high_full_low =
+            ctx.create_sim_order(LOW_PROFIT, HIGH_PROFIT, DONT_CARE_GAS, OrderType::MempoolTx);
+        assert_is_less::<OrderMaxProfitPriority<NonMempoolProfitInfoGetter>>(
+            &sim_full_high_non_mempool_low,
+            &sim_non_mempool_high_full_low,
+        );
+        assert_is_less::<OrderMaxProfitPriority<FullProfitInfoGetter>>(
+            &sim_non_mempool_high_full_low,
+            &sim_full_high_non_mempool_low,
+        );
+        assert_is_less::<OrderMevGasPricePriority<NonMempoolProfitInfoGetter>>(
+            &sim_full_high_non_mempool_low,
+            &sim_non_mempool_high_full_low,
+        );
+        assert_is_less::<OrderMevGasPricePriority<FullProfitInfoGetter>>(
+            &sim_non_mempool_high_full_low,
+            &sim_full_high_non_mempool_low,
+        );
+    }
+
+    /// OrderMevGasPricePriority: Check gas price is not confused by profit.
+    #[test]
+    fn gas_price() {
+        let mut ctx = TestContext::default();
+        let sim_high_gas_price_low_profit =
+            ctx.create_sim_order(LOW_PROFIT, LOW_PROFIT, SUPER_LOW_GAS, OrderType::MempoolTx);
+        let sim_high_profit_low_gas_price =
+            ctx.create_sim_order(HIGH_PROFIT, HIGH_PROFIT, NORMAL_GAS, OrderType::MempoolTx);
+        assert_is_less::<OrderMevGasPricePriority<FullProfitInfoGetter>>(
+            &sim_high_profit_low_gas_price,
+            &sim_high_gas_price_low_profit,
+        );
+    }
+
+    /// OrderTypePriority: bundles wins to mempool
+    #[test]
+    fn order_type() {
+        let mut ctx = TestContext::default();
+        let sim_tx_high = ctx.create_sim_order(
+            HIGH_PROFIT,
+            HIGH_PROFIT,
+            DONT_CARE_GAS,
+            OrderType::MempoolTx,
+        );
+        let sim_tx_low =
+            ctx.create_sim_order(LOW_PROFIT, LOW_PROFIT, DONT_CARE_GAS, OrderType::MempoolTx);
+
+        let sim_bundle_mid = ctx.create_sim_order(
+            MID_PROFIT,
+            MID_PROFIT,
+            DONT_CARE_GAS,
+            OrderType::BundleLength1,
+        );
+        let sim_bundle_low = ctx.create_sim_order(
+            LOW_PROFIT,
+            LOW_PROFIT,
+            DONT_CARE_GAS,
+            OrderType::BundleLength1,
+        );
+        assert_is_less::<OrderTypePriority<FullProfitInfoGetter>>(&sim_tx_high, &sim_bundle_mid);
+        // Tie bundles
+        assert_is_less::<OrderTypePriority<FullProfitInfoGetter>>(&sim_bundle_low, &sim_bundle_mid);
+        // Tie txs
+        assert_is_less::<OrderTypePriority<FullProfitInfoGetter>>(&sim_tx_low, &sim_tx_high);
+    }
+
+    /// OrderLengthThreeMaxProfitPriority: size 3 before size < 3 (even if < 3 has good profit)
+    #[test]
+    fn order_length_three_max_profit_priority() {
+        let mut ctx = TestContext::default();
+        let sim_size_1_high = ctx.create_sim_order(
+            HIGH_PROFIT,
+            HIGH_PROFIT,
+            DONT_CARE_GAS,
+            OrderType::BundleLength1,
+        );
+
+        let sim_size_1_low = ctx.create_sim_order(
+            LOW_PROFIT,
+            LOW_PROFIT,
+            DONT_CARE_GAS,
+            OrderType::BundleLength1,
+        );
+
+        let sim_size_3_mid = ctx.create_sim_order(
+            MID_PROFIT,
+            MID_PROFIT,
+            DONT_CARE_GAS,
+            OrderType::BundleLength3,
+        );
+        let sim_size_3_low = ctx.create_sim_order(
+            LOW_PROFIT,
+            LOW_PROFIT,
+            DONT_CARE_GAS,
+            OrderType::BundleLength3,
+        );
+
+        assert_is_less::<OrderLengthThreeMaxProfitPriority<FullProfitInfoGetter>>(
+            &sim_size_1_high,
+            &sim_size_3_low,
+        );
+
+        // Tie on size 3, wins profit
+        assert_is_less::<OrderLengthThreeMaxProfitPriority<FullProfitInfoGetter>>(
+            &sim_size_3_low,
+            &sim_size_3_mid,
+        );
+
+        // Tie on size 1, wins profit
+        assert_is_less::<OrderLengthThreeMaxProfitPriority<FullProfitInfoGetter>>(
+            &sim_size_1_low,
+            &sim_size_1_high,
+        );
+    }
+
+    /// OrderLengthThreeMevGasPricePriority
+    #[test]
+    fn order_length_three_mev_gas_price_priority() {
+        let mut ctx = TestContext::default();
+        let sim_size_1_high = ctx.create_sim_order(
+            MID_PROFIT,
+            MID_PROFIT,
+            SUPER_LOW_GAS,
+            OrderType::BundleLength1,
+        );
+
+        let sim_size_1_low =
+            ctx.create_sim_order(LOW_PROFIT, LOW_PROFIT, NORMAL_GAS, OrderType::BundleLength1);
+
+        let sim_size_3_mid = ctx.create_sim_order(
+            LOW_PROFIT,
+            LOW_PROFIT,
+            SUPER_LOW_GAS,
+            OrderType::BundleLength3,
+        );
+        let sim_size_3_low =
+            ctx.create_sim_order(LOW_PROFIT, LOW_PROFIT, NORMAL_GAS, OrderType::BundleLength3);
+
+        assert_is_less::<OrderLengthThreeMevGasPricePriority<FullProfitInfoGetter>>(
+            &sim_size_1_high,
+            &sim_size_3_low,
+        );
+
+        // Tie on size 3, wins profit
+        assert_is_less::<OrderLengthThreeMevGasPricePriority<FullProfitInfoGetter>>(
+            &sim_size_3_low,
+            &sim_size_3_mid,
+        );
+
+        // Tie on size 1, wins profit
+        assert_is_less::<OrderLengthThreeMevGasPricePriority<FullProfitInfoGetter>>(
+            &sim_size_1_low,
+            &sim_size_1_high,
+        );
+    }
+}

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -57,6 +57,9 @@ pub struct OrderingBuilderConfig {
     /// Amount of time allocated for EVM execution while building block.
     #[serde(default)]
     pub build_duration_deadline_ms: Option<u64>,
+    #[serde(default)]
+    /// Use SimValue::non_mempool_profit_info instead of full_profit_info when comparing Orders.
+    pub ignore_mempool_profit_on_bundles: bool,
 }
 
 impl OrderingBuilderConfig {
@@ -403,7 +406,9 @@ fn simulation_too_low<OrderPriorityType: OrderPriority>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::building::order_priority::{OrderMaxProfitPriority, OrderMevGasPricePriority};
+    use crate::building::order_priority::{
+        FullProfitInfoGetter, OrderMaxProfitPriority, OrderMevGasPricePriority,
+    };
     use alloy_primitives::U256;
 
     #[test]
@@ -413,19 +418,31 @@ mod tests {
 
         // Lower than 95% of the original value
         assert!(
-            simulation_too_low::<OrderMaxProfitPriority>(sim_result, inplace_sim_result).is_err()
+            simulation_too_low::<OrderMaxProfitPriority::<FullProfitInfoGetter>>(
+                sim_result,
+                inplace_sim_result
+            )
+            .is_err()
         );
 
         // Equal to original value
         let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(100), U256::from(0));
         assert!(
-            simulation_too_low::<OrderMaxProfitPriority>(sim_result, inplace_sim_result).is_ok()
+            simulation_too_low::<OrderMaxProfitPriority::<FullProfitInfoGetter>>(
+                sim_result,
+                inplace_sim_result
+            )
+            .is_ok()
         );
 
         // Higher than original value
         let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(105), U256::from(0));
         assert!(
-            simulation_too_low::<OrderMaxProfitPriority>(sim_result, inplace_sim_result).is_ok()
+            simulation_too_low::<OrderMaxProfitPriority::<FullProfitInfoGetter>>(
+                sim_result,
+                inplace_sim_result
+            )
+            .is_ok()
         );
     }
 
@@ -436,19 +453,31 @@ mod tests {
         let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(0), U256::from(94));
 
         assert!(
-            simulation_too_low::<OrderMevGasPricePriority>(sim_result, inplace_sim_result).is_err()
+            simulation_too_low::<OrderMevGasPricePriority::<FullProfitInfoGetter>>(
+                sim_result,
+                inplace_sim_result
+            )
+            .is_err()
         );
 
         // Equal to original value
         let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(0), U256::from(100));
         assert!(
-            simulation_too_low::<OrderMevGasPricePriority>(sim_result, inplace_sim_result).is_ok()
+            simulation_too_low::<OrderMevGasPricePriority::<FullProfitInfoGetter>>(
+                sim_result,
+                inplace_sim_result
+            )
+            .is_ok()
         );
 
         // Higher than original value
         let inplace_sim_result = &SimValue::new_test_no_gas(U256::from(0), U256::from(105));
         assert!(
-            simulation_too_low::<OrderMevGasPricePriority>(sim_result, inplace_sim_result).is_ok()
+            simulation_too_low::<OrderMevGasPricePriority::<FullProfitInfoGetter>>(
+                sim_result,
+                inplace_sim_result
+            )
+            .is_ok()
         );
     }
 }

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -22,7 +22,7 @@ use alloy_eips::{
     merge::BEACON_NONCE,
 };
 use alloy_evm::{block::system_calls::SystemCaller, env::EvmEnv, eth::eip6110};
-use alloy_primitives::{utils::format_ether, Address, Bytes, B256, I256, U256};
+use alloy_primitives::{Address, Bytes, B256, I256, U256};
 use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
 use cached_reads::{LocalCachedReads, SharedCachedReads};
 use evm::EthCachedEvmFactory;

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -950,7 +950,7 @@ pub fn create_sim_value(
             .filter(|tx_info| !mempool_detector.is_mempool(&tx_info.tx))
             .map(|tx_info| tx_info.coinbase_profit)
             .sum::<I256>();
-        if non_mempool_coinbase_profit.is_positive() {
+        if non_mempool_coinbase_profit.is_zero() || non_mempool_coinbase_profit.is_positive() {
             non_mempool_coinbase_profit.unsigned_abs()
         } else {
             error!(

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -953,9 +953,7 @@ pub fn create_sim_value(
         if non_mempool_coinbase_profit.is_zero() || non_mempool_coinbase_profit.is_positive() {
             non_mempool_coinbase_profit.unsigned_abs()
         } else {
-            error!(
-            non_mempool_coinbase_profit = format_ether(non_mempool_coinbase_profit),
-            "Non mempool orders have always positive profit but a negative value was found on a OrderOk");
+            // This could be a bundle which was positive thanks to the inclusion of mempool txs.
             U256::ZERO
         }
     };

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -25,8 +25,9 @@ use crate::{
             BacktestSimulateBlockInput, Block, BlockBuildingAlgorithm,
         },
         order_priority::{
-            OrderLengthThreeMaxProfitPriority, OrderLengthThreeMevGasPricePriority,
-            OrderMaxProfitPriority, OrderMevGasPricePriority, OrderTypePriority,
+            FullProfitInfoGetter, NonMempoolProfitInfoGetter, OrderLengthThreeMaxProfitPriority,
+            OrderLengthThreeMevGasPricePriority, OrderMaxProfitPriority, OrderMevGasPricePriority,
+            OrderTypePriority, ProfitInfoGetter,
         },
         Sorting,
     },
@@ -437,41 +438,59 @@ impl LiveBuilderConfig for Config {
     {
         let builder_cfg = self.builder(building_algorithm_name)?;
         match builder_cfg.builder {
-            SpecificBuilderConfig::OrderingBuilder(config) => match config.sorting {
-                Sorting::MevGasPrice => {
-                    crate::building::builders::ordering_builder::backtest_simulate_block::<
-                        P,
-                        OrderMevGasPricePriority,
-                    >(config, input)
+            SpecificBuilderConfig::OrderingBuilder(config) => {
+                if config.ignore_mempool_profit_on_bundles {
+                    build_backtest_block_ordering_builder::<P, NonMempoolProfitInfoGetter>(
+                        config, input,
+                    )
+                } else {
+                    build_backtest_block_ordering_builder::<P, FullProfitInfoGetter>(config, input)
                 }
-                Sorting::MaxProfit => {
-                    crate::building::builders::ordering_builder::backtest_simulate_block::<
-                        P,
-                        OrderMaxProfitPriority,
-                    >(config, input)
-                }
-                Sorting::TypeMaxProfit => {
-                    crate::building::builders::ordering_builder::backtest_simulate_block::<
-                        P,
-                        OrderTypePriority,
-                    >(config, input)
-                }
-                Sorting::LengthThreeMaxProfit => {
-                    crate::building::builders::ordering_builder::backtest_simulate_block::<
-                        P,
-                        OrderLengthThreeMaxProfitPriority,
-                    >(config, input)
-                }
-                Sorting::LengthThreeMevGasPrice => {
-                    crate::building::builders::ordering_builder::backtest_simulate_block::<
-                        P,
-                        OrderLengthThreeMevGasPricePriority,
-                    >(config, input)
-                }
-            },
+            }
             SpecificBuilderConfig::ParallelBuilder(config) => {
                 parallel_build_backtest::<P>(input, config)
             }
+        }
+    }
+}
+
+fn build_backtest_block_ordering_builder<P, ProfitInfoGetterType: ProfitInfoGetter + 'static>(
+    config: OrderingBuilderConfig,
+    input: BacktestSimulateBlockInput<'_, P>,
+) -> eyre::Result<Block>
+where
+    P: StateProviderFactory + Clone + 'static,
+{
+    match config.sorting {
+        Sorting::MevGasPrice => {
+            crate::building::builders::ordering_builder::backtest_simulate_block::<
+                P,
+                OrderMevGasPricePriority<ProfitInfoGetterType>,
+            >(config, input)
+        }
+        Sorting::MaxProfit => {
+            crate::building::builders::ordering_builder::backtest_simulate_block::<
+                P,
+                OrderMaxProfitPriority<ProfitInfoGetterType>,
+            >(config, input)
+        }
+        Sorting::TypeMaxProfit => {
+            crate::building::builders::ordering_builder::backtest_simulate_block::<
+                P,
+                OrderTypePriority<ProfitInfoGetterType>,
+            >(config, input)
+        }
+        Sorting::LengthThreeMaxProfit => {
+            crate::building::builders::ordering_builder::backtest_simulate_block::<
+                P,
+                OrderLengthThreeMaxProfitPriority<ProfitInfoGetterType>,
+            >(config, input)
+        }
+        Sorting::LengthThreeMevGasPrice => {
+            crate::building::builders::ordering_builder::backtest_simulate_block::<
+                P,
+                OrderLengthThreeMevGasPricePriority<ProfitInfoGetterType>,
+            >(config, input)
         }
     }
 }
@@ -509,6 +528,7 @@ impl Default for Config {
                         drop_failed_orders: true,
                         coinbase_payment: false,
                         build_duration_deadline_ms: None,
+                        ignore_mempool_profit_on_bundles: false,
                     }),
                 },
                 BuilderConfig {
@@ -520,6 +540,7 @@ impl Default for Config {
                         drop_failed_orders: true,
                         coinbase_payment: false,
                         build_duration_deadline_ms: None,
+                        ignore_mempool_profit_on_bundles: false,
                     }),
                 },
                 BuilderConfig {
@@ -531,6 +552,7 @@ impl Default for Config {
                         drop_failed_orders: true,
                         coinbase_payment: false,
                         build_duration_deadline_ms: Some(30),
+                        ignore_mempool_profit_on_bundles: false,
                     }),
                 },
                 BuilderConfig {
@@ -542,6 +564,7 @@ impl Default for Config {
                         drop_failed_orders: true,
                         coinbase_payment: true,
                         build_duration_deadline_ms: None,
+                        ignore_mempool_profit_on_bundles: false,
                     }),
                 },
                 BuilderConfig {
@@ -553,6 +576,7 @@ impl Default for Config {
                         drop_failed_orders: false,
                         coinbase_payment: false,
                         build_duration_deadline_ms: None,
+                        ignore_mempool_profit_on_bundles: false,
                     }),
                 },
                 BuilderConfig {
@@ -632,26 +656,42 @@ where
     P: StateProviderFactory + Clone + 'static,
 {
     match cfg.builder {
-        SpecificBuilderConfig::OrderingBuilder(order_cfg) => match order_cfg.sorting {
-            Sorting::MevGasPrice => Arc::new(
-                OrderingBuildingAlgorithm::<OrderMevGasPricePriority>::new(order_cfg, cfg.name),
-            ),
-            Sorting::MaxProfit => Arc::new(
-                OrderingBuildingAlgorithm::<OrderMaxProfitPriority>::new(order_cfg, cfg.name),
-            ),
-            Sorting::TypeMaxProfit => Arc::new(
-                OrderingBuildingAlgorithm::<OrderTypePriority>::new(order_cfg, cfg.name),
-            ),
-            Sorting::LengthThreeMaxProfit => Arc::new(OrderingBuildingAlgorithm::<
-                OrderLengthThreeMaxProfitPriority,
-            >::new(order_cfg, cfg.name)),
-            Sorting::LengthThreeMevGasPrice => Arc::new(OrderingBuildingAlgorithm::<
-                OrderLengthThreeMevGasPricePriority,
-            >::new(order_cfg, cfg.name)),
-        },
+        SpecificBuilderConfig::OrderingBuilder(order_cfg) => {
+            if order_cfg.ignore_mempool_profit_on_bundles {
+                create_ordering_builder::<P, NonMempoolProfitInfoGetter>(order_cfg, cfg.name)
+            } else {
+                create_ordering_builder::<P, FullProfitInfoGetter>(order_cfg, cfg.name)
+            }
+        }
         SpecificBuilderConfig::ParallelBuilder(parallel_cfg) => {
             Arc::new(ParallelBuildingAlgorithm::new(parallel_cfg, cfg.name))
         }
+    }
+}
+
+fn create_ordering_builder<P, ProfitInfoGetterType: ProfitInfoGetter + 'static>(
+    cfg: OrderingBuilderConfig,
+    name: String,
+) -> Arc<dyn BlockBuildingAlgorithm<P>>
+where
+    P: StateProviderFactory + Clone + 'static,
+{
+    match cfg.sorting {
+        Sorting::MevGasPrice => Arc::new(OrderingBuildingAlgorithm::<
+            OrderMevGasPricePriority<ProfitInfoGetterType>,
+        >::new(cfg, name)),
+        Sorting::MaxProfit => Arc::new(OrderingBuildingAlgorithm::<
+            OrderMaxProfitPriority<ProfitInfoGetterType>,
+        >::new(cfg, name)),
+        Sorting::TypeMaxProfit => Arc::new(OrderingBuildingAlgorithm::<
+            OrderTypePriority<ProfitInfoGetterType>,
+        >::new(cfg, name)),
+        Sorting::LengthThreeMaxProfit => Arc::new(OrderingBuildingAlgorithm::<
+            OrderLengthThreeMaxProfitPriority<ProfitInfoGetterType>,
+        >::new(cfg, name)),
+        Sorting::LengthThreeMevGasPrice => Arc::new(OrderingBuildingAlgorithm::<
+            OrderLengthThreeMevGasPricePriority<ProfitInfoGetterType>,
+        >::new(cfg, name)),
     }
 }
 

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -454,7 +454,7 @@ impl LiveBuilderConfig for Config {
     }
 }
 
-fn build_backtest_block_ordering_builder<P, ProfitInfoGetterType: ProfitInfoGetter + 'static>(
+pub fn build_backtest_block_ordering_builder<P, ProfitInfoGetterType: ProfitInfoGetter + 'static>(
     config: OrderingBuilderConfig,
     input: BacktestSimulateBlockInput<'_, P>,
 ) -> eyre::Result<Block>

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -1120,14 +1120,20 @@ impl SimValue {
     }
 
     /// For testing specific coinbase_profit/mev_gas_price values ignoring gas.
-    pub fn new_test_no_gas(
-        // full profit
-        coinbase_profit: U256,
-        mev_gas_price: U256,
-    ) -> Self {
+    /// coinbase_profit is the same for full_profit_info/non_mempool_profit_info
+    pub fn new_test_no_gas(coinbase_profit: U256, mev_gas_price: U256) -> Self {
         Self {
             full_profit_info: ProfitInfo::new_test(coinbase_profit, mev_gas_price),
             non_mempool_profit_info: ProfitInfo::new_test(coinbase_profit, mev_gas_price),
+            ..Default::default()
+        }
+    }
+
+    pub fn new_test(full_coinbase_profit: U256, non_mempool_profit: U256, gas_used: u64) -> Self {
+        Self {
+            full_profit_info: ProfitInfo::new(full_coinbase_profit, gas_used),
+            non_mempool_profit_info: ProfitInfo::new(non_mempool_profit, gas_used),
+            gas_used,
             ..Default::default()
         }
     }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -90,6 +90,7 @@ Each instantiated algorithm starts with:
 |drop_failed_orders|mandatory bool| if a tx fails in a block building iteration it's dropped so next iterations will not use it.||
 |coinbase_payment|optional bool | Start the first iteration of block building using direct pay to fee_recipient (validator)<br>This mode saves gas on the payout tx from builder to validator but disables mev-share and profit taking.|false|
 |build_duration_deadline_ms|optional int| Amount of time allocated for EVM execution while building block. If None it only stops when it tried all orders.| None|
+|ignore_mempool_profit_on_bundles|bool|When computing profit to prioritize orders on s/bundles any profit from a mempool tx will be ignored.|false|
 
 ### Fields for algo="parallel-builder"
 


### PR DESCRIPTION
## 📝 Summary

Add a new flag to ordering builder to ignore tx profit on s/bundles.

## 💡 Motivation and Context

Some searchers are adding mempool txs to bundles to fake profit and position better on the ordering.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [X] Added tests (if applicable)
