### PR TITLE
feat: batched eoa refunds

### DIFF
--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -288,7 +288,7 @@ impl BlockBuildingHelperFromProvider {
             (self.payout_tx_gas, payout_tx_value)
         {
             use_last_tx_payment = true;
-            match self.partial_block.insert_proposer_payout_tx(
+            match self.partial_block.insert_refunds_and_proposer_payout_tx(
                 payout_tx_gas,
                 payout_tx_value,
                 &self.building_ctx,

--- a/crates/rbuilder/src/building/conflict.rs
+++ b/crates/rbuilder/src/building/conflict.rs
@@ -31,12 +31,15 @@ pub fn find_conflict_slow(
 ) -> eyre::Result<HashMap<(OrderId, OrderId), Conflict>> {
     let mut state_provider = Arc::<dyn StateProvider>::from(state_provider);
     let mut local_ctx = ThreadBlockBuildingContext::default();
+    // We use empty combined refunds because the value of the bundle will
+    // not change from batching.
+    let combined_refunds = std::collections::HashMap::default();
     let profits_alone = {
         let mut profits_alone = HashMap::new();
         for order in orders {
             let mut state = BlockState::new_arc(state_provider);
             let mut fork = PartialBlockFork::new(&mut state, ctx, &mut local_ctx);
-            if let Ok(res) = fork.commit_order(order, 0, 0, 0, true)? {
+            if let Ok(res) = fork.commit_order(order, 0, 0, 0, true, &combined_refunds)? {
                 profits_alone.insert(order.id(), res.coinbase_profit);
             };
             state_provider = state.into_provider();
@@ -76,7 +79,7 @@ pub fn find_conflict_slow(
         let mut fork = PartialBlockFork::new(&mut state, ctx, &mut local_ctx);
         let mut gas_used = 0;
         let mut blob_gas_used = 0;
-        match fork.commit_order(order1, gas_used, 0, blob_gas_used, true)? {
+        match fork.commit_order(order1, gas_used, 0, blob_gas_used, true, &combined_refunds)? {
             Ok(res) => {
                 gas_used += res.gas_used;
                 blob_gas_used += res.blob_gas_used;
@@ -85,7 +88,7 @@ pub fn find_conflict_slow(
                 results.insert(pair, Conflict::Fatal);
             }
         };
-        match fork.commit_order(order2, gas_used, 0, blob_gas_used, true)? {
+        match fork.commit_order(order2, gas_used, 0, blob_gas_used, true, &combined_refunds)? {
             Ok(re) => {
                 let profit_alone = *profits_alone.get(&order2.id()).unwrap();
                 let profit_with_conflict = re.coinbase_profit;

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -7,7 +7,9 @@ use crate::{
     provider::RootHasher,
     roothash::RootHashError,
     utils::{
-        a2r_withdrawal, default_cfg_env, elapsed_ms,
+        a2r_withdrawal,
+        constants::BASE_TX_GAS,
+        default_cfg_env, elapsed_ms,
         receipts::{
             calculate_receipt_root_and_block_logs_bloom, calculate_transactions_root, BloomCache,
             TransactionRootCache,
@@ -15,7 +17,7 @@ use crate::{
         timestamp_as_u64, Signer,
     },
 };
-use alloy_consensus::{Header, EMPTY_OMMER_ROOT_HASH};
+use alloy_consensus::{constants::KECCAK_EMPTY, Header, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::{
     eip1559::{calculate_block_gas_limit, ETHEREUM_BLOCK_GAS_LIMIT_30M},
     eip4844::BlobTransactionSidecar,
@@ -673,13 +675,26 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
 
         for (refund_recipient, refund_amount) in &self.delayed_refunds {
+            let refund_recipient_code_hash = fork
+                .state
+                .code_hash(
+                    *refund_recipient,
+                    &ctx.shared_cached_reads,
+                    &mut fork.local_ctx.cached_reads,
+                )
+                .map_err(CriticalCommitOrderError::Reth)?;
+            if refund_recipient_code_hash != KECCAK_EMPTY {
+                error!(%refund_recipient_code_hash, %refund_recipient, %refund_amount, "Refund recipient has code, skipping refund");
+                continue;
+            }
+
             let refund_tx = TransactionSignedEcRecoveredWithBlobs::new_no_blobs(create_payout_tx(
                 ctx.chain_spec.as_ref(),
                 ctx.evm_env.block_env.basefee,
                 builder_signer,
                 nonce,
                 *refund_recipient,
-                21_000,
+                BASE_TX_GAS,
                 *refund_amount,
             )?)
             .unwrap();
@@ -1062,6 +1077,7 @@ mod test {
                     coinbase_profit: profit_2,
                 },
             ],
+            delayed_kickback: None,
             original_order_ids: Default::default(),
             nonces_updated: Default::default(),
             paid_kickbacks: Default::default(),
@@ -1104,6 +1120,7 @@ mod test {
                 gas_used: Default::default(),
                 coinbase_profit: profit,
             }],
+            delayed_kickback: None,
             original_order_ids: Default::default(),
             nonces_updated: Default::default(),
             paid_kickbacks: Default::default(),

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -52,7 +52,7 @@ use revm::{
 };
 use serde::Deserialize;
 use std::{
-    collections::HashMap,
+    collections::{hash_map, HashMap},
     hash::Hash,
     str::FromStr,
     sync::Arc,
@@ -427,6 +427,8 @@ pub struct PartialBlock<Tracer: SimulationTracer> {
     pub coinbase_profit: U256,
     /// Tx execution info belonging to successfully executed orders.
     pub executed_tx_infos: Vec<TransactionExecutionInfo>,
+    /// Delayed refunds.
+    pub delayed_refunds: HashMap<Address, U256>,
     pub tracer: Tracer,
 }
 
@@ -450,6 +452,8 @@ pub enum InsertPayoutTxErr {
     CriticalCommitError(#[from] CriticalCommitOrderError),
     #[error("Profit too low to insert payout tx")]
     ProfitTooLow,
+    #[error("Delayed refund tx reverted")]
+    DelayedRefundTxReverted,
     #[error("Payout tx reverted")]
     PayoutTxReverted,
     #[error("Signer error: {0}")]
@@ -542,6 +546,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             blob_gas_used: self.blob_gas_used,
             coinbase_profit: self.coinbase_profit,
             executed_tx_infos: self.executed_tx_infos,
+            delayed_refunds: self.delayed_refunds,
             tracer,
         }
     }
@@ -603,6 +608,22 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         self.blob_gas_used += ok_result.blob_gas_used;
         self.coinbase_profit += ok_result.coinbase_profit;
         self.executed_tx_infos.extend(ok_result.tx_infos.clone());
+
+        // Update delayed refunds
+        if let Some((address, payout)) = ok_result.delayed_kickback {
+            match self.delayed_refunds.entry(address) {
+                hash_map::Entry::Occupied(mut entry) => {
+                    // Add full refundable value as we already accounted for the tx cost.
+                    *entry.get_mut() += payout.total_refundable_value;
+                }
+                hash_map::Entry::Vacant(entry) => {
+                    // Use discounted value to account for tx cost and reserve gas for the payout.
+                    entry.insert(payout.tx_value);
+                    self.gas_reserved += 21_000;
+                }
+            }
+        }
+
         Ok(Ok(ExecutionResult {
             coinbase_profit: ok_result.coinbase_profit,
             inplace_sim: inplace_sim_result,
@@ -628,7 +649,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
 
     /// Inserts payout tx to ctx.attributes.suggested_fee_recipient (should be called at the end of the block)
     /// Returns the paid value (block profit after subtracting the burned basefee of the payout tx)
-    pub fn insert_proposer_payout_tx(
+    pub fn insert_refunds_and_proposer_payout_tx(
         &mut self,
         gas_limit: u64,
         value: U256,
@@ -641,13 +662,40 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             .as_ref()
             .ok_or(InsertPayoutTxErr::NoSigner)?;
         self.free_reserved_gas();
-        let nonce = state
+        let mut nonce = state
             .nonce(
                 builder_signer.address,
                 &ctx.shared_cached_reads,
                 &mut local_ctx.cached_reads,
             )
             .map_err(CriticalCommitOrderError::Reth)?;
+
+        let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
+
+        for (refund_recipient, refund_amount) in &self.delayed_refunds {
+            let refund_tx = TransactionSignedEcRecoveredWithBlobs::new_no_blobs(create_payout_tx(
+                ctx.chain_spec.as_ref(),
+                ctx.evm_env.block_env.basefee,
+                builder_signer,
+                nonce,
+                *refund_recipient,
+                21_000,
+                *refund_amount,
+            )?)
+            .unwrap();
+            let refund_result =
+                fork.commit_tx(&refund_tx, self.gas_used, 0, self.blob_gas_used)??;
+            if !refund_result.tx_info.receipt.success {
+                return Err(InsertPayoutTxErr::DelayedRefundTxReverted);
+            }
+
+            self.gas_used += refund_result.tx_info.gas_used;
+            self.blob_gas_used += refund_result.blob_gas_used;
+            self.executed_tx_infos.push(refund_result.tx_info);
+
+            nonce += 1;
+        }
+
         let tx = create_payout_tx(
             ctx.chain_spec.as_ref(),
             ctx.evm_env.block_env.basefee,
@@ -659,7 +707,6 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         )?;
         // payout tx has no blobs so it's safe to unwrap
         let tx = TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx).unwrap();
-        let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
         let exec_result = fork.commit_tx(&tx, self.gas_used, 0, self.blob_gas_used)?;
         let ok_result = exec_result?;
         if !ok_result.tx_info.receipt.success {
@@ -919,6 +966,7 @@ impl PartialBlock<()> {
             blob_gas_used: 0,
             coinbase_profit: U256::ZERO,
             executed_tx_infos: Vec::new(),
+            delayed_refunds: HashMap::default(),
             tracer: (),
         }
     }

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -587,6 +587,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             self.gas_reserved,
             self.blob_gas_used,
             self.discard_txs,
+            &self.combined_refunds,
         )?;
         let ok_result = match exec_result {
             Ok(ok) => ok,
@@ -612,18 +613,14 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         self.executed_tx_infos.extend(ok_result.tx_infos.clone());
 
         // Update combined refunds
-        if let Some((address, payout)) = ok_result.delayed_kickback {
-            match self.combined_refunds.entry(address) {
-                hash_map::Entry::Occupied(mut entry) => {
-                    // Add full refundable value as we already accounted for the tx cost.
-                    *entry.get_mut() += payout.total_refundable_value;
-                }
-                hash_map::Entry::Vacant(entry) => {
-                    // Use discounted value to account for tx cost and reserve gas for the payout.
-                    entry.insert(payout.tx_value);
-                    self.gas_reserved += 21_000;
-                }
+        if let Some((address, refund_value)) = ok_result.delayed_kickback {
+            let entry = self.combined_refunds.entry(address);
+            if matches!(entry, hash_map::Entry::Vacant(_)) {
+                // This is the first refund for the recipient,
+                // so we need to reserve the gas for the refund tx.
+                self.gas_reserved += 21_000;
             }
+            *entry.or_default() += refund_value;
         }
 
         Ok(Ok(ExecutionResult {

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -429,8 +429,8 @@ pub struct PartialBlock<Tracer: SimulationTracer> {
     pub coinbase_profit: U256,
     /// Tx execution info belonging to successfully executed orders.
     pub executed_tx_infos: Vec<TransactionExecutionInfo>,
-    /// Delayed refunds.
-    pub delayed_refunds: HashMap<Address, U256>,
+    /// Combined refunds.
+    pub combined_refunds: HashMap<Address, U256>,
     pub tracer: Tracer,
 }
 
@@ -454,8 +454,8 @@ pub enum InsertPayoutTxErr {
     CriticalCommitError(#[from] CriticalCommitOrderError),
     #[error("Profit too low to insert payout tx")]
     ProfitTooLow,
-    #[error("Delayed refund tx reverted")]
-    DelayedRefundTxReverted,
+    #[error("Combined refund tx reverted")]
+    CombinedRefundTxReverted,
     #[error("Payout tx reverted")]
     PayoutTxReverted,
     #[error("Signer error: {0}")]
@@ -548,7 +548,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             blob_gas_used: self.blob_gas_used,
             coinbase_profit: self.coinbase_profit,
             executed_tx_infos: self.executed_tx_infos,
-            delayed_refunds: self.delayed_refunds,
+            combined_refunds: self.combined_refunds,
             tracer,
         }
     }
@@ -611,9 +611,9 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         self.coinbase_profit += ok_result.coinbase_profit;
         self.executed_tx_infos.extend(ok_result.tx_infos.clone());
 
-        // Update delayed refunds
+        // Update combined refunds
         if let Some((address, payout)) = ok_result.delayed_kickback {
-            match self.delayed_refunds.entry(address) {
+            match self.combined_refunds.entry(address) {
                 hash_map::Entry::Occupied(mut entry) => {
                     // Add full refundable value as we already accounted for the tx cost.
                     *entry.get_mut() += payout.total_refundable_value;
@@ -674,7 +674,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
 
         let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
 
-        for (refund_recipient, refund_amount) in &self.delayed_refunds {
+        for (refund_recipient, refund_amount) in &self.combined_refunds {
             let refund_recipient_code_hash = fork
                 .state
                 .code_hash(
@@ -701,7 +701,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
             let refund_result =
                 fork.commit_tx(&refund_tx, self.gas_used, 0, self.blob_gas_used)??;
             if !refund_result.tx_info.receipt.success {
-                return Err(InsertPayoutTxErr::DelayedRefundTxReverted);
+                return Err(InsertPayoutTxErr::CombinedRefundTxReverted);
             }
 
             self.gas_used += refund_result.tx_info.gas_used;
@@ -981,7 +981,7 @@ impl PartialBlock<()> {
             blob_gas_used: 0,
             coinbase_profit: U256::ZERO,
             executed_tx_infos: Vec::new(),
-            delayed_refunds: HashMap::default(),
+            combined_refunds: HashMap::default(),
             tracer: (),
         }
     }

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -15,7 +15,7 @@ use crate::{
         Bundle, Order, OrderId, RefundConfig, ShareBundle, ShareBundleBody, ShareBundleInner,
         TransactionSignedEcRecoveredWithBlobs,
     },
-    utils::get_percent,
+    utils::{constants::BASE_TX_GAS, get_percent},
 };
 use ahash::HashSet;
 use alloy_consensus::{constants::KECCAK_EMPTY, Transaction};
@@ -793,7 +793,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             };
 
             let gas_limit = self.ctx.evm_env.block_env.gas_limit;
-            if payout.gas_limit == 21_000
+            if payout.gas_limit == BASE_TX_GAS
                 && gas_limit
                     .checked_sub(insert.cumulative_gas_used + gas_reserved)
                     .is_some_and(|remaining| remaining > payout.gas_limit)

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -224,7 +224,8 @@ pub struct BundleOk {
     /// nonces_updates has a set of deduplicated final nonces of the txs in the order
     pub nonces_updated: Vec<(Address, u64)>,
     pub paid_kickbacks: Vec<(Address, U256)>,
-    pub delayed_kickback: Option<(Address, ReservedPayout)>,
+    /// The refund amount to accrue per recipient and be paid at the end of the block.
+    pub delayed_kickback: Option<(Address, U256)>,
     /// Only for sbundles we accumulate ShareBundleInner::original_order_id that executed ok.
     /// Its original use is for only one level or orders with original_order_id but if nesting happens the parent order original_order_id goes before its children (pre-order DFS)
     /// Fully dropped orders (TxRevertBehavior::AllowedExcluded allows it!) are not included.
@@ -290,7 +291,7 @@ pub struct OrderOk {
     /// nonces_updates has a set of deduplicated final nonces of the txs in the order
     pub nonces_updated: Vec<(Address, u64)>,
     pub paid_kickbacks: Vec<(Address, U256)>,
-    pub delayed_kickback: Option<(Address, ReservedPayout)>,
+    pub delayed_kickback: Option<(Address, U256)>,
     pub used_state_trace: Option<UsedStateTrace>,
 }
 
@@ -577,6 +578,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
         allow_tx_skip: bool,
+        combined_refunds: &HashMap<Address, U256>,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
         let current_block = self.ctx.evm_env.block_env.number;
         // None is good for any block
@@ -610,6 +612,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                 gas_reserved,
                 cumulative_blob_gas_used,
                 allow_tx_skip,
+                combined_refunds,
             )
         })
     }
@@ -725,6 +728,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
         allow_tx_skip: bool,
+        combined_refunds: &HashMap<Address, U256>,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
         let mut refundable_profit = U256::ZERO;
         let mut insert = BundleOk {
@@ -781,8 +785,23 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             return Ok(Err(BundleErr::EmptyBundle));
         }
 
-        if let Some(refunds_cfg) = &bundle.refund {
+        'refund: {
+            let Some(refunds_cfg) = &bundle.refund else {
+                break 'refund;
+            };
+
+            // Calculate the refund value without refund tx cost.
             let refundable_value = get_percent(refundable_profit, refunds_cfg.percent as usize);
+
+            if combined_refunds.contains_key(&refunds_cfg.recipient) {
+                // We already determined that refund for this recipient will cost [`BASE_TX_GAS`]
+                // and previously inserted a bundle that is capable of paying this cost.
+                // The recipient will be awarded full refund value for the current bundle.
+                insert.delayed_kickback = Some((refunds_cfg.recipient, refundable_value));
+                break 'refund;
+            }
+
+            // Estimate refund tx cost and calculate deducted refund value.
             let payout = match self.estimate_refund_payout_tx(
                 refunds_cfg.recipient,
                 refundable_value,
@@ -798,8 +817,13 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     .checked_sub(insert.cumulative_gas_used + gas_reserved)
                     .is_some_and(|remaining| remaining > payout.gas_limit)
             {
-                insert.delayed_kickback = Some((refunds_cfg.recipient, payout));
-            } else if let Err(err) = self.insert_refund_payout_tx(
+                // This refund recipient is eligible for a combined refund at the end of the block.
+                insert.delayed_kickback = Some((refunds_cfg.recipient, payout.tx_value));
+                break 'refund;
+            }
+
+            // Refund the recipient immediately.
+            if let Err(err) = self.insert_refund_payout_tx(
                 payout,
                 refunds_cfg.recipient,
                 gas_reserved,
@@ -808,6 +832,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                 return Ok(Err(err));
             }
         }
+
         Ok(Ok(insert))
     }
 
@@ -1083,6 +1108,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
         allow_tx_skip: bool,
+        combined_refunds: &HashMap<Address, U256>,
     ) -> Result<Result<OrderOk, OrderErr>, CriticalCommitOrderError> {
         self.execute_with_rollback(|s| {
             s.commit_order_no_rollback(
@@ -1091,6 +1117,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                 gas_reserved,
                 cumulative_blob_gas_used,
                 allow_tx_skip,
+                combined_refunds,
             )
         })
     }
@@ -1102,6 +1129,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         gas_reserved: u64,
         cumulative_blob_gas_used: u64,
         allow_tx_skip: bool,
+        combined_refunds: &HashMap<Address, U256>,
     ) -> Result<Result<OrderOk, OrderErr>, CriticalCommitOrderError> {
         match order {
             Order::Tx(tx) => {
@@ -1143,6 +1171,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     gas_reserved,
                     cumulative_blob_gas_used,
                     allow_tx_skip,
+                    combined_refunds,
                 )?;
                 self.bundle_to_order_result(res, coinbase_balance_before)
             }
@@ -1170,7 +1199,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                 let delayed_refund_value = ok
                     .delayed_kickback
                     .as_ref()
-                    .map_or(U256::ZERO, |(_, p)| p.total_refundable_value);
+                    .map_or(U256::ZERO, |(_, value)| *value);
 
                 // Builder does sign txs in this code path, so do not allow negative coinbase
                 // profit.

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -224,6 +224,7 @@ pub struct BundleOk {
     /// nonces_updates has a set of deduplicated final nonces of the txs in the order
     pub nonces_updated: Vec<(Address, u64)>,
     pub paid_kickbacks: Vec<(Address, U256)>,
+    pub delayed_kickback: Option<(Address, ReservedPayout)>,
     /// Only for sbundles we accumulate ShareBundleInner::original_order_id that executed ok.
     /// Its original use is for only one level or orders with original_order_id but if nesting happens the parent order original_order_id goes before its children (pre-order DFS)
     /// Fully dropped orders (TxRevertBehavior::AllowedExcluded allows it!) are not included.
@@ -289,6 +290,7 @@ pub struct OrderOk {
     /// nonces_updates has a set of deduplicated final nonces of the txs in the order
     pub nonces_updated: Vec<(Address, u64)>,
     pub paid_kickbacks: Vec<(Address, U256)>,
+    pub delayed_kickback: Option<(Address, ReservedPayout)>,
     pub used_state_trace: Option<UsedStateTrace>,
 }
 
@@ -733,6 +735,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             tx_infos: Vec::new(),
             nonces_updated: Vec::new(),
             paid_kickbacks: Vec::new(),
+            delayed_kickback: None,
             original_order_ids: Vec::new(),
         };
         for tx_with_blobs in &bundle.txs {
@@ -788,7 +791,15 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                 Ok(payout) => payout,
                 Err(err) => return Ok(Err(err)),
             };
-            if let Err(err) = self.insert_refund_payout_tx(
+
+            let gas_limit = self.ctx.evm_env.block_env.gas_limit;
+            if payout.gas_limit == 21_000
+                && gas_limit
+                    .checked_sub(insert.cumulative_gas_used + gas_reserved)
+                    .is_some_and(|remaining| remaining > payout.gas_limit)
+            {
+                insert.delayed_kickback = Some((refunds_cfg.recipient, payout));
+            } else if let Err(err) = self.insert_refund_payout_tx(
                 payout,
                 refunds_cfg.recipient,
                 gas_reserved,
@@ -898,6 +909,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
             tx_infos: Vec::new(),
             nonces_updated: Vec::new(),
             paid_kickbacks: Vec::new(),
+            delayed_kickback: None,
             original_order_ids: Vec::new(),
         };
         let coinbase_balance_before = self.coinbase_balance()?;
@@ -1115,6 +1127,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                             tx_infos: vec![ok.tx_info],
                             nonces_updated: vec![ok.nonce_updated],
                             paid_kickbacks: Vec::new(),
+                            delayed_kickback: None,
                             used_state_trace: self.get_used_state_trace(),
                             original_order_ids: Vec::new(),
                         }))
@@ -1154,13 +1167,19 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
     ) -> Result<Result<OrderOk, OrderErr>, CriticalCommitOrderError> {
         match bundle_result {
             Ok(ok) => {
+                let delayed_refund_value = ok
+                    .delayed_kickback
+                    .as_ref()
+                    .map_or(U256::ZERO, |(_, p)| p.total_refundable_value);
+
                 // Builder does sign txs in this code path, so do not allow negative coinbase
                 // profit.
-                let coinbase_profit =
-                    match self.coinbase_profit_when_refunds(coinbase_balance_before)? {
-                        Ok(profit) => profit,
-                        Err(err) => return Ok(Err(err)),
-                    };
+                let coinbase_profit = match self
+                    .coinbase_profit_when_refunds(coinbase_balance_before, delayed_refund_value)?
+                {
+                    Ok(profit) => profit,
+                    Err(err) => return Ok(Err(err)),
+                };
 
                 Ok(Ok(OrderOk {
                     coinbase_profit,
@@ -1171,6 +1190,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     tx_infos: ok.tx_infos,
                     nonces_updated: ok.nonces_updated,
                     paid_kickbacks: ok.paid_kickbacks,
+                    delayed_kickback: ok.delayed_kickback,
                     used_state_trace: self.get_used_state_trace(),
                     original_order_ids: ok.original_order_ids,
                 }))
@@ -1183,13 +1203,15 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
     fn coinbase_profit_when_refunds(
         &mut self,
         initial_balance: U256,
+        delayed_refund_value: U256,
     ) -> Result<Result<U256, OrderErr>, CriticalCommitOrderError> {
         let coinbase_balance_after = self.coinbase_balance()?;
-        if coinbase_balance_after >= initial_balance {
-            Ok(Ok(coinbase_balance_after - initial_balance))
+        let min_balance = initial_balance + delayed_refund_value;
+        if coinbase_balance_after >= min_balance {
+            Ok(Ok(coinbase_balance_after - min_balance))
         } else {
             Ok(Err(OrderErr::NegativeProfit(
-                initial_balance - coinbase_balance_after,
+                min_balance - coinbase_balance_after,
             )))
         }
     }

--- a/crates/rbuilder/src/building/sim.rs
+++ b/crates/rbuilder/src/building/sim.rs
@@ -439,8 +439,12 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
     // simulate parents
     let mut gas_used = 0;
     let mut blob_gas_used = 0;
+    // We use empty combined refunds because the value of the bundle will
+    // not change from batching.
+    let combined_refunds = std::collections::HashMap::default();
     for parent in parent_orders {
-        let result = fork.commit_order(&parent, gas_used, 0, blob_gas_used, true)?;
+        let result =
+            fork.commit_order(&parent, gas_used, 0, blob_gas_used, true, &combined_refunds)?;
         match result {
             Ok(res) => {
                 gas_used += res.gas_used;
@@ -454,7 +458,7 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
     }
 
     // simulate
-    let result = fork.commit_order(&order, gas_used, 0, blob_gas_used, true)?;
+    let result = fork.commit_order(&order, gas_used, 0, blob_gas_used, true, &combined_refunds)?;
     let sim_time = start.elapsed();
     add_order_simulation_time(sim_time, "sim", result.is_ok()); // we count parent sim time + order sim time time here
 

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -1,13 +1,14 @@
 pub mod setup;
 
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Address, Bytes, B256, U256};
 use itertools::Itertools;
-use std::collections::HashSet;
+use reth_primitives::Bytecode;
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     building::{
-        testing::bundle_tests::setup::NonceValue, BuiltBlockTrace, BundleErr, OrderErr,
-        TransactionErr,
+        testing::bundle_tests::setup::NonceValue, BuiltBlockTrace, BundleErr, ExecutionResult,
+        OrderErr, TransactionErr,
     },
     primitives::{Bundle, BundleRefund, Order, OrderId, Refund, RefundConfig, TxRevertBehavior},
     utils::{constants::BASE_TX_GAS, int_percentage},
@@ -324,34 +325,119 @@ fn test_share_bundle_revert() -> eyre::Result<()> {
     Ok(())
 }
 
+/// Test combined refunds
 #[test]
-fn test_bundle_ok_refunds() -> eyre::Result<()> {
+fn test_bundle_combined_refunds() -> eyre::Result<()> {
     let target_block = 11;
-    let mut test_setup = TestSetup::gen_test_setup(BlockArgs::default().number(target_block))?;
     let profit: u64 = 100_000;
-    let percent: u8 = 90;
-    let refundable_value = int_percentage(profit, percent as usize);
+    let refund_percent: u8 = 90;
+    let refundable_value = int_percentage(profit, refund_percent as usize);
+
+    let mut test_setup = TestSetup::gen_test_setup(BlockArgs::default().number(target_block))?;
+    let recipient = NamedAddr::User(2);
+    let recipient_address = test_setup.named_address(recipient)?;
+    let recipient_balance_before = test_setup.balance(recipient)?;
+
+    let commit_refund_order =
+        |setup: &mut TestSetup, recipient: Address| -> eyre::Result<ExecutionResult> {
+            setup.begin_bundle_order(target_block);
+            setup.add_dummy_tx_0_1_no_rev()?;
+            let profit_tx_hash = setup.add_send_to_coinbase_tx(NamedAddr::User(1), profit)?;
+            setup.set_bundle_refund(BundleRefund {
+                recipient,
+                percent: refund_percent,
+                tx_hash: profit_tx_hash,
+            });
+            Ok(setup.commit_order_ok())
+        };
+
+    let result = commit_refund_order(&mut test_setup, recipient_address).unwrap();
+    assert!(result.paid_kickbacks.is_empty());
+    assert_eq!(test_setup.balance(recipient)?, recipient_balance_before);
+    assert_eq!(
+        test_setup.partial_block().combined_refunds,
+        HashMap::from_iter([(
+            recipient_address,
+            U256::from(refundable_value - BASE_TX_GAS)
+        )])
+    );
+
+    let result = commit_refund_order(&mut test_setup, recipient_address).unwrap();
+    assert!(result.paid_kickbacks.is_empty());
+    assert_eq!(test_setup.balance(recipient)?, recipient_balance_before);
+    assert_eq!(
+        test_setup.partial_block().combined_refunds,
+        HashMap::from_iter([(
+            recipient_address,
+            U256::from(refundable_value * 2 - BASE_TX_GAS)
+        )])
+    );
+
+    let second_recipient = NamedAddr::User(3);
+    let second_recipient_address = test_setup.named_address(second_recipient)?;
+    let second_recipient_balance_before = test_setup.balance(second_recipient)?;
+
+    let result = commit_refund_order(&mut test_setup, second_recipient_address).unwrap();
+    assert!(result.paid_kickbacks.is_empty());
+    assert_eq!(
+        test_setup.balance(second_recipient)?,
+        second_recipient_balance_before
+    );
+    assert_eq!(
+        test_setup.partial_block().combined_refunds,
+        HashMap::from_iter([
+            (
+                recipient_address,
+                U256::from(refundable_value * 2 - BASE_TX_GAS)
+            ),
+            (
+                second_recipient_address,
+                U256::from(refundable_value - BASE_TX_GAS)
+            )
+        ])
+    );
+
+    Ok(())
+}
+
+/// Test immediate refunds to contract recipients
+#[test]
+fn test_bundle_contract_refunds() -> eyre::Result<()> {
+    let target_block = 11;
+    let profit: u64 = 100_000;
+    let refund_percent: u8 = 90;
+    let refundable_value = int_percentage(profit, refund_percent as usize);
+
+    let mut test_setup = TestSetup::gen_test_setup(BlockArgs::default().number(target_block))?;
     let recipient_named_address = NamedAddr::User(2);
-    let recipient = test_setup.named_address(recipient_named_address)?;
+    let recipient_contract_address = test_setup.named_address(recipient_named_address)?;
+    test_setup
+        .chain_state_mut()
+        .upsert_contract(
+            recipient_contract_address,
+            Bytecode::new_raw(Bytes::from([0x38 /* CODESIZE */])),
+        )
+        .unwrap();
+
     let recipient_balance_before = test_setup.balance(recipient_named_address)?;
     test_setup.begin_bundle_order(target_block);
     test_setup.add_dummy_tx_0_1_no_rev()?;
     let profit_tx_hash = test_setup.add_send_to_coinbase_tx(NamedAddr::User(1), profit)?;
     test_setup.set_bundle_refund(BundleRefund {
-        percent,
-        recipient,
+        percent: refund_percent,
+        recipient: recipient_contract_address,
         tx_hash: profit_tx_hash,
     });
     let result = test_setup.commit_order_ok();
     let recipient_balance_after = test_setup.balance(recipient_named_address)?;
-    let expected_refund = refundable_value - BASE_TX_GAS;
+    let expected_refund = refundable_value - BASE_TX_GAS - 2 /* 0x38 CODESIZE cost */;
     assert_eq!(
         recipient_balance_after - recipient_balance_before,
         expected_refund as i128
     );
     assert_eq!(
         result.paid_kickbacks,
-        vec![(recipient, U256::from(expected_refund))]
+        vec![(recipient_contract_address, U256::from(expected_refund))]
     );
     Ok(())
 }

--- a/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/setup.rs
@@ -44,9 +44,20 @@ impl TestSetup {
         })
     }
 
+    /// Return a reference to a partial block.
+    pub fn partial_block(&self) -> &PartialBlock<()> {
+        &self.partial_block
+    }
+
+    /// Return a mutable reference to the chain state.
+    pub fn chain_state_mut(&mut self) -> &mut TestChainState {
+        &mut self.test_chain
+    }
+
     pub fn named_address(&self, named_addr: NamedAddr) -> eyre::Result<Address> {
         self.test_chain.named_address(named_addr)
     }
+
     // Build order methods
 
     pub fn begin_mempool_tx_order(&mut self) {

--- a/crates/rbuilder/src/building/testing/test_chain_state.rs
+++ b/crates/rbuilder/src/building/testing/test_chain_state.rs
@@ -20,6 +20,7 @@ use reth::{
 };
 use reth_chainspec::{ChainSpec, EthereumHardfork, MAINNET};
 use reth_db::{cursor::DbCursorRW, tables, transaction::DbTxMut};
+use reth_errors::ProviderResult;
 use reth_primitives::{Recovered, TransactionSigned};
 use reth_primitives_traits::Block as _;
 use reth_provider::test_utils::{create_test_provider_factory, MockNodeTypesWithDB};
@@ -293,6 +294,28 @@ impl TestChainState {
 
     pub fn provider_factory(&self) -> &ProviderFactory<MockNodeTypesWithDB> {
         &self.provider_factory
+    }
+
+    pub fn upsert_contract(&self, address: Address, bytecode: Bytecode) -> ProviderResult<()> {
+        let code_hash = bytecode.hash_slow();
+        let provider = self.provider_factory.provider_rw()?;
+        provider
+            .tx_ref()
+            .cursor_write::<tables::PlainAccountState>()?
+            .upsert(
+                address,
+                &Account {
+                    nonce: 1,
+                    balance: U256::ZERO,
+                    bytecode_hash: Some(code_hash),
+                },
+            )?;
+        provider
+            .tx_ref()
+            .cursor_write::<tables::Bytecodes>()?
+            .upsert(code_hash, &bytecode)?;
+        provider.commit()?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## 📝 Summary

Introduce batched end of block refunds for EOA refunds recipients.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
