### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -25,7 +25,7 @@ jobs:
           - ""
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # https://github.com/dtolnay/rust-toolchain
       - name: Setup rust toolchain
@@ -76,7 +76,7 @@ jobs:
           - ""
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # https://github.com/dtolnay/rust-toolchain
       - name: Setup rust toolchain

--- a/.github/workflows/checks_docker.yaml
+++ b/.github/workflows/checks_docker.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,7 +94,7 @@ jobs:
             protobuf-compiler
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-      - uses: actions/checkout@v4 # must install git before checkout and set safe.directory after checkout because of container
+      - uses: actions/checkout@v5 # must install git before checkout and set safe.directory after checkout because of container
 
       - name: Build rbuilder binary
         run: |
@@ -132,7 +132,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -176,7 +176,7 @@ jobs:
 
     steps:
       - name: checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: docker qemu
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0