### PR TITLE
Upgrade relay set with relays that can ignore gas limit.

### DIFF
--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -70,7 +70,8 @@ async fn main() -> eyre::Result<()> {
     let cancel = CancellationToken::new();
 
     let flashbots_relay_url = "https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net";
-    let relay_client = RelayClient::from_url(flashbots_relay_url.parse()?, None, None, None, false);
+    let relay_client =
+        RelayClient::from_url(flashbots_relay_url.parse()?, None, None, None, false, false);
     let relay = MevBoostRelaySlotInfoProvider::new(relay_client, "flashbots".to_string());
     let blocklist_provider = Arc::new(NullBlockListProvider::new());
     let payload_event = MevBoostSlotDataGenerator::new(

--- a/crates/rbuilder/src/integration/playground.rs
+++ b/crates/rbuilder/src/integration/playground.rs
@@ -162,6 +162,7 @@ impl Playground {
             None,
             None,
             false,
+            false,
         );
 
         let payload = client

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -116,6 +116,7 @@ pub struct Config {
 
 const DEFAULT_SLOT_DELTA_TO_START_BIDDING_MS: i64 = -8000;
 const DEFAULT_ASK_FOR_FILTERING_VALIDATORS: bool = false;
+const DEFAULT_CAN_IGNORE_GAS_LIMIT: bool = false;
 
 #[serde_as]
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -250,6 +251,9 @@ impl L1Config {
                         relay_config
                             .ask_for_filtering_validators
                             .unwrap_or(DEFAULT_ASK_FOR_FILTERING_VALIDATORS),
+                        relay_config
+                            .can_ignore_gas_limit
+                            .unwrap_or(DEFAULT_CAN_IGNORE_GAS_LIMIT),
                     );
                     Self::create_relay_sub_objects(
                         relay_config,
@@ -759,6 +763,7 @@ lazy_static! {
                 builder_id_header: None,
                 api_token_header: None,
                 ask_for_filtering_validators: None,
+                can_ignore_gas_limit: None,
             },
         );
         map.insert(
@@ -779,6 +784,7 @@ lazy_static! {
                 builder_id_header: None,
                 api_token_header: None,
                 ask_for_filtering_validators: None,
+                can_ignore_gas_limit: None,
             },
         );
         map.insert(
@@ -799,6 +805,7 @@ lazy_static! {
                 builder_id_header: None,
                 api_token_header: None,
                 ask_for_filtering_validators: None,
+                can_ignore_gas_limit: None,
             },
         );
         map.insert(
@@ -818,6 +825,7 @@ lazy_static! {
                 builder_id_header: None,
                 api_token_header: None,
                 ask_for_filtering_validators: None,
+                can_ignore_gas_limit: None,
             },
         );
         map.insert(
@@ -838,6 +846,7 @@ lazy_static! {
                 builder_id_header: None,
                 api_token_header: None,
                 ask_for_filtering_validators: None,
+                can_ignore_gas_limit: None,
             },
         );
         map

--- a/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
@@ -3,7 +3,7 @@ use crate::{
     primitives::mev_boost::{MevBoostRelayID, MevBoostRelaySlotInfoProvider},
     telemetry::{inc_conn_relay_errors, inc_other_relay_errors, inc_too_many_req_relay_errors},
 };
-use ahash::HashMap;
+use ahash::{HashMap, HashSet};
 use alloy_primitives::Address;
 use futures::stream::FuturesOrdered;
 use primitive_types::H384;
@@ -69,15 +69,23 @@ impl RelayEpochCache {
 pub struct RelaysForSlotData {
     /// Sorted by priority so when we use them on slot_data the one with the highest priority wins.
     relay: Vec<(MevBoostRelayID, RelayEpochCache)>,
+    /// Redundant with relay but easier to access/pass around.
+    can_ignore_gas_limit: HashSet<MevBoostRelayID>,
 }
 
 impl RelaysForSlotData {
     pub fn new(relays: &[MevBoostRelaySlotInfoProvider]) -> Self {
+        let can_ignore_gas_limit = relays
+            .iter()
+            .filter(|relay| relay.can_ignore_gas_limit())
+            .map(|relay| relay.id().clone())
+            .collect();
         Self {
             relay: relays
                 .iter()
                 .map(|relay| (relay.id().clone(), RelayEpochCache::new(relay.clone())))
                 .collect(),
+            can_ignore_gas_limit,
         }
     }
 
@@ -127,12 +135,13 @@ impl RelaysForSlotData {
             assert_eq!(relay_data.slot, slot);
             relay_ok_res.push((relay, relay_data));
         }
-        resolve_relay_slot_data(relay_ok_res)
+        resolve_relay_slot_data(relay_ok_res, &self.can_ignore_gas_limit)
     }
 }
 
 fn resolve_relay_slot_data(
     fetched_data: Vec<(MevBoostRelayID, ValidatorSlotData)>,
+    can_ignore_gas_limit: &HashSet<MevBoostRelayID>,
 ) -> Option<(SlotData, Vec<MevBoostRelayID>)> {
     if fetched_data.is_empty() {
         return None;
@@ -169,13 +178,27 @@ fn resolve_relay_slot_data(
                 .unwrap_or_default()
         })
         .unwrap();
-    let selected_relays = slot_relays.get(latest_slot_data).unwrap();
-
+    let latest_slot_data = latest_slot_data.clone();
+    let mut selected_relays = slot_relays.get(&latest_slot_data).unwrap().clone();
     let span = trace_span!("raw_relay_data", ?slot_raw_data);
     let _span_guard = span.enter();
     info!(all_data = ?slot_relays, ?selected_relays, "Relays returned different slot data");
+    // Add all relays that can ignore gas limit to the selected relays.
+    for (slot, relays) in slot_relays {
+        if slot.fee_recipient == latest_slot_data.fee_recipient
+            && slot.pubkey == latest_slot_data.pubkey
+            && slot.gas_limit != latest_slot_data.gas_limit
+        {
+            for relay in relays {
+                if can_ignore_gas_limit.contains(&relay) {
+                    info!(?relay, "Upgraded relay set with can_ignore_gas_limit relay");
+                    selected_relays.push(relay);
+                }
+            }
+        }
+    }
 
-    Some(slot_relays.remove_entry(latest_slot_data).unwrap())
+    Some((latest_slot_data, selected_relays))
 }
 
 #[cfg(test)]
@@ -211,6 +234,7 @@ mod test {
         // Test when all relays return same data
         let relay1 = MevBoostRelayID::from("relay1");
         let relay2 = MevBoostRelayID::from("relay2");
+        let relay3 = MevBoostRelayID::from("relay3");
         let data = make_test_data(address!("1111111111111111111111111111111111111111"), 100);
 
         let fetched = vec![
@@ -218,7 +242,7 @@ mod test {
             (relay2.clone(), data.clone()),
         ];
 
-        let result = resolve_relay_slot_data(fetched);
+        let result = resolve_relay_slot_data(fetched, &HashSet::default());
         let (slot_data, relays) = result.unwrap();
         assert_eq!(
             SlotData {
@@ -237,7 +261,7 @@ mod test {
             (relay2.clone(), data2.clone()),
         ];
 
-        let result = resolve_relay_slot_data(fetched);
+        let result = resolve_relay_slot_data(fetched, &HashSet::default());
         let (slot_data, relays) = result.unwrap();
         assert_eq!(
             SlotData {
@@ -248,5 +272,48 @@ mod test {
             slot_data
         );
         assert_eq!(relays, vec![relay2.clone()]);
+
+        // Test when relays return different gas limit but same fee recipient and pubkey
+        let mut data3 = data2.clone();
+        data3.entry.message.gas_limit = 40000000;
+        // We want data2 to win.
+        data3.entry.message.timestamp -= 1;
+        let fetched = vec![
+            (relay1.clone(), data.clone()),
+            (relay2.clone(), data2.clone()),
+            (relay3.clone(), data3.clone()),
+        ];
+
+        // No can_ignore_gas_limit
+        let result = resolve_relay_slot_data(fetched, &HashSet::default());
+        let (slot_data, relays) = result.unwrap();
+        assert_eq!(
+            SlotData {
+                fee_recipient: address!("2222222222222222222222222222222222222222"),
+                gas_limit: 30000000,
+                pubkey: H384::zero(),
+            },
+            slot_data
+        );
+        assert_eq!(relays, vec![relay2.clone()]);
+
+        // data3 can_ignore_gas_limit
+        let fetched = vec![
+            (relay1.clone(), data.clone()),
+            (relay2.clone(), data2.clone()),
+            (relay3.clone(), data3.clone()),
+        ];
+        let can_ignore_gas_limit = HashSet::from_iter([relay3.clone()]);
+        let result = resolve_relay_slot_data(fetched, &can_ignore_gas_limit);
+        let (slot_data, relays) = result.unwrap();
+        assert_eq!(
+            SlotData {
+                fee_recipient: address!("2222222222222222222222222222222222222222"),
+                gas_limit: 30000000,
+                pubkey: H384::zero(),
+            },
+            slot_data
+        );
+        assert_eq!(relays, vec![relay2.clone(), relay3.clone()]);
     }
 }

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -150,6 +150,8 @@ pub struct RelayClient {
     api_token_header: Option<String>,
     /// Adds "filtering=true" as query
     ask_for_filtering_validators: bool,
+    /// If we submit a block with a different gas than the one the validator registered with in this relay the relay does not mind.
+    can_ignore_gas_limit: bool,
 }
 
 impl RelayClient {
@@ -159,6 +161,7 @@ impl RelayClient {
         builder_id_header: Option<String>,
         api_token_header: Option<String>,
         ask_for_filtering_validators: bool,
+        can_ignore_gas_limit: bool,
     ) -> Self {
         Self {
             url,
@@ -167,11 +170,16 @@ impl RelayClient {
             builder_id_header,
             api_token_header,
             ask_for_filtering_validators,
+            can_ignore_gas_limit,
         }
     }
 
     pub fn from_known_relay(relay: KnownRelay) -> Self {
-        Self::from_url(relay.url(), None, None, None, false)
+        Self::from_url(relay.url(), None, None, None, false, false)
+    }
+
+    pub fn can_ignore_gas_limit(&self) -> bool {
+        self.can_ignore_gas_limit
     }
 }
 
@@ -829,7 +837,7 @@ mod tests {
         let mut generator = TestDataGenerator::default();
 
         let relay_url = Url::from_str(&srv.endpoint()).unwrap();
-        let relay = RelayClient::from_url(relay_url, None, None, None, false);
+        let relay = RelayClient::from_url(relay_url, None, None, None, false, false);
         let submission = SubmitBlockRequest::Deneb(generator.create_deneb_submit_block_request());
         let sub_relay = SubmitBlockRequestWithMetadata {
             submission,

--- a/crates/rbuilder/src/primitives/mev_boost.rs
+++ b/crates/rbuilder/src/primitives/mev_boost.rs
@@ -66,6 +66,9 @@ pub struct RelayConfig {
     /// On 2025/06/24 (my birthday!) only supported by ultrasound.
     /// None -> false
     pub ask_for_filtering_validators: Option<bool>,
+    /// If we submit a block with a different gas than the one the validator registered with in this relay the relay does not mind.
+    /// None -> false
+    pub can_ignore_gas_limit: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
@@ -220,6 +223,10 @@ impl MevBoostRelaySlotInfoProvider {
 
     pub async fn get_current_epoch_validators(&self) -> Result<Vec<ValidatorSlotData>, RelayError> {
         self.client.get_current_epoch_validators().await
+    }
+
+    pub fn can_ignore_gas_limit(&self) -> bool {
+        self.client.can_ignore_gas_limit()
     }
 }
 

--- a/crates/test-relay/src/main.rs
+++ b/crates/test-relay/src/main.rs
@@ -102,7 +102,7 @@ async fn main() -> eyre::Result<()> {
 
     let relay = {
         let url: Url = cli.relay.parse()?;
-        let client = RelayClient::from_url(url, None, None, None, false);
+        let client = RelayClient::from_url(url, None, None, None, false, false);
         MevBoostRelaySlotInfoProvider::new(client, "relay".to_string())
     };
 


### PR DESCRIPTION
## 📝 Summary

Sometimes we don't send bids to a relay with validator registered with a different gas limit but some relays may allow it.
I added a new flag to allow this.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [X] Added tests (if applicable)
