### PR TITLE
Feed mempool_tx_detector on backtesting

### DIFF
--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -97,6 +97,9 @@ where
         .iter()
         .map(|order| order.order.clone())
         .collect::<Vec<_>>();
+    for order in &orders {
+        ctx.mempool_tx_detector.add_tx(order);
+    }
 
     let (sim_orders, sim_errors) =
         simulate_all_orders_with_sim_tree(provider, &ctx, &orders, false)?;


### PR DESCRIPTION
## 📝 Summary

It was giving the same results since mempool_tx_detector  wasn't aware of the orders.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
