### PR TITLE
Fix delayed refunds cost calc

### DIFF
--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -613,14 +613,19 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         self.executed_tx_infos.extend(ok_result.tx_infos.clone());
 
         // Update combined refunds
-        if let Some((address, refund_value, _)) = ok_result.delayed_kickback {
-            let entry = self.combined_refunds.entry(address);
+        if let Some(DelayedKickback {
+            recipient,
+            payout_value,
+            ..
+        }) = ok_result.delayed_kickback
+        {
+            let entry = self.combined_refunds.entry(recipient);
             if matches!(entry, hash_map::Entry::Vacant(_)) {
                 // This is the first refund for the recipient,
                 // so we need to reserve the gas for the refund tx.
                 self.gas_reserved += 21_000;
             }
-            *entry.or_default() += refund_value;
+            *entry.or_default() += payout_value;
         }
 
         Ok(Ok(ExecutionResult {

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -613,7 +613,7 @@ impl<Tracer: SimulationTracer> PartialBlock<Tracer> {
         self.executed_tx_infos.extend(ok_result.tx_infos.clone());
 
         // Update combined refunds
-        if let Some((address, refund_value)) = ok_result.delayed_kickback {
+        if let Some((address, refund_value, _)) = ok_result.delayed_kickback {
             let entry = self.combined_refunds.entry(address);
             if matches!(entry, hash_map::Entry::Vacant(_)) {
                 // This is the first refund for the recipient,

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -215,6 +215,13 @@ pub enum TransactionErr {
 }
 
 #[derive(Debug, Clone)]
+pub struct DelayedKickback {
+    pub recipient: Address,
+    pub payout_value: U256,
+    pub payout_tx_fee: U256,
+}
+
+#[derive(Debug, Clone)]
 pub struct BundleOk {
     pub gas_used: u64,
     pub cumulative_gas_used: u64,
@@ -225,7 +232,7 @@ pub struct BundleOk {
     pub nonces_updated: Vec<(Address, u64)>,
     pub paid_kickbacks: Vec<(Address, U256)>,
     /// The refund amount to accrue per recipient and be paid at the end of the block and tx fee value that is deducted from the profit of the first delayed refund bundle for the recipient in the block
-    pub delayed_kickback: Option<(Address, U256, U256)>,
+    pub delayed_kickback: Option<DelayedKickback>,
     /// Only for sbundles we accumulate ShareBundleInner::original_order_id that executed ok.
     /// Its original use is for only one level or orders with original_order_id but if nesting happens the parent order original_order_id goes before its children (pre-order DFS)
     /// Fully dropped orders (TxRevertBehavior::AllowedExcluded allows it!) are not included.
@@ -291,7 +298,7 @@ pub struct OrderOk {
     /// nonces_updates has a set of deduplicated final nonces of the txs in the order
     pub nonces_updated: Vec<(Address, u64)>,
     pub paid_kickbacks: Vec<(Address, U256)>,
-    pub delayed_kickback: Option<(Address, U256, U256)>,
+    pub delayed_kickback: Option<DelayedKickback>,
     pub used_state_trace: Option<UsedStateTrace>,
 }
 
@@ -799,8 +806,11 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                 // We already determined that refund for this recipient will cost [`BASE_TX_GAS`]
                 // and previously inserted a bundle that is capable of paying this cost.
                 // The recipient will be awarded full refund value for the current bundle.
-                insert.delayed_kickback =
-                    Some((refunds_cfg.recipient, refundable_value, U256::ZERO));
+                insert.delayed_kickback = Some(DelayedKickback {
+                    recipient: refunds_cfg.recipient,
+                    payout_value: refundable_value,
+                    payout_tx_fee: U256::ZERO,
+                });
                 break 'refund;
             }
 
@@ -821,8 +831,11 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     .is_some_and(|remaining| remaining > payout.gas_limit)
             {
                 // This refund recipient is eligible for a combined refund at the end of the block.
-                insert.delayed_kickback =
-                    Some((refunds_cfg.recipient, payout.tx_value, payout.base_fee));
+                insert.delayed_kickback = Some(DelayedKickback {
+                    recipient: refunds_cfg.recipient,
+                    payout_value: payout.tx_value,
+                    payout_tx_fee: payout.base_fee,
+                });
                 break 'refund;
             }
 
@@ -1203,7 +1216,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                 let delayed_refund_cost = ok
                     .delayed_kickback
                     .as_ref()
-                    .map(|(_, value, fee)| value + fee)
+                    .map(|r| r.payout_value + r.payout_tx_fee)
                     .unwrap_or_default();
 
                 // Builder does sign txs in this code path, so do not allow negative coinbase

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -224,8 +224,8 @@ pub struct BundleOk {
     /// nonces_updates has a set of deduplicated final nonces of the txs in the order
     pub nonces_updated: Vec<(Address, u64)>,
     pub paid_kickbacks: Vec<(Address, U256)>,
-    /// The refund amount to accrue per recipient and be paid at the end of the block.
-    pub delayed_kickback: Option<(Address, U256)>,
+    /// The refund amount to accrue per recipient and be paid at the end of the block and tx fee value that is deducted from the profit of the first delayed refund bundle for the recipient in the block
+    pub delayed_kickback: Option<(Address, U256, U256)>,
     /// Only for sbundles we accumulate ShareBundleInner::original_order_id that executed ok.
     /// Its original use is for only one level or orders with original_order_id but if nesting happens the parent order original_order_id goes before its children (pre-order DFS)
     /// Fully dropped orders (TxRevertBehavior::AllowedExcluded allows it!) are not included.
@@ -291,7 +291,7 @@ pub struct OrderOk {
     /// nonces_updates has a set of deduplicated final nonces of the txs in the order
     pub nonces_updated: Vec<(Address, u64)>,
     pub paid_kickbacks: Vec<(Address, U256)>,
-    pub delayed_kickback: Option<(Address, U256)>,
+    pub delayed_kickback: Option<(Address, U256, U256)>,
     pub used_state_trace: Option<UsedStateTrace>,
 }
 
@@ -324,6 +324,7 @@ pub struct ReservedPayout {
     pub gas_limit: u64,
     pub tx_value: U256,
     pub total_refundable_value: U256,
+    pub base_fee: U256,
 }
 
 #[derive(Debug, Clone)]
@@ -651,6 +652,7 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
         Ok(ReservedPayout {
             gas_limit,
             tx_value,
+            base_fee,
             total_refundable_value: refundable_value,
         })
     }
@@ -797,7 +799,8 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                 // We already determined that refund for this recipient will cost [`BASE_TX_GAS`]
                 // and previously inserted a bundle that is capable of paying this cost.
                 // The recipient will be awarded full refund value for the current bundle.
-                insert.delayed_kickback = Some((refunds_cfg.recipient, refundable_value));
+                insert.delayed_kickback =
+                    Some((refunds_cfg.recipient, refundable_value, U256::ZERO));
                 break 'refund;
             }
 
@@ -818,7 +821,8 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
                     .is_some_and(|remaining| remaining > payout.gas_limit)
             {
                 // This refund recipient is eligible for a combined refund at the end of the block.
-                insert.delayed_kickback = Some((refunds_cfg.recipient, payout.tx_value));
+                insert.delayed_kickback =
+                    Some((refunds_cfg.recipient, payout.tx_value, payout.base_fee));
                 break 'refund;
             }
 
@@ -1196,15 +1200,16 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
     ) -> Result<Result<OrderOk, OrderErr>, CriticalCommitOrderError> {
         match bundle_result {
             Ok(ok) => {
-                let delayed_refund_value = ok
+                let delayed_refund_cost = ok
                     .delayed_kickback
                     .as_ref()
-                    .map_or(U256::ZERO, |(_, value)| *value);
+                    .map(|(_, value, fee)| value + fee)
+                    .unwrap_or_default();
 
                 // Builder does sign txs in this code path, so do not allow negative coinbase
                 // profit.
                 let coinbase_profit = match self
-                    .coinbase_profit_when_refunds(coinbase_balance_before, delayed_refund_value)?
+                    .coinbase_profit_when_refunds(coinbase_balance_before, delayed_refund_cost)?
                 {
                     Ok(profit) => profit,
                     Err(err) => return Ok(Err(err)),
@@ -1232,10 +1237,10 @@ impl<'a, 'b, 'c, 'd, Tracer: SimulationTracer> PartialBlockFork<'a, 'b, 'c, 'd, 
     fn coinbase_profit_when_refunds(
         &mut self,
         initial_balance: U256,
-        delayed_refund_value: U256,
+        delayed_refund_cost: U256,
     ) -> Result<Result<U256, OrderErr>, CriticalCommitOrderError> {
         let coinbase_balance_after = self.coinbase_balance()?;
-        let min_balance = initial_balance + delayed_refund_value;
+        let min_balance = initial_balance + delayed_refund_cost;
         if coinbase_balance_after >= min_balance {
             Ok(Ok(coinbase_balance_after - min_balance))
         } else {


### PR DESCRIPTION
## 📝 Summary

Delayed refunds were not accounting for base fee for refund transaction. 

When estimating refund tx value the payout tx value was used which does not take base fee cost for the account. 

This PR credits first delayed refund bundle for the base fee.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
