### PR TITLE
New flag to disable dangerous stuff on parallel builder

### DIFF
--- a/config-backtest-example.toml
+++ b/config-backtest-example.toml
@@ -33,3 +33,4 @@ name = "parallel"
 algo = "parallel-builder"
 discard_txs = true
 num_threads = 25
+safe_sorting_only = false

--- a/config-live-example.toml
+++ b/config-live-example.toml
@@ -61,3 +61,4 @@ name = "parallel"
 algo = "parallel-builder"
 discard_txs = true
 num_threads = 25
+safe_sorting_only = false

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_resolving_pool.rs
@@ -28,15 +28,18 @@ pub struct ConflictResolvingPool<P> {
     provider: P,
     simulation_cache: Arc<SharedSimulationCache>,
     num_threads: usize,
+    safe_sorting_only: bool,
 }
 
 impl<P> ConflictResolvingPool<P>
 where
     P: StateProviderFactory + Clone + 'static,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         num_threads: usize,
         task_queue: TaskQueue,
+        safe_sorting_only: bool,
         group_result_sender: std_mpsc::Sender<ConflictResolutionResultPerGroup>,
         cancellation_token: CancellationToken,
         ctx: BlockBuildingContext,
@@ -46,6 +49,7 @@ where
         Self {
             task_queue,
             group_result_sender,
+            safe_sorting_only,
             cancellation_token,
             ctx,
             provider,
@@ -158,7 +162,7 @@ where
     ) -> Vec<(GroupId, (ResolutionResult, ConflictGroup))> {
         let mut results = Vec::new();
         for new_group in new_groups {
-            let tasks = get_tasks_for_group(&new_group, TaskPriority::High);
+            let tasks = get_tasks_for_group(&new_group, TaskPriority::High, self.safe_sorting_only);
             for task in tasks {
                 let simulation_cache = Arc::clone(&simulation_cache);
                 let result = Self::process_task(

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_task_generator.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_task_generator.rs
@@ -519,7 +519,7 @@ mod tests {
 
     fn create_task_generator() -> ConflictTaskGenerator {
         let (sender, _receiver) = mpsc::channel();
-        ConflictTaskGenerator::new(create_task_queue(), sender)
+        ConflictTaskGenerator::new(false, create_task_queue(), sender)
     }
 
     #[test]

--- a/crates/rbuilder/src/building/builders/parallel_builder/conflict_task_generator.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/conflict_task_generator.rs
@@ -22,6 +22,7 @@ pub struct ConflictTaskGenerator {
     existing_groups: HashMap<GroupId, ConflictGroup>,
     task_queue: TaskQueue,
     group_result_sender: std_mpsc::Sender<ConflictResolutionResultPerGroup>,
+    safe_sorting_only: bool,
 }
 
 impl ConflictTaskGenerator {
@@ -32,10 +33,12 @@ impl ConflictTaskGenerator {
     /// * `task_queue` - The queue to store the generated tasks.
     /// * `group_result_sender` - The sender to send the results of the conflict resolution.
     pub fn new(
+        safe_sorting_only: bool,
         task_queue: TaskQueue,
         group_result_sender: std_mpsc::Sender<ConflictResolutionResultPerGroup>,
     ) -> Self {
         Self {
+            safe_sorting_only,
             existing_groups: HashMap::default(),
             task_queue,
             group_result_sender,
@@ -333,7 +336,7 @@ impl ConflictTaskGenerator {
     /// * `new_group` - The `ConflictGroup` to create tasks for.
     /// * `priority` - The priority to assign to the tasks.
     fn create_new_tasks(&mut self, new_group: &ConflictGroup, priority: TaskPriority) {
-        let tasks = get_tasks_for_group(new_group, priority);
+        let tasks = get_tasks_for_group(new_group, priority, self.safe_sorting_only);
         for task in tasks {
             self.task_queue.push(task);
         }
@@ -346,11 +349,16 @@ impl ConflictTaskGenerator {
 ///
 /// * `group` - The `ConflictGroup` to create tasks for.
 /// * `priority` - The priority to assign to the tasks.
+/// * `safe_sorting_only` - See [ParallelBuilderConfig::safe_sorting_only]
 ///
 /// # Returns
 ///
 /// A vector of `ConflictTask`s for the given group.
-pub fn get_tasks_for_group(group: &ConflictGroup, priority: TaskPriority) -> Vec<ConflictTask> {
+pub fn get_tasks_for_group(
+    group: &ConflictGroup,
+    priority: TaskPriority,
+    safe_sorting_only: bool,
+) -> Vec<ConflictTask> {
     let mut tasks = vec![];
 
     let created_at = Instant::now();
@@ -364,7 +372,7 @@ pub fn get_tasks_for_group(group: &ConflictGroup, priority: TaskPriority) -> Vec
     });
 
     // Then, we can push lower priority tasks that have a low chance, but a chance, of finding a better result
-    if group.orders.len() <= MAX_LENGTH_FOR_ALL_PERMUTATIONS {
+    if group.orders.len() <= MAX_LENGTH_FOR_ALL_PERMUTATIONS && !safe_sorting_only {
         // AllPermutations
         tasks.push(ConflictTask {
             group_idx: group.id,
@@ -374,17 +382,19 @@ pub fn get_tasks_for_group(group: &ConflictGroup, priority: TaskPriority) -> Vec
             created_at,
         });
     } else {
-        // Random
-        tasks.push(ConflictTask {
-            group_idx: group.id,
-            algorithm: Algorithm::Random {
-                seed: group.id as u64,
-                count: NUMBER_OF_RANDOM_TASKS,
-            },
-            priority: TaskPriority::Low,
-            group: group.clone(),
-            created_at,
-        });
+        if !safe_sorting_only {
+            // Random
+            tasks.push(ConflictTask {
+                group_idx: group.id,
+                algorithm: Algorithm::Random {
+                    seed: group.id as u64,
+                    count: NUMBER_OF_RANDOM_TASKS,
+                },
+                priority: TaskPriority::Low,
+                group: group.clone(),
+                created_at,
+            });
+        }
         tasks.push(ConflictTask {
             group_idx: group.id,
             algorithm: Algorithm::Length,
@@ -392,13 +402,15 @@ pub fn get_tasks_for_group(group: &ConflictGroup, priority: TaskPriority) -> Vec
             group: group.clone(),
             created_at,
         });
-        tasks.push(ConflictTask {
-            group_idx: group.id,
-            algorithm: Algorithm::ReverseGreedy,
-            priority: TaskPriority::Low,
-            group: group.clone(),
-            created_at,
-        });
+        if !safe_sorting_only {
+            tasks.push(ConflictTask {
+                group_idx: group.id,
+                algorithm: Algorithm::ReverseGreedy,
+                priority: TaskPriority::Low,
+                group: group.clone(),
+                created_at,
+            });
+        }
     }
 
     tasks

--- a/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
@@ -49,11 +49,14 @@ pub type ConflictResolutionResultPerGroup = (GroupId, (ResolutionResult, Conflic
 /// ParallelBuilderConfig configures parallel builder.
 /// * `num_threads` - number of threads to use for merging.
 /// * `merge_wait_time_ms` - time to wait for merging to finish before consuming new orders.
+/// * `safe_sorting_only` - Will only use sort modes that don't risk breaking the "best refund for user" since we don't megabundle the bundles (only the sbundles).
+///   This flag is just to test the algo until we solve every issue.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ParallelBuilderConfig {
     pub discard_txs: bool,
     pub num_threads: usize,
+    pub safe_sorting_only: bool,
     #[serde(default)]
     pub coinbase_payment: bool,
 }
@@ -100,6 +103,7 @@ where
         let conflict_finder = ConflictFinder::new();
 
         let conflict_task_generator = ConflictTaskGenerator::new(
+            config.safe_sorting_only,
             Arc::clone(&task_queue),
             group_result_sender_for_task_generator,
         );
@@ -107,6 +111,7 @@ where
         let conflict_resolving_pool = ConflictResolvingPool::new(
             config.num_threads,
             Arc::clone(&task_queue),
+            config.safe_sorting_only,
             group_result_sender,
             input.cancel.clone(),
             input.ctx.clone(),
@@ -312,6 +317,7 @@ where
     let mut conflict_resolving_pool = ConflictResolvingPool::new(
         config.num_threads,
         Arc::clone(&task_queue),
+        config.safe_sorting_only,
         group_result_sender,
         CancellationToken::new(),
         input.ctx.clone(),

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -585,6 +585,7 @@ impl Default for Config {
                         discard_txs: true,
                         num_threads: 25,
                         coinbase_payment: false,
+                        safe_sorting_only: true,
                     }),
                 },
             ],


### PR DESCRIPTION
## 📝 Summary

THIS IS ONLY FOR TESTING Parallel builder. DON'T use un production yet (eg: no cancellations!).
I added a parameter to make the parallel builder safe regarding bundle refunds.
It's useful only on backtesting.

## 💡 Motivation and Context

Measure the performance of the parallel builder.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
