### PR TITLE
feat(relay): update slot registrations at interval

### DIFF
--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -85,6 +85,7 @@ async fn main() -> eyre::Result<()> {
     let payload_event = MevBoostSlotDataGenerator::new(
         vec![Client::default()],
         vec![relay],
+        Duration::from_millis(1_000),
         blocklist_provider.clone(),
         cancel.clone(),
     );

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -125,6 +125,8 @@ pub struct Config {
     /// selected builder configurations
     pub builders: Vec<BuilderConfig>,
 
+    /// The interval at which validator registrations should be updated.
+    pub registration_update_interval_ms: Option<u64>,
     /// When the sample bidder (see TrueBlockValueBiddingService) will start bidding.
     /// Usually a negative number.
     pub slot_delta_to_start_bidding_ms: Option<i64>,
@@ -133,6 +135,7 @@ pub struct Config {
 }
 
 const DEFAULT_SLOT_DELTA_TO_START_BIDDING_MS: i64 = -8000;
+const DEFAULT_REGISTRATION_UPDATE_INTERVAL_MS: u64 = 5_000;
 const DEFAULT_ASK_FOR_FILTERING_VALIDATORS: bool = false;
 const DEFAULT_CAN_IGNORE_GAS_LIMIT: bool = false;
 
@@ -392,6 +395,7 @@ impl LiveBuilderConfig for Config {
     fn base_config(&self) -> &BaseConfig {
         &self.base_config
     }
+
     async fn new_builder<P>(
         &self,
         provider: P,
@@ -401,7 +405,10 @@ impl LiveBuilderConfig for Config {
         P: StateProviderFactory + Clone + 'static,
     {
         let subsidy = self.subsidy.clone();
-        let slot_delta_to_start_bidding_ms = self.slot_delta_to_start_bidding_ms;
+        let slot_delta_to_start_bidding_ms = time::Duration::milliseconds(
+            self.slot_delta_to_start_bidding_ms
+                .unwrap_or(DEFAULT_SLOT_DELTA_TO_START_BIDDING_MS),
+        );
         // Create the bidding service factory
         let bidding_service_factory = |landed_blocks: &[LandedBlockInfo]| {
             // Clone the data you need for the async block
@@ -415,10 +422,7 @@ impl LiveBuilderConfig for Config {
                 let bidding_service: Arc<dyn BiddingService> =
                     Arc::new(TrueBlockValueBiddingService::new(
                         &landed_blocks,
-                        time::Duration::milliseconds(
-                            slot_delta_to_start_bidding_ms
-                                .unwrap_or(DEFAULT_SLOT_DELTA_TO_START_BIDDING_MS),
-                        ),
+                        slot_delta_to_start_bidding_ms,
                         subsidy,
                     ));
                 Ok(bidding_service)
@@ -436,12 +440,17 @@ impl LiveBuilderConfig for Config {
         )
         .await?;
 
+        let registration_update_interval = Duration::from_millis(
+            self.registration_update_interval_ms
+                .unwrap_or(DEFAULT_REGISTRATION_UPDATE_INTERVAL_MS),
+        );
         let live_builder = create_builder_from_sink(
             &self.base_config,
             &self.l1_config,
             provider,
             sink_factory,
             slot_info_provider,
+            registration_update_interval,
             cancellation_token,
         )
         .await?;
@@ -634,6 +643,7 @@ impl Default for Config {
                     }),
                 },
             ],
+            registration_update_interval_ms: None,
             slot_delta_to_start_bidding_ms: None,
             subsidy: None,
         }
@@ -993,6 +1003,7 @@ pub async fn create_builder_from_sink<P>(
     provider: P,
     sink_factory: Box<dyn UnfinishedBlockBuildingSinkFactory>,
     slot_info_provider: Vec<MevBoostRelaySlotInfoProvider>,
+    registration_update_interval: Duration,
     cancellation_token: CancellationToken,
 ) -> eyre::Result<super::LiveBuilder<P, MevBoostSlotDataGenerator>>
 where
@@ -1004,6 +1015,7 @@ where
     let payload_event = MevBoostSlotDataGenerator::new(
         l1_config.beacon_clients()?,
         slot_info_provider,
+        registration_update_interval,
         blocklist_provider.clone(),
         cancellation_token.clone(),
     );

--- a/crates/rbuilder/src/live_builder/payload_events/mod.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/mod.rs
@@ -130,8 +130,11 @@ impl MevBoostSlotDataGenerator {
     ///     it, but even with the event being created for every slot, the fee_recipient we get from MEV-Boost might be different so we should always replace it.
     ///     Note that with MEV-boost the validator may change the fee_recipient when registering to the Relays.
     pub fn spawn(self) -> (JoinHandle<()>, mpsc::UnboundedReceiver<MevBoostSlotData>) {
-        let relays =
-            RelaysForSlotData::spawn_with_interval(self.relays.clone(), self.update_interval);
+        let relays = RelaysForSlotData::spawn_with_interval(
+            self.relays.clone(),
+            self.update_interval,
+            self.global_cancellation.clone(),
+        );
 
         // we generate first payload id randomly so logs don't have the same payload id after restarts
         // u32 is used because it will fit into json log as integer and its enough to be unique over long interval

--- a/crates/rbuilder/src/live_builder/payload_events/mod.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/mod.rs
@@ -99,6 +99,7 @@ impl MevBoostSlotData {
 pub struct MevBoostSlotDataGenerator {
     cls: Vec<Client>,
     relays: Vec<MevBoostRelaySlotInfoProvider>,
+    update_interval: Duration,
     blocklist_provider: Arc<dyn BlockListProvider>,
     global_cancellation: CancellationToken,
 }
@@ -107,12 +108,14 @@ impl MevBoostSlotDataGenerator {
     pub fn new(
         cls: Vec<Client>,
         relays: Vec<MevBoostRelaySlotInfoProvider>,
+        update_interval: Duration,
         blocklist_provider: Arc<dyn BlockListProvider>,
         global_cancellation: CancellationToken,
     ) -> Self {
         Self {
             cls,
             relays,
+            update_interval,
             blocklist_provider,
             global_cancellation,
         }
@@ -127,7 +130,8 @@ impl MevBoostSlotDataGenerator {
     ///     it, but even with the event being created for every slot, the fee_recipient we get from MEV-Boost might be different so we should always replace it.
     ///     Note that with MEV-boost the validator may change the fee_recipient when registering to the Relays.
     pub fn spawn(self) -> (JoinHandle<()>, mpsc::UnboundedReceiver<MevBoostSlotData>) {
-        let relays = RelaysForSlotData::new(&self.relays);
+        let relays =
+            RelaysForSlotData::spawn_with_interval(self.relays.clone(), self.update_interval);
 
         // we generate first payload id randomly so logs don't have the same payload id after restarts
         // u32 is used because it will fit into json log as integer and its enough to be unique over long interval
@@ -168,17 +172,16 @@ impl MevBoostSlotDataGenerator {
                     "Payload attributes received from CL client"
                 );
 
-                let (slot_data, relay_registrations) =
-                    if let Some(res) = relays.slot_data(slot).await {
-                        res
-                    } else {
-                        info!(
-                            payload_id,
-                            reason = "no MEV-Boost relay data",
-                            "Payload attributes discarded"
-                        );
-                        continue;
-                    };
+                let (slot_data, relay_registrations) = if let Some(res) = relays.slot_data(slot) {
+                    res
+                } else {
+                    info!(
+                        payload_id,
+                        reason = "no MEV-Boost relay data",
+                        "Payload attributes discarded"
+                    );
+                    continue;
+                };
 
                 info!(
                     payload_id,

--- a/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
@@ -8,6 +8,8 @@ use alloy_primitives::Address;
 use parking_lot::RwLock;
 use primitive_types::H384;
 use std::{sync::Arc, time::Duration};
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 use tracing::*;
 
 /// Info about a slot obtained from a relay.
@@ -93,6 +95,7 @@ impl RelaysForSlotData {
     pub fn spawn_with_interval(
         relays: Vec<MevBoostRelaySlotInfoProvider>,
         interval: Duration,
+        cancellation_token: CancellationToken,
     ) -> Self {
         let cache = RelayValidatorSlotDataCache::default();
         let can_ignore_gas_limit = relays
@@ -105,7 +108,12 @@ impl RelaysForSlotData {
             let cache = cache.clone();
             async move {
                 loop {
-                    tokio::time::sleep(interval).await;
+                    if timeout(interval, cancellation_token.cancelled())
+                        .await
+                        .is_ok()
+                    {
+                        return;
+                    }
                     cache.update(&relays).await;
                 }
             }

--- a/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{
     mev_boost::{RelayError, ValidatorSlotData},
     primitives::mev_boost::{MevBoostRelayID, MevBoostRelaySlotInfoProvider},
@@ -7,10 +5,10 @@ use crate::{
 };
 use ahash::{HashMap, HashSet};
 use alloy_primitives::Address;
-use futures::stream::FuturesOrdered;
+use parking_lot::RwLock;
 use primitive_types::H384;
-use tokio_stream::StreamExt;
-use tracing::{info, info_span, trace, warn};
+use std::{sync::Arc, time::Duration};
+use tracing::*;
 
 /// Info about a slot obtained from a relay.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
@@ -22,125 +20,112 @@ pub struct SlotData {
     pub pubkey: H384,
 }
 
-/// Gets ValidatorSlotData for a single slot via get_slot_data.
-/// Since the low level API used (/relay/v1/builder/validators) brings current and next epoch validator data it caches the results.
-#[derive(Debug)]
-struct RelayEpochCache {
-    relay: MevBoostRelaySlotInfoProvider,
-    min_slot: u64,
-    max_slot: u64,
-    slot_data: Vec<ValidatorSlotData>,
+/// Validator slot data by relay.
+#[derive(Clone, Debug)]
+struct RelayValidatorSlotDataCache(
+    Arc<RwLock<HashMap<MevBoostRelayID, HashMap<u64, ValidatorSlotData>>>>,
+);
+
+impl Default for RelayValidatorSlotDataCache {
+    fn default() -> Self {
+        Self(Arc::new(RwLock::new(Default::default())))
+    }
 }
 
-impl RelayEpochCache {
-    fn new(relay: MevBoostRelaySlotInfoProvider) -> Self {
-        Self {
-            relay,
-            min_slot: 0,
-            max_slot: 0,
-            slot_data: Vec::new(),
+impl RelayValidatorSlotDataCache {
+    async fn update(&self, clients: &[MevBoostRelaySlotInfoProvider]) {
+        for client in clients {
+            let registrations = match client.get_current_epoch_validators().await {
+                Ok(data) => data,
+                Err(error) => {
+                    let relay = client.id();
+                    warn!(%relay, ?error, "Error updating validator registrations");
+                    match error {
+                        RelayError::ConnectionError => {
+                            inc_conn_relay_errors(relay);
+                        }
+                        RelayError::TooManyRequests => {
+                            inc_too_many_req_relay_errors(relay);
+                        }
+                        _ => {
+                            inc_other_relay_errors(relay);
+                        }
+                    };
+                    continue;
+                }
+            };
+
+            let min_slot = registrations.iter().map(|v| v.slot).min().unwrap_or(0);
+            let max_slot = registrations.iter().map(|v| v.slot).max().unwrap_or(0);
+            let mut this = self.0.write();
+            let current_registrations = this.entry(client.id().clone()).or_default();
+
+            // Remove old registrations and update the new ones.
+            current_registrations.retain(|slot, _| slot >= &min_slot);
+            current_registrations.extend(registrations.into_iter().map(|r| (r.slot, r)));
+
+            let len = current_registrations.len();
+            info!(relay = %client.id(), len, min_slot, max_slot, "Updated validator registrations");
         }
     }
 
-    async fn update_epoch_data(&mut self) -> Result<(), RelayError> {
-        // @Far validate signatures of proposers here to make sure that relay is correct.
-        let validators = self.relay.get_current_epoch_validators().await?;
-        let min_slot = validators.iter().map(|v| v.slot).min().unwrap_or(0);
-        let max_slot = validators.iter().map(|v| v.slot).max().unwrap_or(0);
-
-        self.slot_data = validators;
-        self.min_slot = min_slot;
-        self.max_slot = max_slot;
-
-        Ok(())
-    }
-
-    /// Might fail (None) if the slot is in the past or far in the future.
-    /// Ideally, it's called just for the next slot.
-    async fn get_slot_data(&mut self, slot: u64) -> Result<Option<ValidatorSlotData>, RelayError> {
-        if slot < self.min_slot || slot > self.max_slot {
-            self.update_epoch_data().await?;
+    fn get_slot_registrations(&self, slot: u64) -> Vec<(MevBoostRelayID, ValidatorSlotData)> {
+        let mut slot_registrations = Vec::new();
+        for (relay_id, registrations) in self.0.read().iter() {
+            if let Some(slot_registration) = registrations.get(&slot) {
+                slot_registrations.push((relay_id.clone(), slot_registration.clone()));
+            }
         }
-
-        Ok(self.slot_data.iter().find(|v| v.slot == slot).cloned())
+        slot_registrations
     }
 }
 
 /// Helper to get SlotData from all relays.
 #[derive(Debug)]
 pub struct RelaysForSlotData {
-    /// Sorted by priority so when we use them on slot_data the one with the highest priority wins.
-    relay: Vec<(MevBoostRelayID, RelayEpochCache)>,
+    /// Validator registration cache.
+    cache: RelayValidatorSlotDataCache,
     /// Redundant with relay but easier to access/pass around.
     can_ignore_gas_limit: HashSet<MevBoostRelayID>,
 }
 
 impl RelaysForSlotData {
-    pub fn new(relays: &[MevBoostRelaySlotInfoProvider]) -> Self {
+    pub fn spawn_with_interval(
+        relays: Vec<MevBoostRelaySlotInfoProvider>,
+        interval: Duration,
+    ) -> Self {
+        let cache = RelayValidatorSlotDataCache::default();
         let can_ignore_gas_limit = relays
             .iter()
             .filter(|relay| relay.can_ignore_gas_limit())
             .map(|relay| relay.id().clone())
             .collect();
+
+        tokio::spawn(Box::pin({
+            let cache = cache.clone();
+            async move {
+                loop {
+                    tokio::time::sleep(interval).await;
+                    cache.update(&relays).await;
+                }
+            }
+        }));
+
         Self {
-            relay: relays
-                .iter()
-                .map(|relay| (relay.id().clone(), RelayEpochCache::new(relay.clone())))
-                .collect(),
+            cache,
             can_ignore_gas_limit,
         }
     }
 
     /// Asks all relays in parallel for ValidatorSlotData.
-    /// Under unconsistencies, the first one (the one with the highest priority as sorted on new) wins and any relay giving a different data
+    /// Under inconsistencies, the first one (the one with the highest priority as sorted on new) wins and any relay giving a different data
     /// is not included on the result.
-    pub async fn slot_data(
+    pub fn slot_data(
         &mut self,
         slot: u64,
     ) -> Option<(SlotData, Arc<HashMap<MevBoostRelayID, ValidatorSlotData>>)> {
-        // ask all relays concurrently about the slot
-        let relay_res = self
-            .relay
-            .iter_mut()
-            .map(|(k, v)| async { (k.clone(), v.get_slot_data(slot).await) })
-            .collect::<FuturesOrdered<_>>()
-            .collect::<Vec<_>>()
-            .await;
-
-        let mut relay_ok_res = Vec::new();
-        for (relay, res) in relay_res {
-            let span = info_span!("relay", relay, slot);
-            let _span_guard = span.enter();
-            let relay_data = match res {
-                Ok(Some(res)) => {
-                    trace!(?res, "Got slot data from the relay");
-                    res
-                }
-                Ok(None) => {
-                    trace!("Relay does not have slot data");
-                    continue;
-                }
-                Err(err) => {
-                    match err {
-                        RelayError::ConnectionError => {
-                            inc_conn_relay_errors(&relay);
-                        }
-                        RelayError::TooManyRequests => {
-                            inc_too_many_req_relay_errors(&relay);
-                        }
-                        _ => {
-                            inc_other_relay_errors(&relay);
-                        }
-                    }
-                    // we always warn here because error at this stage => no bids for slot on this relay
-                    warn!(err = ?err,"Relay returned error while getting epoch data, error");
-                    continue;
-                }
-            };
-            assert_eq!(relay_data.slot, slot);
-            relay_ok_res.push((relay, relay_data));
-        }
-        resolve_relay_slot_data(relay_ok_res, &self.can_ignore_gas_limit)
+        let registrations = self.cache.get_slot_registrations(slot);
+        resolve_relay_slot_data(registrations, &self.can_ignore_gas_limit)
     }
 }
 

--- a/crates/test-relay/src/relay.rs
+++ b/crates/test-relay/src/relay.rs
@@ -332,6 +332,7 @@ fn spawn_mev_boost_slot_data_generator(
     let slot_data_generator = MevBoostSlotDataGenerator::new(
         cl_clients,
         vec![relay],
+        Duration::from_millis(1_000),
         Arc::new(NullBlockListProvider::default()),
         cancellation_token.clone(),
     );
@@ -352,12 +353,12 @@ async fn run_slot_data_fetcher(
 ) {
     'slot_data: loop {
         let new_slot_data = tokio::select! {
-                data = slot_data_generator.recv() => if let Some(data) = data {
-                    data
-        } else {
-                    break 'slot_data;
-        },
-                _ = cancellation_token.cancelled() => break 'slot_data,
+            data = slot_data_generator.recv() => if let Some(data) = data {
+                data
+            } else {
+                break 'slot_data;
+            },
+            _ = cancellation_token.cancelled() => break 'slot_data,
         };
         {
             info!(slot = new_slot_data.slot(), "New slot data");


### PR DESCRIPTION
## 📝 Summary

Update relay validator registrations at a specified interval. Current update logic retails validator registrations for the next epoch, despite the fact that validator might update its preferences.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
