### PR TITLE
Fusaka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,11 +97,11 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.0"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7734aecfc58a597dde036e4c5cace2ae43e2f8bf3d406b022a1ef34da178dd49"
+checksum = "ef8ff73a143281cb77c32006b04af9c047a6b8fe5860e85a88ad325328965355"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "num_enum",
  "serde",
@@ -133,15 +133,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad451f9a70c341d951bca4e811d74dbe1e193897acd17e9dbac1353698cc430b"
+checksum = "b7345077623aaa080fc06735ac13b8fa335125c8550f9c4f64135a5bf6f79967"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
- "alloy-trie 0.8.1",
+ "alloy-serde 1.0.27",
+ "alloy-trie 0.9.1",
+ "alloy-tx-macros",
  "arbitrary",
  "auto_impl",
  "c-kzg",
@@ -150,7 +151,7 @@ dependencies = [
  "k256 0.13.4",
  "once_cell",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -172,29 +173,29 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142daffb15d5be1a2b20d2cd540edbcef03037b55d4ff69dc06beb4d06286dba"
+checksum = "501f83565d28bdb9d6457dd3b5d646e19db37709d0f27608a26a1839052ddade"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.27",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9135eb501feccf7f4cb8a183afd406a65483fdad7bbd7332d0470e5d725c92f"
+checksum = "a3f56873f3cac7a2c63d8e98a4314b8311aa96adb1a0f82ae923eb2119809d2c"
 dependencies = [
- "alloy-json-abi 1.2.0",
- "alloy-primitives 1.2.0",
- "alloy-sol-type-parser 1.2.0",
- "alloy-sol-types 1.2.0",
+ "alloy-json-abi 1.3.1",
+ "alloy-primitives 1.3.1",
+ "alloy-sol-type-parser 1.3.1",
+ "alloy-sol-types 1.3.1",
  "derive_more 2.0.1",
  "itoa",
  "serde",
@@ -221,7 +222,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "arbitrary",
  "crc",
@@ -247,7 +248,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "arbitrary",
  "rand 0.8.5",
@@ -272,7 +273,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "arbitrary",
  "k256 0.13.4",
@@ -299,21 +300,21 @@ dependencies = [
  "derive_more 2.0.1",
  "either",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3056872f6da48046913e76edb5ddced272861f6032f09461aea1a2497be5ae5d"
+checksum = "c219a87fb386a75780ddbdbbced242477321887e426b0f946c05815ceabe5e09"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.27",
  "arbitrary",
  "auto_impl",
  "c-kzg",
@@ -322,20 +323,23 @@ dependencies = [
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive",
  "serde",
- "sha2 0.10.8",
+ "serde_with",
+ "sha2 0.10.9",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.10.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394b09cf3a32773eedf11828987f9c72dfa74545040be0422e3f5f09a2a3fab9"
+checksum = "0dbe7c66c859b658d879b22e8aaa19546dab726b0639f4649a424ada3d99349e"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-hardforks",
- "alloy-primitives 1.2.0",
- "alloy-sol-types 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-hardforks 0.3.0",
+ "alloy-primitives 1.3.1",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-sol-types 1.3.1",
  "auto_impl",
  "derive_more 2.0.1",
  "op-alloy-consensus",
@@ -346,15 +350,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98fb40f07997529235cc474de814cd7bd9de561e101716289095696c0e4639d"
+checksum = "2dbf4c6b1b733ba0efaa6cc5f68786997a19ffcd88ff2ee2ba72fdd42594375e"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-serde 1.0.9",
- "alloy-trie 0.8.1",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
+ "alloy-serde 1.0.27",
+ "alloy-trie 0.9.1",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -365,7 +370,20 @@ checksum = "fbff8445282ec080c2673692062bd4930d7a0d6bda257caf138cfc650c503000"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124 0.2.0",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
+ "auto_impl",
+ "dyn-clone",
+]
+
+[[package]]
+name = "alloy-hardforks"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b180071d4f22db71702329101685ccff2e2a8f400d30a68ba907700163bf5"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124 0.2.0",
+ "alloy-primitives 1.3.1",
  "auto_impl",
  "dyn-clone",
  "serde",
@@ -385,12 +403,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b26fdd571915bafe857fccba4ee1a4f352965800e46a53e4a5f50187b7776fa"
+checksum = "125a1c373261b252e53e04d6e92c37d881833afc1315fceab53fd46045695640"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-sol-type-parser 1.2.0",
+ "alloy-primitives 1.3.1",
+ "alloy-sol-type-parser 1.3.1",
  "serde",
  "serde_json",
 ]
@@ -411,12 +429,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc08b31ebf9273839bd9a01f9333cbb7a3abb4e820c312ade349dd18bdc79581"
+checksum = "334555c323fa2bb98f1d4c242b62da9de8c715557a2ed680a76cefbcac19fefd"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-sol-types 1.2.0",
+ "alloy-primitives 1.3.1",
+ "alloy-sol-types 1.3.1",
+ "http 1.3.1",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -425,21 +444,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed117b08f0cc190312bf0c38c34cf4f0dabfb4ea8f330071c587cd7160a88cb2"
+checksum = "c7ea377c9650203d7a7da9e8dee7f04906b49a9253f554b110edd7972e75ef34"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-consensus-any 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-json-rpc 1.0.9",
- "alloy-network-primitives 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-consensus-any 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-json-rpc 1.0.27",
+ "alloy-network-primitives 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-any",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-serde 1.0.27",
  "alloy-signer",
- "alloy-sol-types 1.2.0",
+ "alloy-sol-types 1.3.1",
  "async-trait",
  "auto_impl",
  "derive_more 2.0.1",
@@ -464,27 +483,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7162ff7be8649c0c391f4e248d1273e85c62076703a1f3ec7daf76b283d886d"
+checksum = "b9f9ab9a9e92c49a357edaee2d35deea0a32ac8f313cfa37448f04e7e029c9d9"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-serde 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
+ "alloy-serde 1.0.27",
  "serde",
 ]
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec6d2e7743d2bcb3e7dfc9cb7a7322bc0f808fddd48f4aab5d974260f2ae0cf"
+checksum = "cb0af8bdb3ee8da43a1f1eb9d1df3c8e3bd657dd20eddd3f00f03105c0fdd3f5"
 dependencies = [
  "alloy-genesis",
- "alloy-hardforks",
+ "alloy-hardforks 0.2.6",
  "alloy-network",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-signer",
  "alloy-signer-local",
  "k256 0.13.4",
@@ -547,16 +566,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a326d47106039f38b811057215a92139f46eef7983a4b77b10930a0ea5685b1e"
+checksum = "bc9485c56de23438127a731a6b4c87803d49faf1a7068dcd1d8768aca3a9edb9"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_arbitrary",
  "derive_more 2.0.1",
  "foldhash",
  "getrandom 0.3.2",
@@ -578,22 +596,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84eba1fd8b6fe8b02f2acd5dd7033d0f179e304bd722d11e817db570d1fa6c4"
+checksum = "9a85361c88c16116defbd98053e3d267054d6b82729cdbef0236f7881590f924"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-json-rpc 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-json-rpc 1.0.27",
  "alloy-network",
- "alloy-network-primitives 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-network-primitives 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.27",
  "alloy-signer",
- "alloy-sol-types 1.2.0",
+ "alloy-sol-types 1.3.1",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
@@ -620,13 +638,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8550f7306e0230fc835eb2ff4af0a96362db4b6fc3f25767d161e0ad0ac765bf"
+checksum = "25b1eda077b102b167effaf0c9d9109b1232948a6c7fcaff74abdb5deb562a17"
 dependencies = [
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-json-rpc 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-transport",
+ "auto_impl",
  "bimap",
  "futures",
  "parking_lot",
@@ -663,18 +682,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518a699422a3eab800f3dac2130d8f2edba8e4fff267b27a9c7dc6a2b0d313ee"
+checksum = "743fc964abb0106e454e9e8683fb0809fb32940270ef586a58e913531360b302"
 dependencies = [
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-json-rpc 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
- "async-stream",
  "futures",
  "pin-project",
  "reqwest 0.12.15",
@@ -684,67 +702,66 @@ dependencies = [
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
- "tracing-futures",
  "url",
  "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c000cab4ec26a4b3e29d144e999e1c539c2fa0abed871bf90311eb3466187ca8"
+checksum = "e6445ccdc73c8a97e1794e9f0f91af52fb2bbf9ff004339a801b0293c3928abb"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-serde 1.0.27",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebdc864f573645c5288370c208912b85b5cacc8025b700c50c2b74d06ab9830"
+checksum = "196e0e38efeb2a5efb515758877765db56b3b18e998b809eb1e5d6fc20fcd097"
 dependencies = [
  "alloy-genesis",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abecc34549a208b5f91bc7f02df3205c36e2aa6586f1d9375c3382da1066b3b"
+checksum = "242ff10318efd61c4b17ac8584df03a8db1e12146704c08b1b69d070cd4a1ebf"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-primitives 1.3.1",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-serde 1.0.27",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b2fbe66d952089aa694e53802327798806498cd29ff88c75135770ecaabfc"
+checksum = "97372c51a14a804fb9c17010e3dd6c117f7866620b264e24b64d2259be44bcdf"
 dependencies = [
- "alloy-consensus-any 1.0.9",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-consensus-any 1.0.27",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-serde 1.0.27",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241aba7808bddc3ad1c6228e296a831f326f89118b1017012090709782a13334"
+checksum = "a2210006d3ee0b0468e49d81fc8b94ab9f088e65f955f8d56779545735b90873"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive",
@@ -757,25 +774,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c832f2e851801093928dbb4b7bd83cd22270faf76b2e080646b806a285c8757"
+checksum = "a005a343cae9a0d4078d2f85a666493922d4bfb756229ea2a45a4bafd21cb9f1"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
+ "derive_more 2.0.1",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab52691970553d84879d777419fa7b6a2e92e9fe8641f9324cc071008c2f656"
+checksum = "0e214c7667f88b2f7e48eb8428eeafcbf6faecda04175c5f4d13fdb2563333ac"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.27",
  "derive_more 2.0.1",
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive",
@@ -807,49 +826,50 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf7dff0fdd756a714d58014f4f8354a1706ebf9fa2cf73431e0aeec3c9431e"
+checksum = "672286c19528007df058bafd82c67e23247b4b3ebbc538cbddc705a82d8a930f"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-consensus-any 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-network-primitives 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-consensus-any 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-network-primitives 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
- "alloy-sol-types 1.2.0",
+ "alloy-serde 1.0.27",
+ "alloy-sol-types 1.3.1",
  "arbitrary",
  "itertools 0.14.0",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bd1c5d7b9f3f1caeeaa1c082aa28ba7ce2d67127b12b2a9b462712c8f6e1c5"
+checksum = "fa6c5068a20a19df4481ffd698540af5f3656f401d12d9b3707e8ab90311af1d"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-serde 1.0.27",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3507a04e868dd83219ad3cd6a8c58aefccb64d33f426b3934423a206343e84"
+checksum = "d53c5ea8e10ca72889476343deb98c050da7b85e119a55a2a02a9791cb8242e4"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-primitives 1.3.1",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-serde 1.0.27",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -857,13 +877,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec36272621c3ac82b47dd77f0508346687730b1c2e3e10d3715705c217c0a05"
+checksum = "bb1c7ee378e899353e05a0d9f5b73b5d57bdac257532c6acd98eaa6b093fe642"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
+ "alloy-primitives 1.3.1",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-serde 1.0.27",
  "serde",
 ]
 
@@ -880,11 +900,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730e8f2edf2fc224cabd1c25d090e1655fa6137b2e409f92e5eec735903f1507"
+checksum = "1aae653f049267ae7e040eab6c9b9a417064ca1a6cb21e3dd59b9f1131ef048f"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "arbitrary",
  "serde",
  "serde_json",
@@ -892,11 +912,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d2428445ec13edc711909e023d7779618504c4800be055a5b940025dbafe3"
+checksum = "d97cedce202f848592b96f7e891503d3adb33739c4e76904da73574290141b93"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "async-trait",
  "auto_impl",
  "either",
@@ -907,13 +927,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe6fedb7fe6e0dfae47fe020684f1d8e063274ef14bca387ddb7a6efa8ec1"
+checksum = "83ae7d854db5b7cdd5b9ed7ad13d1e5e034cdd8be85ffef081f61dc6c9e18351"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.27",
  "alloy-network",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-signer",
  "async-trait",
  "k256 0.13.4",
@@ -937,12 +957,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4be1ce1274ddd7fdfac86e5ece1b225e9bba1f2327e20fbb30ee6b9cc1423fe"
+checksum = "d20d867dcf42019d4779519a1ceb55eba8d7f3d0e4f0a89bcba82b8f9eb01e48"
 dependencies = [
- "alloy-sol-macro-expander 1.2.0",
- "alloy-sol-macro-input 1.2.0",
+ "alloy-sol-macro-expander 1.3.1",
+ "alloy-sol-macro-input 1.3.1",
  "proc-macro-error2",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
@@ -969,11 +989,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e92f3708ea4e0d9139001c86c051c538af0146944a2a9c7181753bd944bf57"
+checksum = "b74e91b0b553c115d14bd0ed41898309356dc85d0e3d4b9014c4e7715e48c8ad"
 dependencies = [
- "alloy-sol-macro-input 1.2.0",
+ "alloy-sol-macro-input 1.3.1",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.9.0",
@@ -981,7 +1001,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.100",
- "syn-solidity 1.2.0",
+ "syn-solidity 1.3.1",
  "tiny-keccak",
 ]
 
@@ -1003,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afe1bd348a41f8c9b4b54dfb314886786d6201235b0b3f47198b9d910c86bb2"
+checksum = "84194d31220803f5f62d0a00f583fd3a062b36382e2bea446f1af96727754565"
 dependencies = [
  "const-hex",
  "dunce",
@@ -1014,7 +1034,7 @@ dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
  "syn 2.0.100",
- "syn-solidity 1.2.0",
+ "syn-solidity 1.3.1",
 ]
 
 [[package]]
@@ -1029,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6195df2acd42df92a380a8db6205a5c7b41282d0ce3f4c665ecf7911ac292f1"
+checksum = "fe8c27b3cf6b2bb8361904732f955bc7c05e00be5f469cec7e2280b6167f3ff0"
 dependencies = [
  "serde",
  "winnow",
@@ -1052,24 +1072,25 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6185e98a79cf19010722f48a74b5a65d153631d2f038cabd250f4b9e9813b8ad"
+checksum = "f5383d34ea00079e6dd89c652bcbdb764db160cef84e6250926961a0b2295d04"
 dependencies = [
- "alloy-json-abi 1.2.0",
- "alloy-primitives 1.2.0",
- "alloy-sol-macro 1.2.0",
+ "alloy-json-abi 1.3.1",
+ "alloy-primitives 1.3.1",
+ "alloy-sol-macro 1.3.1",
  "serde",
 ]
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a712bdfeff42401a7dd9518f72f617574c36226a9b5414537fedc34350b73bf9"
+checksum = "c08b383bc903c927635e39e1dae7df2180877d93352d1abd389883665a598afc"
 dependencies = [
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-json-rpc 1.0.27",
+ "alloy-primitives 1.3.1",
+ "auto_impl",
  "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
@@ -1087,11 +1108,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea5a76d7f2572174a382aedf36875bedf60bcc41116c9f031cf08040703a2dc"
+checksum = "6e58dee1f7763ef302074b645fc4f25440637c09a60e8de234b62993f06c0ae3"
 dependencies = [
- "alloy-json-rpc 1.0.9",
+ "alloy-json-rpc 1.0.27",
  "alloy-transport",
  "reqwest 0.12.15",
  "serde_json",
@@ -1102,11 +1123,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606af17a7e064d219746f6d2625676122c79d78bf73dfe746d6db9ecd7dbcb85"
+checksum = "5ae5c6655e5cda1227f0c70b7686ecfb8af856771deebacad8dab9a7fbc51864"
 dependencies = [
- "alloy-json-rpc 1.0.9",
+ "alloy-json-rpc 1.0.27",
  "alloy-pubsub",
  "alloy-transport",
  "bytes",
@@ -1122,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.9"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c6f9b37cd8d44aab959613966cc9d4d7a9b429c575cec43b3e5b46ea109a79"
+checksum = "dcb2141958a1f13722cb20a2e01c130fb375209fa428849ae553c1518bc33a0d"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1148,7 +1169,7 @@ dependencies = [
  "alloy-rlp",
  "arrayvec",
  "derive_more 1.0.0",
- "nybbles",
+ "nybbles 0.3.4",
  "serde",
  "smallvec",
  "tracing",
@@ -1160,18 +1181,46 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more 2.0.1",
+ "nybbles 0.3.4",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3412d52bb97c6c6cc27ccc28d4e6e8cf605469101193b50b0bd5813b1f990b5"
+dependencies = [
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "arbitrary",
  "arrayvec",
  "derive_arbitrary",
  "derive_more 2.0.1",
- "nybbles",
+ "nybbles 0.4.3",
  "proptest",
  "proptest-derive",
  "serde",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d14809f908822dbff0dc472c77ca4aa129ab12e22fd9bff2dd1ef54603e68e3d"
+dependencies = [
+ "alloy-primitives 1.3.1",
+ "darling",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1862,6 +1911,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
 name = "backon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,7 +1986,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
-source = "git+https://github.com/ralexstokes/ethereum-consensus/?rev=ade5ce6c4a19107c1059e5338d8f18855bd2d931#ade5ce6c4a19107c1059e5338d8f18855bd2d931"
+source = "git+https://github.com/ralexstokes/ethereum-consensus/?rev=5031d31e318dd861cf3373702c5d92f085d926e4#5031d31e318dd861cf3373702c5d92f085d926e4"
 dependencies = [
  "clap 4.5.36",
  "ethereum-consensus",
@@ -1960,7 +2015,7 @@ dependencies = [
 name = "bid-scraper"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-provider",
  "alloy-rpc-types-beacon",
  "async-trait",
@@ -2042,7 +2097,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -2093,9 +2148,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 dependencies = [
  "serde",
 ]
@@ -2111,19 +2166,6 @@ dependencies = [
  "serde",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake3"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq 0.3.1",
 ]
 
 [[package]]
@@ -2155,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
 dependencies = [
  "cc",
  "glob",
@@ -2171,7 +2213,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -2187,7 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
 dependencies = [
  "arrayvec",
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "boa_ast",
  "boa_gc",
  "boa_interner",
@@ -2272,7 +2314,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -2368,17 +2410,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
-]
-
-[[package]]
-name = "bstr"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
-dependencies = [
- "memchr",
- "regex-automata 0.4.9",
- "serde",
 ]
 
 [[package]]
@@ -2586,9 +2617,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2862,12 +2893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,7 +3107,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -3392,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.2.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
@@ -3553,7 +3578,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3703,7 +3728,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -3823,7 +3848,7 @@ dependencies = [
  "k256 0.13.4",
  "log",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "sha3",
  "zeroize",
@@ -3913,7 +3938,7 @@ dependencies = [
 name = "eth-sparse-mpt"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-trie 0.8.1",
  "arrayvec",
@@ -3923,6 +3948,7 @@ dependencies = [
  "eyre",
  "flate2",
  "hash-db",
+ "nybbles 0.3.4",
  "parking_lot",
  "proptest",
  "rand 0.8.5",
@@ -3978,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/ralexstokes/ethereum-consensus/?rev=ade5ce6c4a19107c1059e5338d8f18855bd2d931#ade5ce6c4a19107c1059e5338d8f18855bd2d931"
+source = "git+https://github.com/ralexstokes/ethereum-consensus/?rev=5031d31e318dd861cf3373702c5d92f085d926e4#5031d31e318dd861cf3373702c5d92f085d926e4"
 dependencies = [
  "blst",
  "bs58 0.4.0",
@@ -3992,7 +4018,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "ssz_rs",
  "thiserror 1.0.69",
  "tokio",
@@ -4023,7 +4049,7 @@ checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
 dependencies = [
  "cpufeatures",
  "ring 0.17.14",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4035,7 +4061,7 @@ dependencies = [
  "cpufeatures",
  "lazy_static",
  "ring 0.16.20",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4057,7 +4083,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "hex",
  "serde",
  "serde_derive",
@@ -4081,7 +4107,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca8ba45b63c389c6e115b095ca16381534fdcc03cf58176a3f8554db2dbe19b"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "ethereum_serde_utils 0.8.0",
  "itertools 0.13.0",
  "serde",
@@ -4695,7 +4721,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5220b8ba44c68a9a7f7a7659e864dd73692e417ef0211bea133c7b74e031eeb9"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "libc",
  "libgit2-sys",
  "log",
@@ -4773,6 +4799,16 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a636fb6a653382a379ee1e5593dacdc628667994167024c143214cafd40c1a86"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5705,7 +5741,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "inotify-sys",
  "libc",
 ]
@@ -5939,18 +5975,18 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fba77a59c4c644fd48732367624d1bcf6f409f9c9a286fbc71d2f1fc0b2ea16"
+checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
 dependencies = [
- "jsonrpsee-client-transport 0.25.1",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-http-client 0.25.1",
- "jsonrpsee-proc-macros 0.25.1",
- "jsonrpsee-server 0.25.1",
- "jsonrpsee-types 0.25.1",
- "jsonrpsee-wasm-client 0.25.1",
- "jsonrpsee-ws-client 0.25.1",
+ "jsonrpsee-client-transport 0.26.0",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-http-client 0.26.0",
+ "jsonrpsee-proc-macros 0.26.0",
+ "jsonrpsee-server 0.26.0",
+ "jsonrpsee-types 0.26.0",
+ "jsonrpsee-wasm-client 0.26.0",
+ "jsonrpsee-ws-client 0.26.0",
  "tokio",
  "tracing",
 ]
@@ -5980,16 +6016,16 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a320a3f1464e4094f780c4d48413acd786ce5627aaaecfac9e9c7431d13ae1"
+checksum = "cf36eb27f8e13fa93dcb50ccb44c417e25b818cfa1a481b5470cd07b19c60b98"
 dependencies = [
  "base64 0.22.1",
  "futures-channel",
  "futures-util",
  "gloo-net 0.6.0",
  "http 1.3.1",
- "jsonrpsee-core 0.25.1",
+ "jsonrpsee-core 0.26.0",
  "pin-project",
  "rustls 0.23.26",
  "rustls-pki-types",
@@ -6031,9 +6067,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693c93cbb7db25f4108ed121304b671a36002c2db67dff2ee4391a688c738547"
+checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6042,7 +6078,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-types 0.26.0",
  "parking_lot",
  "pin-project",
  "rand 0.9.0",
@@ -6079,17 +6115,17 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6962d2bd295f75e97dd328891e58fce166894b974c1f7ce2e7597f02eeceb791"
+checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
 dependencies = [
  "base64 0.22.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
  "hyper-util",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-types 0.26.0",
  "rustls 0.23.26",
  "rustls-platform-verifier",
  "serde",
@@ -6115,9 +6151,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa4f5daed39f982a1bb9d15449a28347490ad42b212f8eaa2a2a344a0dce9e9"
+checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate 3.3.0",
@@ -6151,9 +6187,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38b0bcf407ac68d241f90e2d46041e6a06988f97fe1721fb80b91c42584fae6"
+checksum = "4c51b7c290bb68ce3af2d029648148403863b982f138484a73f02a9dd52dbd7f"
 dependencies = [
  "futures-util",
  "http 1.3.1",
@@ -6161,8 +6197,8 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-util",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-types 0.26.0",
  "pin-project",
  "route-recognizer",
  "serde",
@@ -6192,9 +6228,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66df7256371c45621b3b7d2fb23aea923d577616b9c0e9c0b950a6ea5c2be0ca"
+checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
 dependencies = [
  "http 1.3.1",
  "serde",
@@ -6215,13 +6251,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67695cbcf4653f39f8f8738925547e0e23fd9fe315bccf951097b9f6a38781"
+checksum = "7902885de4779f711a95d82c8da2d7e5f9f3a7c7cfa44d51c067fd1c29d72a3c"
 dependencies = [
- "jsonrpsee-client-transport 0.25.1",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-client-transport 0.26.0",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-types 0.26.0",
  "tower 0.5.2",
 ]
 
@@ -6240,14 +6276,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da2694c9ff271a9d3ebfe520f6b36820e85133a51be77a3cb549fd615095261"
+checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
 dependencies = [
  "http 1.3.1",
- "jsonrpsee-client-transport 0.25.1",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-client-transport 0.26.0",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-types 0.26.0",
  "tower 0.5.2",
  "url",
 ]
@@ -6276,7 +6312,7 @@ dependencies = [
  "cfg-if",
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6290,7 +6326,7 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "once_cell",
  "serdect",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "signature 2.2.0",
 ]
 
@@ -6462,7 +6498,7 @@ dependencies = [
  "libsecp256k1",
  "multihash 0.19.3",
  "quick-protobuf",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tracing",
  "zeroize",
@@ -6485,7 +6521,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "libc",
  "redox_syscall",
 ]
@@ -7101,7 +7137,7 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "unsigned-varint 0.7.2",
 ]
 
@@ -7217,7 +7253,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -7415,9 +7451,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
 dependencies = [
  "alloy-rlp",
- "arbitrary",
  "const-hex",
  "proptest",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63cb50036b1ad148038105af40aaa70ff24d8a14fbc44ae5c914e1348533d12e"
+dependencies = [
+ "alloy-rlp",
+ "arbitrary",
+ "cfg-if",
+ "proptest",
+ "ruint",
  "serde",
  "smallvec",
 ]
@@ -7449,15 +7499,15 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.17.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2423a125ef2daa0d15dacc361805a0b6f76d6acfc6e24a1ff6473582087fe75"
+checksum = "d9ade20c592484ba1ea538006e0454284174447a3adf9bb59fa99ed512f95493"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.27",
  "arbitrary",
  "derive_more 2.0.1",
  "serde",
@@ -7467,17 +7517,18 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.17.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aea08d8ad3f533df0c5082d3e93428a4c57898b7ade1be928fa03918f22e71"
+checksum = "d4256b1eda5766a9fa7de5874e54515994500bef632afda41e940aed015f9455"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "ethereum_ssz 0.9.0",
+ "ethereum_ssz_derive",
  "op-alloy-consensus",
  "snap",
  "thiserror 2.0.12",
@@ -7485,12 +7536,11 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "5.0.1"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e8a3830a2be82166fbe9ead34361149ff4320743ed7ee5502ab779de221361"
+checksum = "5ba21d705bbbfc947a423cba466d75e4af0c7d43ee89ba0a0f1cfa04963cede9"
 dependencies = [
  "auto_impl",
- "once_cell",
  "revm",
  "serde",
 ]
@@ -7532,7 +7582,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -7597,7 +7647,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7723,7 +7773,7 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8017,7 +8067,7 @@ checksum = "b24f92fc5b167f668ff85ab9607dfa72e2c09664cacef59297ee8601dee60126"
 dependencies = [
  "ahash",
  "arrow2",
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "chrono",
  "comfy-table",
  "either",
@@ -8088,7 +8138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c33762ec2a55e01c9f8776b34db86257c70a0a3b3929bd4eb91a52aacf61456"
 dependencies = [
  "ahash",
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "glob",
  "once_cell",
  "polars-arrow",
@@ -8441,7 +8491,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "chrono",
  "flate2",
  "hex",
@@ -8455,7 +8505,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "chrono",
  "hex",
 ]
@@ -8477,18 +8527,18 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_xorshift 0.3.0",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
+ "rand_xorshift 0.4.0",
  "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
@@ -8580,7 +8630,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "memchr",
  "unicase",
 ]
@@ -8933,11 +8983,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -8955,7 +9005,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -8976,7 +9026,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -9005,20 +9055,20 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "alloy-chains",
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
  "alloy-evm",
- "alloy-json-rpc 1.0.9",
+ "alloy-json-rpc 1.0.27",
  "alloy-network",
- "alloy-network-primitives 1.0.9",
+ "alloy-network-primitives 1.0.27",
  "alloy-node-bindings",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.27",
  "alloy-signer-local",
  "assert_matches",
  "async-trait",
@@ -9071,6 +9121,7 @@ dependencies = [
  "reth-db",
  "reth-db-common",
  "reth-errors",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-node-api",
@@ -9084,11 +9135,11 @@ dependencies = [
  "reth-trie-parallel",
  "revm",
  "revm-inspectors",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "shellexpand",
  "sqlx",
  "sysperf",
@@ -9131,7 +9182,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -9337,8 +9388,8 @@ dependencies = [
 
 [[package]]
 name = "reth"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -9371,9 +9422,9 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
@@ -9383,12 +9434,12 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "futures-core",
  "futures-util",
  "metrics",
@@ -9407,12 +9458,12 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-signer",
  "alloy-signer-local",
  "derive_more 2.0.1",
@@ -9438,16 +9489,16 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
  "alloy-evm",
  "alloy-genesis",
- "alloy-primitives 1.2.0",
- "alloy-trie 0.8.1",
+ "alloy-primitives 1.3.1",
+ "alloy-trie 0.9.1",
  "auto_impl",
  "derive_more 2.0.1",
  "reth-ethereum-forks",
@@ -9458,8 +9509,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-genesis",
  "clap 4.5.36",
@@ -9472,14 +9523,14 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "ahash",
  "alloy-chains",
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "backon",
  "clap 4.5.36",
@@ -9507,6 +9558,7 @@ dependencies = [
  "reth-discv5",
  "reth-downloaders",
  "reth-ecies",
+ "reth-era",
  "reth-era-downloader",
  "reth-era-utils",
  "reth-eth-wire",
@@ -9526,12 +9578,13 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
+ "reth-revm",
  "reth-stages",
  "reth-static-file",
  "reth-static-file-types",
  "reth-trie",
  "reth-trie-db",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "tar",
@@ -9543,8 +9596,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9553,17 +9606,17 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "cfg-if",
  "eyre",
  "libc",
  "rand 0.8.5",
  "reth-fs-util",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.12",
  "tikv-jemallocator",
@@ -9571,14 +9624,14 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
  "alloy-genesis",
- "alloy-primitives 1.2.0",
- "alloy-trie 0.8.1",
+ "alloy-primitives 1.3.1",
+ "alloy-trie 0.9.1",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -9591,8 +9644,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "convert_case 0.7.1",
  "proc-macro2 1.0.95",
@@ -9602,8 +9655,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9612,15 +9665,16 @@ dependencies = [
  "reth-stages-types",
  "serde",
  "toml 0.8.20",
+ "url",
 ]
 
 [[package]]
 name = "reth-consensus"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-primitives 1.3.1",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -9629,11 +9683,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -9641,13 +9695,13 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-json-rpc 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-provider",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -9660,15 +9714,16 @@ dependencies = [
  "reth-tracing",
  "ringbuffer",
  "serde",
+ "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "reth-db"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "derive_more 2.0.1",
  "eyre",
  "metrics",
@@ -9691,12 +9746,12 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.27",
  "alloy-genesis",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
@@ -9719,12 +9774,12 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.27",
  "alloy-genesis",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
@@ -9732,6 +9787,7 @@ dependencies = [
  "reth-config",
  "reth-db-api",
  "reth-etl",
+ "reth-execution-errors",
  "reth-fs-util",
  "reth-node-types",
  "reth-primitives-traits",
@@ -9748,11 +9804,11 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -9763,10 +9819,10 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "discv5",
  "enr 0.13.0",
@@ -9779,7 +9835,7 @@ dependencies = [
  "reth-net-nat",
  "reth-network-peers",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.12",
  "tokio",
@@ -9789,10 +9845,10 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "derive_more 2.0.1",
  "discv5",
@@ -9805,7 +9861,7 @@ dependencies = [
  "reth-ethereum-forks",
  "reth-metrics",
  "reth-network-peers",
- "secp256k1",
+ "secp256k1 0.30.0",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -9813,10 +9869,10 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "data-encoding",
  "enr 0.13.0",
  "hickory-resolver",
@@ -9826,7 +9882,7 @@ dependencies = [
  "reth-network-peers",
  "reth-tokio-util",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -9837,12 +9893,12 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "futures",
  "futures-util",
@@ -9867,11 +9923,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "aes",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "block-padding",
  "byteorder",
@@ -9885,8 +9941,8 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
- "secp256k1",
- "sha2 0.10.8",
+ "secp256k1 0.30.0",
+ "sha2 0.10.9",
  "sha3",
  "thiserror 2.0.12",
  "tokio",
@@ -9898,27 +9954,20 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
  "eyre",
  "futures-util",
  "reth-chainspec",
- "reth-consensus",
  "reth-engine-primitives",
- "reth-engine-service",
- "reth-engine-tree",
  "reth-ethereum-engine-primitives",
- "reth-evm",
- "reth-node-types",
  "reth-payload-builder",
  "reth-payload-primitives",
  "reth-provider",
- "reth-prune",
- "reth-stages-api",
  "reth-transaction-pool",
  "tokio",
  "tokio-stream",
@@ -9927,22 +9976,23 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
  "auto_impl",
  "futures",
  "reth-chain-state",
  "reth-errors",
  "reth-ethereum-primitives",
+ "reth-evm",
  "reth-execution-types",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
- "reth-trie",
  "reth-trie-common",
  "serde",
  "thiserror 2.0.12",
@@ -9951,8 +10001,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "futures",
  "pin-project",
@@ -9974,18 +10024,17 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
  "alloy-evm",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "futures",
- "itertools 0.14.0",
  "metrics",
  "mini-moka",
  "parking_lot",
@@ -9997,6 +10046,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
+ "reth-execution-types",
  "reth-metrics",
  "reth-network-p2p",
  "reth-payload-builder",
@@ -10011,9 +10061,11 @@ dependencies = [
  "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
+ "reth-trie-sparse-parallel",
  "revm",
  "revm-primitives",
  "schnellru",
+ "smallvec",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -10021,10 +10073,10 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.27",
  "alloy-rpc-types-engine",
  "eyre",
  "futures",
@@ -10032,6 +10084,7 @@ dependencies = [
  "pin-project",
  "reth-chainspec",
  "reth-engine-primitives",
+ "reth-engine-tree",
  "reth-errors",
  "reth-evm",
  "reth-fs-util",
@@ -10048,12 +10101,12 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "ethereum_ssz 0.9.0",
  "ethereum_ssz_derive",
@@ -10064,34 +10117,38 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "bytes",
  "eyre",
  "futures-util",
  "reqwest 0.12.15",
  "reth-fs-util",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tokio",
 ]
 
 [[package]]
 name = "reth-era-utils"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-primitives 1.3.1",
+ "alloy-rlp",
  "eyre",
  "futures-util",
  "reth-db-api",
  "reth-era",
  "reth-era-downloader",
+ "reth-ethereum-primitives",
  "reth-etl",
  "reth-fs-util",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-stages-types",
  "reth-storage-api",
  "tokio",
  "tracing",
@@ -10099,8 +10156,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10110,11 +10167,11 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-chains",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "bytes",
  "derive_more 2.0.1",
@@ -10138,14 +10195,14 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-hardforks",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-hardforks 0.3.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "bytes",
  "derive_more 2.0.1",
@@ -10159,71 +10216,33 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-rlp",
- "alloy-rpc-types",
- "backon",
  "clap 4.5.36",
  "eyre",
- "futures",
- "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-runner",
- "reth-cli-util",
- "reth-config",
- "reth-consensus",
  "reth-db",
- "reth-db-api",
- "reth-downloaders",
- "reth-errors",
- "reth-ethereum-payload-builder",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-execution-types",
- "reth-exex",
- "reth-fs-util",
- "reth-network",
- "reth-network-api",
- "reth-network-p2p",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
  "reth-node-ethereum",
- "reth-node-events",
  "reth-node-metrics",
- "reth-payload-builder",
- "reth-primitives-traits",
- "reth-provider",
- "reth-prune",
- "reth-revm",
- "reth-stages",
- "reth-static-file",
- "reth-tasks",
  "reth-tracing",
- "reth-transaction-pool",
- "reth-trie",
- "reth-trie-db",
- "serde_json",
- "similar-asserts",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -10234,11 +10253,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -10246,18 +10265,18 @@ dependencies = [
  "reth-payload-primitives",
  "reth-primitives-traits",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-eip2124 0.2.0",
- "alloy-hardforks",
- "alloy-primitives 1.2.0",
+ "alloy-hardforks 0.3.0",
+ "alloy-primitives 1.3.1",
  "auto_impl",
  "once_cell",
  "rustc-hash 2.1.1",
@@ -10265,15 +10284,17 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "reth-basic-payload-builder",
  "reth-chainspec",
+ "reth-consensus-common",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
@@ -10292,12 +10313,12 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "arbitrary",
  "modular-bitfield",
@@ -10310,8 +10331,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10320,13 +10341,13 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
  "alloy-evm",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "auto_impl",
  "derive_more 2.0.1",
  "futures-util",
@@ -10343,13 +10364,14 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
  "alloy-evm",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
+ "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "reth-chainspec",
  "reth-ethereum-forks",
@@ -10357,31 +10379,32 @@ dependencies = [
  "reth-evm",
  "reth-execution-types",
  "reth-primitives-traits",
+ "reth-storage-errors",
  "revm",
 ]
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-evm",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "nybbles",
+ "nybbles 0.4.3",
  "reth-storage-errors",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "reth-execution-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
  "alloy-evm",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "derive_more 2.0.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -10393,12 +10416,12 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "eyre",
  "futures",
  "itertools 0.14.0",
@@ -10431,11 +10454,11 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "reth-chain-state",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -10445,8 +10468,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "serde",
  "serde_json",
@@ -10455,16 +10478,16 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-rpc-types-debug",
  "eyre",
  "futures",
- "jsonrpsee 0.25.1",
+ "jsonrpsee 0.26.0",
  "pretty_assertions",
  "reth-chainspec",
  "reth-engine-primitives",
@@ -10483,14 +10506,14 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "bytes",
  "futures",
  "futures-util",
  "interprocess",
- "jsonrpsee 0.25.1",
+ "jsonrpsee 0.26.0",
  "pin-project",
  "serde_json",
  "thiserror 2.0.12",
@@ -10503,10 +10526,10 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "byteorder",
  "dashmap 6.1.0",
  "derive_more 2.0.1",
@@ -10520,8 +10543,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "bindgen",
  "cc",
@@ -10529,8 +10552,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "futures",
  "metrics",
@@ -10541,16 +10564,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10563,12 +10586,12 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
@@ -10606,7 +10629,7 @@ dependencies = [
  "reth-transaction-pool",
  "rustc-hash 2.1.1",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "smallvec",
  "thiserror 2.0.12",
@@ -10618,11 +10641,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-admin",
+ "alloy-rpc-types-eth 1.0.27",
  "auto_impl",
  "derive_more 2.0.1",
  "enr 0.13.0",
@@ -10641,12 +10666,12 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "auto_impl",
  "derive_more 2.0.1",
  "futures",
@@ -10663,13 +10688,13 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "enr 0.13.0",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde_with",
  "thiserror 2.0.12",
  "tokio",
@@ -10678,8 +10703,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-eip2124 0.2.0",
  "humantime-serde",
@@ -10692,8 +10717,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10709,8 +10734,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10733,12 +10758,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
@@ -10746,7 +10771,7 @@ dependencies = [
  "eyre",
  "fdlimit",
  "futures",
- "jsonrpsee 0.25.1",
+ "jsonrpsee 0.26.0",
  "rayon",
  "reth-basic-payload-builder",
  "reth-chain-state",
@@ -10759,6 +10784,7 @@ dependencies = [
  "reth-db-common",
  "reth-downloaders",
  "reth-engine-local",
+ "reth-engine-primitives",
  "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
@@ -10771,9 +10797,11 @@ dependencies = [
  "reth-network-p2p",
  "reth-node-api",
  "reth-node-core",
+ "reth-node-ethstats",
  "reth-node-events",
  "reth-node-metrics",
  "reth-payload-builder",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
  "reth-rpc",
@@ -10788,7 +10816,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -10797,12 +10825,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
  "clap 4.5.36",
  "derive_more 2.0.1",
@@ -10818,6 +10846,7 @@ dependencies = [
  "reth-db",
  "reth-discv4",
  "reth-discv5",
+ "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-forks",
  "reth-net-nat",
@@ -10826,36 +10855,38 @@ dependencies = [
  "reth-network-peers",
  "reth-primitives-traits",
  "reth-prune-types",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-tracing",
  "reth-transaction-pool",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "shellexpand",
  "strum 0.27.1",
  "thiserror 2.0.12",
  "toml 0.8.20",
  "tracing",
+ "url",
  "vergen",
  "vergen-git2",
 ]
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
+ "alloy-eips 1.0.27",
+ "alloy-network",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.27",
  "eyre",
  "reth-chainspec",
- "reth-consensus",
+ "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-consensus",
  "reth-ethereum-engine-primitives",
@@ -10873,22 +10904,47 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
+ "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie-db",
  "revm",
+ "tokio",
+]
+
+[[package]]
+name = "reth-node-ethstats"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
+dependencies = [
+ "alloy-consensus 1.0.27",
+ "alloy-primitives 1.3.1",
+ "chrono",
+ "futures-util",
+ "reth-chain-state",
+ "reth-network-api",
+ "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-transaction-pool",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.26.2",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "reth-node-events"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
  "derive_more 2.0.1",
  "futures",
@@ -10907,12 +10963,12 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "eyre",
  "http 1.3.1",
- "jsonrpsee-server 0.25.1",
+ "jsonrpsee-server 0.26.0",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
@@ -10928,25 +10984,24 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
  "reth-engine-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
- "reth-trie-db",
 ]
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "arbitrary",
  "bytes",
@@ -10960,10 +11015,10 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.27",
  "alloy-rpc-types",
  "futures-util",
  "metrics",
@@ -10980,8 +11035,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10992,11 +11047,11 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
  "auto_impl",
  "op-alloy-rpc-types-engine",
@@ -11011,20 +11066,20 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.27",
  "alloy-rpc-types-engine",
  "reth-primitives-traits",
 ]
 
 [[package]]
 name = "reth-primitives"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.27",
  "c-kzg",
  "once_cell",
  "reth-ethereum-forks",
@@ -11035,15 +11090,16 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
  "alloy-genesis",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-trie 0.9.1",
  "arbitrary",
  "auto_impl",
  "byteorder",
@@ -11059,7 +11115,7 @@ dependencies = [
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -11067,12 +11123,12 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
  "dashmap 6.1.0",
  "eyre",
@@ -11112,12 +11168,12 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "itertools 0.14.0",
  "metrics",
  "rayon",
@@ -11140,10 +11196,10 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "arbitrary",
  "derive_more 2.0.1",
  "modular-bitfield",
@@ -11173,11 +11229,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "futures",
  "reth-eth-wire",
@@ -11192,11 +11248,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-primitives 1.3.1",
  "eyre",
  "futures",
  "parking_lot",
@@ -11219,10 +11275,10 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -11232,27 +11288,28 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.27",
  "alloy-dyn-abi",
- "alloy-eips 1.0.9",
+ "alloy-eips 1.0.27",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
+ "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.27",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.27",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -11261,18 +11318,20 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
- "jsonrpsee 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "itertools 0.14.0",
+ "jsonrpsee 0.26.0",
+ "jsonrpsee-types 0.26.0",
  "jsonwebtoken",
  "parking_lot",
  "pin-project",
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
+ "reth-consensus-common",
  "reth-engine-primitives",
  "reth-errors",
- "reth-ethereum-primitives",
  "reth-evm",
+ "reth-evm-ethereum",
  "reth-execution-types",
  "reth-metrics",
  "reth-network-api",
@@ -11282,11 +11341,11 @@ dependencies = [
  "reth-primitives-traits",
  "reth-revm",
  "reth-rpc-api",
+ "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -11296,7 +11355,7 @@ dependencies = [
  "revm-primitives",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -11307,25 +11366,25 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
+ "alloy-eips 1.0.27",
  "alloy-genesis",
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-json-rpc 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.27",
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde 1.0.9",
- "jsonrpsee 0.25.1",
+ "alloy-serde 1.0.27",
+ "jsonrpsee 0.26.0",
  "reth-chain-state",
  "reth-engine-primitives",
  "reth-network-peers",
@@ -11335,13 +11394,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-network",
  "alloy-provider",
  "http 1.3.1",
- "jsonrpsee 0.25.1",
+ "jsonrpsee 0.26.0",
  "metrics",
  "pin-project",
  "reth-chain-state",
@@ -11372,16 +11431,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-engine-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+name = "reth-rpc-convert"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-json-rpc 1.0.27",
+ "alloy-network",
+ "alloy-primitives 1.3.1",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-signer",
+ "jsonrpsee-types 0.26.0",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-primitives-traits",
+ "revm-context",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "reth-rpc-engine-api"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
+dependencies = [
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
  "async-trait",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-types 0.26.0",
  "metrics",
  "parking_lot",
  "reth-chainspec",
@@ -11403,37 +11481,38 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
+ "alloy-consensus 1.0.27",
  "alloy-dyn-abi",
- "alloy-eips 1.0.9",
- "alloy-json-rpc 1.0.9",
+ "alloy-eips 1.0.27",
+ "alloy-evm",
+ "alloy-json-rpc 1.0.27",
  "alloy-network",
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-rpc-types-eth 1.0.27",
  "alloy-rpc-types-mev",
- "alloy-serde 1.0.9",
+ "alloy-serde 1.0.27",
  "async-trait",
  "auto_impl",
  "dyn-clone",
  "futures",
- "jsonrpsee 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee 0.26.0",
+ "jsonrpsee-types 0.26.0",
  "parking_lot",
+ "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
  "reth-evm",
  "reth-network-api",
  "reth-node-api",
- "reth-payload-builder",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-convert",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -11446,21 +11525,26 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-sol-types 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-evm",
+ "alloy-network",
+ "alloy-primitives 1.3.1",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-sol-types 1.3.1",
+ "alloy-transport",
  "derive_more 2.0.1",
  "futures",
  "itertools 0.14.0",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-types 0.26.0",
  "metrics",
  "rand 0.9.0",
+ "reqwest 0.12.15",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -11470,8 +11554,8 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-revm",
+ "reth-rpc-convert",
  "reth-rpc-server-types",
- "reth-rpc-types-compat",
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
@@ -11488,12 +11572,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
- "jsonrpsee-http-client 0.25.1",
+ "jsonrpsee-http-client 0.26.0",
  "pin-project",
  "tower 0.5.2",
  "tower-http",
@@ -11502,14 +11586,14 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-types 0.26.0",
  "reth-errors",
  "reth-network-api",
  "serde",
@@ -11517,28 +11601,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-rpc-types-compat"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
-dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
- "jsonrpsee-types 0.25.1",
- "reth-primitives-traits",
- "serde",
-]
-
-[[package]]
 name = "reth-stages"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "bincode",
- "blake3",
+ "eyre",
  "futures-util",
  "itertools 0.14.0",
  "num-traits",
@@ -11549,6 +11620,9 @@ dependencies = [
  "reth-consensus",
  "reth-db",
  "reth-db-api",
+ "reth-era",
+ "reth-era-downloader",
+ "reth-era-utils",
  "reth-etl",
  "reth-evm",
  "reth-execution-types",
@@ -11565,7 +11639,6 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-db",
- "serde",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -11573,11 +11646,11 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "aquamarine",
  "auto_impl",
  "futures-util",
@@ -11600,10 +11673,10 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "arbitrary",
  "bytes",
  "modular-bitfield",
@@ -11614,10 +11687,10 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "parking_lot",
  "rayon",
  "reth-codecs",
@@ -11634,10 +11707,10 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "clap 4.5.36",
  "derive_more 2.0.1",
  "serde",
@@ -11646,12 +11719,12 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
@@ -11664,17 +11737,16 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "reth-trie-db",
  "revm-database",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "derive_more 2.0.1",
  "reth-primitives-traits",
@@ -11686,8 +11758,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11704,8 +11776,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11714,8 +11786,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "clap 4.5.36",
  "eyre",
@@ -11729,19 +11801,20 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "futures-util",
  "metrics",
  "parking_lot",
+ "pin-project",
  "rand 0.9.0",
  "reth-chain-state",
  "reth-chainspec",
@@ -11758,6 +11831,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "schnellru",
  "serde",
+ "serde_json",
  "smallvec",
  "thiserror 2.0.12",
  "tokio",
@@ -11767,14 +11841,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-eips 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-eips 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-trie 0.9.1",
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
@@ -11792,21 +11866,21 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-consensus 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-rpc-types-eth 1.0.9",
- "alloy-serde 1.0.9",
- "alloy-trie 0.8.1",
+ "alloy-rpc-types-eth 1.0.27",
+ "alloy-serde 1.0.27",
+ "alloy-trie 0.9.1",
  "arbitrary",
  "bytes",
  "derive_more 2.0.1",
  "hash-db",
  "itertools 0.14.0",
- "nybbles",
+ "nybbles 0.4.3",
  "plain_hasher",
  "rayon",
  "reth-codecs",
@@ -11818,10 +11892,10 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "reth-db-api",
  "reth-execution-errors",
  "reth-primitives-traits",
@@ -11831,10 +11905,10 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "derive_more 2.0.1",
  "itertools 0.14.0",
@@ -11856,14 +11930,15 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
- "alloy-trie 0.8.1",
+ "alloy-trie 0.9.1",
  "auto_impl",
  "metrics",
+ "rayon",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -11873,18 +11948,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-trie-sparse-parallel"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
+dependencies = [
+ "alloy-primitives 1.3.1",
+ "alloy-rlp",
+ "alloy-trie 0.9.1",
+ "metrics",
+ "rayon",
+ "reth-execution-errors",
+ "reth-metrics",
+ "reth-trie-common",
+ "reth-trie-sparse",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
 name = "reth-zstd-compressors"
-version = "1.4.8"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.4.8#127595e23079de2c494048d0821ea1f1107eb624"
+version = "1.6.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b316160a9915ac80c4ae867f69e304aca85ec01#0b316160a9915ac80c4ae867f69e304aca85ec01"
 dependencies = [
  "zstd 0.13.3",
 ]
 
 [[package]]
 name = "revm"
-version = "24.0.1"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d277408ff8d6f747665ad9e52150ab4caf8d5eaf0d787614cf84633c8337b4"
+checksum = "0c278b6ee9bba9e25043e3fae648fdce632d1944d3ba16f5203069b43bddd57f"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11901,12 +11994,11 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "4.0.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91f9b90b3bab18942252de2d970ee8559794c49ca7452b2cc1774456040f8fb"
+checksum = "66c52031b73cae95d84cd1b07725808b5fd1500da3e5e24574a3b2dc13d9f16d"
 dependencies = [
  "bitvec",
- "once_cell",
  "phf 0.11.3",
  "revm-primitives",
  "serde",
@@ -11914,10 +12006,11 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "5.0.1"
+version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01aad49e1233f94cebda48a4e5cef022f7c7ed29b4edf0d202b081af23435ef"
+checksum = "0fb02c5dab3b535aa5b18277b1d21c5117a25d42af717e6ce133df0ea56663e1"
 dependencies = [
+ "bitvec",
  "cfg-if",
  "derive-where",
  "revm-bytecode",
@@ -11930,9 +12023,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "5.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b844f48a411e62c7dde0f757bf5cce49c85b86d6fc1d3b2722c07f2bec4c3ce"
+checksum = "6b8e9311d27cf75fbf819e7ba4ca05abee1ae02e44ff6a17301c7ab41091b259"
 dependencies = [
  "alloy-eip2930 0.2.1",
  "alloy-eip7702 0.6.1",
@@ -11946,11 +12039,11 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "4.0.1"
+version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad3fbe34f6bb00a9c3155723b3718b9cb9f17066ba38f9eb101b678cd3626775"
+checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
 dependencies = [
- "alloy-eips 1.0.9",
+ "alloy-eips 1.0.27",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -11960,11 +12053,12 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "4.0.1"
+version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8acd36784a6d95d5b9e1b7be3ce014f1e759abb59df1fa08396b30f71adc2a"
+checksum = "8c523c77e74eeedbac5d6f7c092e3851dbe9c7fec6f418b85992bd79229db361"
 dependencies = [
  "auto_impl",
+ "either",
  "revm-primitives",
  "revm-state",
  "serde",
@@ -11972,11 +12066,12 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "5.0.1"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481e8c3290ff4fa1c066592fdfeb2b172edfd14d12e6cade6f6f5588cad9359a"
+checksum = "528d2d81cc918d311b8231c35330fac5fba8b69766ddc538833e2b5593ee016e"
 dependencies = [
  "auto_impl",
+ "derive-where",
  "revm-bytecode",
  "revm-context",
  "revm-context-interface",
@@ -11990,11 +12085,12 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "5.0.1"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc1167ef8937d8867888e63581d8ece729a72073d322119ef4627d813d99ecb"
+checksum = "bf443b664075999a14916b50c5ae9e35a7d71186873b8f8302943d50a672e5e0"
 dependencies = [
  "auto_impl",
+ "either",
  "revm-context",
  "revm-database-interface",
  "revm-handler",
@@ -12007,14 +12103,14 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.23.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b50ef375dbacefecfdacf8f02afc31df98acc5d8859a6f2b24d121ff2a740a8"
+checksum = "2b5c15d9c33ae98988a2a6a8db85b6a9e3389d1f3f2fdb95628a992f2b65b2c1"
 dependencies = [
- "alloy-primitives 1.2.0",
- "alloy-rpc-types-eth 1.0.9",
+ "alloy-primitives 1.3.1",
+ "alloy-rpc-types-eth 1.0.27",
  "alloy-rpc-types-trace",
- "alloy-sol-types 1.2.0",
+ "alloy-sol-types 1.3.1",
  "anstyle",
  "boa_engine",
  "boa_gc",
@@ -12027,9 +12123,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "20.0.0"
+version = "25.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ee65e57375c6639b0f50555e92a4f1b2434349dd32f52e2176f5c711171697"
+checksum = "53d6406b711fac73b4f13120f359ed8e65964380dd6182bd12c4c09ad0d4641f"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12039,47 +12135,49 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "21.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9311e735123d8d53a02af2aa81877bba185be7c141be7f931bb3d2f3af449c"
+checksum = "25b57d4bd9e6b5fe469da5452a8a137bc2d030a3cd47c46908efc615bbc699da"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
+ "arrayref",
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
  "cfg-if",
  "k256 0.13.4",
  "libsecp256k1",
- "once_cell",
  "p256",
  "revm-primitives",
  "ripemd",
- "secp256k1",
- "sha2 0.10.8",
+ "rug",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "19.1.0"
+version = "20.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ea2ea0134568ee1e14281ce52f60e2710d42be316888d464c53e37ff184fd8"
+checksum = "5aa29d9da06fe03b249b6419b33968ecdf92ad6428e2f012dc57bcd619b5d94e"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "num_enum",
+ "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "4.0.1"
+version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0040c61c30319254b34507383ba33d85f92949933adf6525a2cede05d165e1fa"
+checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -12249,10 +12347,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruint"
-version = "1.14.0"
+name = "rug"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
+checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "libm",
+]
+
+[[package]]
+name = "ruint"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -12368,7 +12478,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -12381,7 +12491,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -12673,8 +12783,19 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.0",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -12687,12 +12808,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -12705,7 +12835,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -12728,7 +12858,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "cssparser",
  "derive_more 0.99.19",
  "fxhash",
@@ -12808,9 +12938,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "indexmap 2.9.0",
  "itoa",
@@ -12957,9 +13087,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -13065,27 +13195,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-dependencies = [
- "bstr",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "similar-asserts"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
-dependencies = [
- "console",
- "serde",
- "similar",
-]
 
 [[package]]
 name = "simple_asn1"
@@ -13324,7 +13433,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "sqlformat",
  "thiserror 1.0.69",
@@ -13364,7 +13473,7 @@ dependencies = [
  "quote 1.0.40",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -13384,7 +13493,7 @@ dependencies = [
  "atoi",
  "base64 0.21.7",
  "bigdecimal 0.3.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "byteorder",
  "bytes",
  "chrono",
@@ -13410,7 +13519,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -13430,7 +13539,7 @@ dependencies = [
  "atoi",
  "base64 0.21.7",
  "bigdecimal 0.3.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "byteorder",
  "chrono",
  "crc",
@@ -13453,7 +13562,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -13729,9 +13838,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c8c8f496c33dc6343dac05b4be8d9e0bca180a4caa81d7b8416b10cc2273cd"
+checksum = "a0b198d366dbec045acfcd97295eb653a7a2b40e4dc764ef1e79aafcad439d3c"
 dependencies = [
  "paste",
  "proc-macro2 1.0.95",
@@ -13809,7 +13918,7 @@ dependencies = [
 name = "sysperf"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "num_cpus",
  "rand 0.8.5",
  "rayon",
@@ -13833,7 +13942,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -13931,9 +14040,9 @@ name = "test-relay"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "alloy-consensus 1.0.9",
- "alloy-json-rpc 1.0.9",
- "alloy-primitives 1.2.0",
+ "alloy-consensus 1.0.27",
+ "alloy-json-rpc 1.0.27",
+ "alloy-primitives 1.3.1",
  "alloy-provider",
  "clap 4.5.36",
  "clap_builder",
@@ -14393,7 +14502,7 @@ checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -14479,8 +14588,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "futures",
- "futures-task",
  "pin-project",
  "tracing",
 ]
@@ -14576,7 +14683,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
 dependencies = [
- "alloy-primitives 1.2.0",
+ "alloy-primitives 1.3.1",
  "ethereum_hashing 0.7.0",
  "ethereum_ssz 0.9.0",
  "smallvec",
@@ -15395,7 +15502,7 @@ checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result 0.3.2",
  "windows-strings 0.3.1",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -15490,6 +15597,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15537,9 +15653,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -15756,7 +15872,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -15966,7 +16082,7 @@ dependencies = [
  "aes",
  "byteorder",
  "bzip2",
- "constant_time_eq 0.1.5",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,94 +49,75 @@ codegen-units = 1
 incremental = false
 
 [workspace.dependencies]
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8", features = [
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01", features = [
     "test-utils",
 ] }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b316160a9915ac80c4ae867f69e304aca85ec01" }
 
-# reth optimism
-reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-node = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-reth-optimism-txpool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.4.8" }
-
-# compatible with reth v1.4.8 dependencies
-revm = { version = "24.0.1", features = [
+# compatible with reth 0b316160a9915ac80c4ae867f69e304aca85ec01 dependencies
+revm = { version = "29.0.0", features = [
     "std",
     "secp256k1",
     "optional_balance_check",
 ], default-features = false }
-revm-inspectors = { version = "0.23.0", default-features = false }
-op-revm = { version = "5.0.0", default-features = false }
+revm-inspectors = { version = "0.29.0", default-features = false }
 
 ethereum_ssz_derive = "0.9.0"
 ethereum_ssz = "0.9.0"
 
-alloy-primitives = { version = "1.1.0", default-features = false, features = ["getrandom"] }
+alloy-primitives = { version = "1.3.1", default-features = false, features = ["getrandom"] }
 alloy-rlp = "0.3.10"
-alloy-chains = "0.2.0"
-alloy-evm = { version = "0.10", default-features = false }
-alloy-provider = { version = "1.0.9", features = ["ipc", "pubsub", "ws"] }
-alloy-pubsub = { version = "1.0.9" }
-alloy-eips = { version = "1.0.9" }
-alloy-rpc-types = { version = "1.0.9" }
-alloy-json-rpc = { version = "1.0.9" }
-alloy-transport-http = { version = "1.0.9" }
-alloy-network = { version = "1.0.9" }
-alloy-network-primitives = { version = "1.0.9" }
-alloy-transport = { version = "1.0.9" }
-alloy-node-bindings = { version = "1.0.9" }
-alloy-consensus = { version = "1.0.9", features = ["kzg"] }
-alloy-serde = { version = "1.0.9" }
-alloy-rpc-types-beacon = { version = "1.0.9", features = ["ssz"] }
-alloy-rpc-types-engine = { version = "1.0.9", features = ["ssz"] }
-alloy-rpc-types-eth = { version = "1.0.9" }
-alloy-signer-local = { version = "1.0.9" }
-alloy-rpc-client = { version = "1.0.9" }
-alloy-genesis = { version = "1.0.9" }
-alloy-trie = { version = "0.8.1" }
-
-# optimism
-alloy-op-evm = { version = "0.5.0", default-features = false }
-op-alloy-rpc-types = { version = "0.14.1", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.14.1", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.14.1", default-features = false }
-op-alloy-network = { version = "0.14.1", default-features = false }
-op-alloy-consensus = { version = "0.14.1", default-features = false }
+alloy-chains = "0.2.5"
+alloy-evm = { version = "0.20.1", default-features = false }
+alloy-provider = { version = "1.0.27", features = ["ipc", "pubsub", "ws"] }
+alloy-pubsub = { version = "1.0.27" }
+alloy-eips = { version = "1.0.27" }
+alloy-rpc-types = { version = "1.0.27" }
+alloy-json-rpc = { version = "1.0.27" }
+alloy-transport-http = { version = "1.0.27" }
+alloy-network = { version = "1.0.27" }
+alloy-network-primitives = { version = "1.0.27" }
+alloy-transport = { version = "1.0.27" }
+alloy-node-bindings = { version = "1.0.27" }
+alloy-consensus = { version = "1.0.27", features = ["kzg"] }
+alloy-serde = { version = "1.0.27" }
+alloy-rpc-types-beacon = { version = "1.0.27", features = ["ssz"] }
+alloy-rpc-types-engine = { version = "1.0.27", features = ["ssz"] }
+alloy-rpc-types-eth = { version = "1.0.27" }
+alloy-signer-local = { version = "1.0.27" }
+alloy-rpc-client = { version = "1.0.27" }
+alloy-genesis = { version = "1.0.27" }
 
 async-trait = { version = "0.1.83" }
 clap = { version = "4.4.3", features = ["derive", "env"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 ARG FEATURES
 ARG RBUILDER_BIN="rbuilder"
 
-FROM rust:1.86 AS base
+FROM rust:1.88 AS base
 ARG TARGETPLATFORM
 
 RUN apt-get update \

--- a/crates/bid-scraper/src/best_bid_ws_connector.rs
+++ b/crates/bid-scraper/src/best_bid_ws_connector.rs
@@ -60,7 +60,7 @@ impl<BestBidValueSinkType: BestBidValueSink> BestBidWSConnector<BestBidValueSink
         let mut connection_request = url.into_client_request()?;
         connection_request
             .headers_mut()
-            .insert("Authorization", format!("Basic {}", basic_auth).parse()?);
+            .insert("Authorization", format!("Basic {basic_auth}").parse()?);
 
         Ok(Self {
             connection_request,

--- a/crates/bid-scraper/src/bids_publisher.rs
+++ b/crates/bid-scraper/src/bids_publisher.rs
@@ -157,8 +157,7 @@ impl BidsPublisherService {
         debug!("Getting bids for relay {relay_name}");
         let block_number = self.inner().last_block_number + 1;
         let url = format!(
-            "{}/relay/v1/data/bidtraces/builder_blocks_received?block_number={}&order_by=-value",
-            relay_endpoint, block_number
+            "{relay_endpoint}/relay/v1/data/bidtraces/builder_blocks_received?block_number={block_number}&order_by=-value",
         );
         // By default it's ordered by slot (so, no effect). So we order by decreasing value
         // instead, it's more interesting to us.

--- a/crates/bid-scraper/src/headers_publisher.rs
+++ b/crates/bid-scraper/src/headers_publisher.rs
@@ -206,8 +206,7 @@ impl HeadersPublisherService {
         // instead, it's more interesting to us.
         let response = client
             .get(format!(
-                "{}/eth/v1/builder/header/{next_slot}/{last_block_hash}/{next_validator_pubkey}",
-                relay_endpoint,
+                "{relay_endpoint}/eth/v1/builder/header/{next_slot}/{last_block_hash}/{next_validator_pubkey}",
             ))
             .send()
             .await?;

--- a/crates/eth-sparse-mpt/Cargo.toml
+++ b/crates/eth-sparse-mpt/Cargo.toml
@@ -16,6 +16,8 @@ serde_with = "3.9.0"
 rustc-hash = "2.0.0"
 rayon = "1.10.0"
 smallvec = "1.13.2"
+alloy-trie = { version = "0.8.1", default-features = false }
+nybbles = { version = "0.3.3" }
 
 tracing.workspace = true
 
@@ -32,7 +34,6 @@ revm.workspace = true
 # alloy
 alloy-primitives.workspace = true
 alloy-rlp.workspace = true
-alloy-trie.workspace = true
 
 # other
 parking_lot.workspace = true

--- a/crates/eth-sparse-mpt/benches/trie_do_bench.rs
+++ b/crates/eth-sparse-mpt/benches/trie_do_bench.rs
@@ -7,7 +7,7 @@ use eth_sparse_mpt::{
     v1::sparse_mpt::{DiffTrie, FixedTrie},
     v2::trie::{proof_store::ProofStore, Trie},
 };
-use reth_trie::Nibbles;
+use nybbles::Nibbles;
 
 fn prepare_key_value_data(n: usize) -> (Vec<Bytes>, Vec<Bytes>) {
     let mut keys = Vec::with_capacity(n);

--- a/crates/eth-sparse-mpt/src/lib.rs
+++ b/crates/eth-sparse-mpt/src/lib.rs
@@ -9,10 +9,8 @@
 use std::sync::Arc;
 
 use alloy_primitives::{Address, B256};
-
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, ExecutionOutcome,
-    StateCommitmentProvider,
 };
 
 #[cfg(any(test, feature = "benchmark-utils"))]
@@ -100,7 +98,6 @@ pub fn prefetch_tries_for_accounts<'a, Provider>(
 ) -> Result<SparseTrieMetrics, SparseTrieError>
 where
     Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-    Provider: StateCommitmentProvider,
 {
     match version {
         ETHSpareMPTVersion::V1 => {
@@ -151,7 +148,6 @@ pub fn calculate_root_hash_with_sparse_trie<Provider>(
 ) -> (Result<B256, SparseTrieError>, SparseTrieMetrics)
 where
     Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-    Provider: StateCommitmentProvider,
 {
     if let Some(thread_pool) = thread_pool {
         thread_pool.rayon_pool.install(|| {
@@ -183,7 +179,6 @@ pub fn calculate_root_hash_with_sparse_trie_internal<Provider>(
 ) -> (Result<B256, SparseTrieError>, SparseTrieMetrics)
 where
     Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-    Provider: StateCommitmentProvider,
 {
     match version {
         ETHSpareMPTVersion::V1 => {

--- a/crates/eth-sparse-mpt/src/lib.rs
+++ b/crates/eth-sparse-mpt/src/lib.rs
@@ -47,7 +47,7 @@ impl RootHashThreadPool {
     pub fn try_new(threads: usize) -> Result<RootHashThreadPool, rayon::ThreadPoolBuildError> {
         let rayon_pool = rayon::ThreadPoolBuilder::new()
             .num_threads(threads)
-            .thread_name(|idx| format!("sparse_mpt:{}", idx))
+            .thread_name(|idx| format!("sparse_mpt:{idx}"))
             .build()?;
         Ok(RootHashThreadPool {
             rayon_pool: Arc::new(rayon_pool),

--- a/crates/eth-sparse-mpt/src/utils.rs
+++ b/crates/eth-sparse-mpt/src/utils.rs
@@ -2,10 +2,8 @@ use std::hash::{Hash, Hasher};
 
 use alloy_primitives::{keccak256, Bytes};
 use alloy_rlp::{length_of_length, BufMut, Encodable, Header, EMPTY_STRING_CODE};
-use alloy_trie::{
-    nodes::{ExtensionNodeRef, LeafNodeRef},
-    Nibbles,
-};
+use alloy_trie::nodes::{ExtensionNodeRef, LeafNodeRef};
+use nybbles::Nibbles;
 use reth_trie::RlpNode;
 use rustc_hash::{FxBuildHasher, FxHasher};
 
@@ -137,4 +135,17 @@ fn mismatch_chunks<const N: usize>(xs: &[u8], ys: &[u8]) -> usize {
     off + std::iter::zip(&xs[off..], &ys[off..])
         .take_while(|(x, y)| x == y)
         .count()
+}
+
+// rbuilder uses nybbles v3.3.0 and reth_trie uses nybbles v4.3.0. This is a temporary fix to convert between the two.
+// We can remove the below methods once rbuilder has been upgraded to nybbles v4.3.0.
+// nybbles v4.3.0 has a breaking change (byte array with 1 byte per nybble vs U256 packed data + length) in the API which breaks a lot of parts of the eth sparse trie code.
+#[inline]
+pub fn convert_reth_nybbles_to_nibbles(n: reth_trie::Nibbles) -> Nibbles {
+    Nibbles::from_nibbles(&n.to_vec())
+}
+
+#[inline]
+pub fn convert_nibbles_to_reth_nybbles(n: Nibbles) -> reth_trie::Nibbles {
+    reth_trie::Nibbles::from_nibbles(n.as_slice())
 }

--- a/crates/eth-sparse-mpt/src/utils.rs
+++ b/crates/eth-sparse-mpt/src/utils.rs
@@ -142,7 +142,7 @@ fn mismatch_chunks<const N: usize>(xs: &[u8], ys: &[u8]) -> usize {
 // nybbles v4.3.0 has a breaking change (byte array with 1 byte per nybble vs U256 packed data + length) in the API which breaks a lot of parts of the eth sparse trie code.
 #[inline]
 pub fn convert_reth_nybbles_to_nibbles(n: reth_trie::Nibbles) -> Nibbles {
-    Nibbles::from_nibbles(&n.to_vec())
+    Nibbles::from_nibbles(n.to_vec())
 }
 
 #[inline]

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/hash.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/hash.rs
@@ -55,6 +55,7 @@ pub enum RootHashError {
 }
 
 impl EthSparseTries {
+    #[allow(clippy::result_large_err)]
     pub fn calculate_root_hash(
         &mut self,
         changes: ETHTrieChangeSet,
@@ -112,6 +113,7 @@ impl EthSparseTries {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     fn calculate_account_hashes_seq(
         &mut self,
         changes: &ETHTrieChangeSet,
@@ -140,6 +142,7 @@ impl EthSparseTries {
         Ok(account_hashes)
     }
 
+    #[allow(clippy::result_large_err)]
     fn calculate_account_hashes_parallel(
         &mut self,
         changes: &ETHTrieChangeSet,
@@ -172,6 +175,7 @@ impl EthSparseTries {
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn hash_storage_trie(
     storage_trie: &mut DiffTrie,
     account: &Bytes,

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/mod.rs
@@ -3,7 +3,6 @@ use change_set::{prepare_change_set, prepare_change_set_for_prefetch};
 use hash::RootHashError;
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, ExecutionOutcome,
-    StateCommitmentProvider,
 };
 use std::time::{Duration, Instant};
 
@@ -65,7 +64,6 @@ pub fn prefetch_tries_for_accounts<'a, Provider>(
 ) -> Result<SparseTrieMetrics, SparseTrieError>
 where
     Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-    Provider: StateCommitmentProvider,
 {
     let mut metrics = SparseTrieMetrics::default();
 
@@ -111,7 +109,6 @@ pub fn calculate_root_hash_with_sparse_trie<Provider>(
 ) -> (Result<B256, SparseTrieError>, SparseTrieMetrics)
 where
     Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-    Provider: StateCommitmentProvider,
 {
     let mut metrics = SparseTrieMetrics::default();
 

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/mod.rs
@@ -57,6 +57,7 @@ impl SparseTrieError {
 }
 
 /// Prefetches data
+#[allow(clippy::result_large_err)]
 pub fn prefetch_tries_for_accounts<'a, Provider>(
     consistent_db_view: ConsistentDbView<Provider>,
     shared_cache: SparseTrieSharedCache,

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/shared_cache.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/shared_cache.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_primitives::Bytes;
 use alloy_primitives::B256;
-use alloy_trie::Nibbles;
+use nybbles::Nibbles;
 
 /// SparseTrieSharedCache is a storage for fetched parts of the ethereum tries
 /// It should be created once for each parent block and can be shared with a different threads.

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/trie_fetcher/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/trie_fetcher/mod.rs
@@ -1,17 +1,16 @@
 use std::time::Instant;
 
-use crate::utils::{hash_map_with_capacity, HashMap, HashSet};
+use crate::utils::{convert_reth_nybbles_to_nibbles, hash_map_with_capacity, HashMap, HashSet};
 use alloy_primitives::map::HashSet as AlloyHashSet;
 use tracing::trace;
 
 use alloy_primitives::{Bytes, B256};
-use alloy_trie::Nibbles;
+use nybbles::Nibbles;
 use rayon::prelude::*;
 use reth_errors::ProviderError;
 use reth_execution_errors::trie::StateProofError;
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DBProvider, DatabaseProviderFactory,
-    StateCommitmentProvider,
 };
 use reth_trie::{proof::Proof, MultiProof as RethMultiProof, MultiProofTargets, EMPTY_ROOT_HASH};
 use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
@@ -62,7 +61,6 @@ pub struct TrieFetcher<Provider> {
 impl<Provider> TrieFetcher<Provider>
 where
     Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-    Provider: StateCommitmentProvider,
 {
     pub fn new(consistent_db_view: ConsistentDbView<Provider>) -> Self {
         Self { consistent_db_view }
@@ -194,7 +192,7 @@ fn convert_reth_multiproof(
 ) -> MultiProof {
     let mut account_subtree = Vec::with_capacity(reth_proof.account_subtree.len());
     for (k, v) in reth_proof.account_subtree.into_inner() {
-        account_subtree.push((k, v));
+        account_subtree.push((convert_reth_nybbles_to_nibbles(k), v));
     }
     account_subtree.sort_by_key(|a| a.0.clone());
     let mut storages = hash_map_with_capacity(reth_proof.storages.len());
@@ -208,7 +206,7 @@ fn convert_reth_multiproof(
         let mut subtree = Vec::with_capacity(reth_storage_proof.subtree.len());
 
         for (k, v) in reth_storage_proof.subtree.into_inner() {
-            subtree.push((k, v));
+            subtree.push((convert_reth_nybbles_to_nibbles(k), v));
         }
         subtree.sort_by_key(|a| a.0.clone());
         let v = StorageMultiProof { subtree };

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/mod.rs
@@ -1,7 +1,7 @@
 use crate::utils::{extract_prefix_and_suffix, rlp_pointer, strip_first_nibble_mut, HashMap};
 use alloy_primitives::{keccak256, Bytes, B256};
+use nybbles::Nibbles;
 use parking_lot::Mutex;
-use reth_trie::Nibbles;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Seq};
 

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/nodes.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/diff_trie/nodes.rs
@@ -3,7 +3,7 @@ use crate::utils::{
     encode_len_extension, encode_len_leaf, encode_null_node, rlp_pointer,
 };
 use alloy_primitives::Bytes;
-use reth_trie::Nibbles;
+use nybbles::Nibbles;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::sync::Arc;

--- a/crates/eth-sparse-mpt/src/v1/sparse_mpt/fixed_trie.rs
+++ b/crates/eth-sparse-mpt/src/v1/sparse_mpt/fixed_trie.rs
@@ -5,7 +5,7 @@ use alloy_trie::nodes::{
     BranchNode as AlloyBranchNode, ExtensionNode as AlloyExtensionNode, LeafNode as AlloyLeafNode,
     TrieNode as AlloyTrieNode,
 };
-use reth_trie::Nibbles;
+use nybbles::Nibbles;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, Seq};
 use smallvec::SmallVec;

--- a/crates/eth-sparse-mpt/src/v2/fetch.rs
+++ b/crates/eth-sparse-mpt/src/v2/fetch.rs
@@ -1,15 +1,18 @@
 use std::sync::Arc;
 
-use crate::{utils::HashMap, SparseTrieError};
+use crate::{
+    utils::{convert_nibbles_to_reth_nybbles, convert_reth_nybbles_to_nibbles, HashMap},
+    SparseTrieError,
+};
 use alloy_primitives::map::B256Set;
 use parking_lot::Mutex;
 use rayon::prelude::*;
 
 use alloy_primitives::B256;
-use alloy_trie::Nibbles;
+use nybbles::Nibbles;
 use reth_provider::{
     providers::ConsistentDbView, BlockHashReader, BlockNumReader, BlockReader, DBProvider,
-    DatabaseProviderFactory, StateCommitmentProvider,
+    DatabaseProviderFactory,
 };
 use reth_trie::{
     proof::{Proof, StorageProof},
@@ -53,7 +56,6 @@ impl MissingNodesFetcher {
     ) -> Result<usize, SparseTrieError>
     where
         Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-        Provider: StateCommitmentProvider,
     {
         let fetched_nodes: Arc<Mutex<usize>> = Default::default();
 
@@ -87,13 +89,17 @@ impl MissingNodesFetcher {
                         .map_err(SparseTrieError::other)?;
                     *fetched_nodes.lock() += requested_proofs.len();
                     for requested_proof in requested_proofs {
-                        let proof_for_node = storge_multiproof
-                            .subtree
-                            .matching_nodes_sorted(&requested_proof);
+                        let proof_for_node = storge_multiproof.subtree.matching_nodes_sorted(
+                            &convert_nibbles_to_reth_nybbles(requested_proof.clone()),
+                        );
+                        let reth_proof_for_node = proof_for_node
+                            .into_iter()
+                            .map(|(k, v)| (convert_reth_nybbles_to_nibbles(k), v))
+                            .collect();
                         let proof_store =
                             shared_cache.account_proof_store_hashed_address(&hashed_address);
                         proof_store
-                            .add_proof(requested_proof, proof_for_node)
+                            .add_proof(requested_proof, reth_proof_for_node)
                             .map_err(SparseTrieError::other)?;
                     }
                     Ok(())
@@ -127,10 +133,15 @@ impl MissingNodesFetcher {
         for requested_node in self.account_proof_requested_nodes.drain(..) {
             let proof_for_node = multiproof
                 .account_subtree
-                .matching_nodes_sorted(&requested_node);
+                .matching_nodes_sorted(&convert_nibbles_to_reth_nybbles(requested_node.clone()));
+
+            let reth_proof_for_node = proof_for_node
+                .into_iter()
+                .map(|(k, v)| (convert_reth_nybbles_to_nibbles(k), v))
+                .collect();
             shared_cache
                 .account_trie
-                .add_proof(requested_node, proof_for_node)
+                .add_proof(requested_node, reth_proof_for_node)
                 .map_err(SparseTrieError::other)?;
         }
         let fetched_nodes = *fetched_nodes.lock();

--- a/crates/eth-sparse-mpt/src/v2/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/mod.rs
@@ -5,12 +5,12 @@ use std::time::Instant;
 use alloy_primitives::{keccak256, Address, B256, U256};
 use dashmap::DashMap;
 use fetch::MissingNodesFetcher;
+use nybbles::Nibbles;
 use parking_lot::{Mutex, RwLock};
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, ExecutionOutcome,
-    StateCommitmentProvider,
 };
-use reth_trie::{Nibbles, TrieAccount};
+use reth_trie::TrieAccount;
 use revm::state::AccountInfo;
 use rustc_hash::FxBuildHasher;
 use std::ops::Range;
@@ -232,7 +232,6 @@ pub fn prefetch_proofs<'a, Provider>(
 ) -> Result<SparseTrieMetrics, SparseTrieError>
 where
     Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-    Provider: StateCommitmentProvider,
 {
     let mut metrics = SparseTrieMetrics::default();
     let mut fetcher = MissingNodesFetcher::default();
@@ -365,7 +364,6 @@ impl RootHashCalculator {
     ) -> Result<(), SparseTrieError>
     where
         Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-        Provider: StateCommitmentProvider,
     {
         stats.start();
 
@@ -562,7 +560,6 @@ impl RootHashCalculator {
     ) -> Result<(), SparseTrieError>
     where
         Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-        Provider: StateCommitmentProvider,
     {
         let fetcher = Arc::new(Mutex::new(MissingNodesFetcher::default()));
 
@@ -805,7 +802,6 @@ impl RootHashCalculator {
     ) -> Result<(), SparseTrieError>
     where
         Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-        Provider: StateCommitmentProvider,
     {
         let mut fetcher = MissingNodesFetcher::default();
 
@@ -864,7 +860,6 @@ impl RootHashCalculator {
     ) -> Result<(B256, SparseTrieMetrics), SparseTrieError>
     where
         Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
-        Provider: StateCommitmentProvider,
     {
         let mut stats = Stats::default();
         stats.start_global();

--- a/crates/eth-sparse-mpt/src/v2/trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/mod.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 use alloy_primitives::{keccak256, B256};
 use alloy_rlp::EMPTY_STRING_CODE;
 use arrayvec::ArrayVec;
+use nybbles::Nibbles;
 use proof_store::ProofNode;
 use proof_store::ProofStore;
-use reth_trie::Nibbles;
 
 pub mod proof_store;
 

--- a/crates/eth-sparse-mpt/src/v2/trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/mod.rs
@@ -38,7 +38,7 @@ impl NodePtr {
     fn expect_local(&self, msg: &str) -> usize {
         match self {
             NodePtr::Local(idx) => *idx,
-            NodePtr::Remote(_) => panic!("eth-sparse-mpt expect local node: {}", msg),
+            NodePtr::Remote(_) => panic!("eth-sparse-mpt expect local node: {msg}"),
         }
     }
 }
@@ -849,11 +849,11 @@ impl Trie {
         let h = alloy_primitives::hex::encode;
         match node {
             DiffTrieNode::Branch { children } => {
-                println!("{} Branch", node_idx);
+                println!("{node_idx} Branch");
                 println!("{}", h(self.rlp_ptrs_local[node_idx].as_slice()));
                 for (idx, child) in self.branch_node_children[children].into_iter().enumerate() {
                     if child.is_some() {
-                        println!("  {} -> {:?}", idx, child);
+                        println!("  {idx} -> {child:?}");
                     }
                 }
                 for child in self.branch_node_children[children].into_iter().flatten() {
@@ -884,7 +884,7 @@ impl Trie {
                 println!("{}", h(self.rlp_ptrs_local[node_idx].as_slice()));
             }
             DiffTrieNode::Null => {
-                println!("{} Null", node_idx);
+                println!("{node_idx} Null");
                 println!("{}", h(self.rlp_ptrs_local[node_idx].as_slice()));
             }
         }

--- a/crates/eth-sparse-mpt/src/v2/trie/proof_store.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/proof_store.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use alloy_trie::nodes::TrieNode as AlloyTrieNode;
 use arrayvec::ArrayVec;
 use dashmap::DashMap;
-use reth_trie::Nibbles;
+use nybbles::Nibbles;
 use rustc_hash::FxBuildHasher;
 
 #[derive(Debug, Clone)]

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -28,6 +28,7 @@ reth-trie-parallel.workspace = true
 reth-node-api.workspace = true
 reth-node-core.workspace = true
 reth-primitives.workspace = true
+reth-ethereum-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-chainspec.workspace = true
@@ -91,8 +92,8 @@ flate2.workspace = true
 # Version required by ethereum-consensus beacon-api-client
 mev-share-sse = { git = "https://github.com/paradigmxyz/mev-share-rs", rev = "9eb2b0138ab3202b9eb3af4b19c7b3bf40b0faa8", default-features = false }
 jsonrpsee = { version = "0.20.3", features = ["full"] }
-beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "ade5ce6c4a19107c1059e5338d8f18855bd2d931" }
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "ade5ce6c4a19107c1059e5338d8f18855bd2d931" }
+beacon-api-client = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "5031d31e318dd861cf3373702c5d92f085d926e4" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus/", rev = "5031d31e318dd861cf3373702c5d92f085d926e4" }
 uuid = { version = "1.6.1", features = ["serde", "v5", "v4"] }
 prometheus.workspace = true
 warp.workspace = true

--- a/crates/rbuilder/benches/benchmarks/mev_boost.rs
+++ b/crates/rbuilder/benches/benchmarks/mev_boost.rs
@@ -1,5 +1,5 @@
 use alloy_consensus::{Block, Header};
-use alloy_eips::eip4844::BlobTransactionSidecar;
+use alloy_eips::{eip4844::BlobTransactionSidecar, eip7594::BlobTransactionSidecarVariant};
 use alloy_primitives::U256;
 use criterion::{criterion_group, Criterion};
 use primitive_types::H384;
@@ -73,7 +73,9 @@ fn bench_mevboost_sign(c: &mut Criterion) {
     let signer = BLSBlockSigner::test_signer();
     let mut blobs = vec![];
     for _ in 0..3 {
-        blobs.push(Arc::new(blob.clone()));
+        blobs.push(Arc::new(BlobTransactionSidecarVariant::Eip4844(
+            blob.clone(),
+        )));
     }
 
     let chain_spec = SEPOLIA.clone();

--- a/crates/rbuilder/src/backtest/backtest_build_range.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_range.rs
@@ -370,9 +370,9 @@ impl CSVResultWriter {
         let mut line = String::new();
         line.push_str("block_number,winning_bid_value,simulated_orders_count");
         for builder_name in &self.builder_names {
-            line.push_str(&format!(",{}", builder_name));
+            line.push_str(&format!(",{builder_name}"));
         }
-        writeln!(self.file, "{}", line)?;
+        writeln!(self.file, "{line}")?;
         self.file.flush()
     }
 
@@ -393,7 +393,7 @@ impl CSVResultWriter {
                 .unwrap_or_default();
             line.push_str(&format!(",{}", format_ether(builder_res)));
         }
-        writeln!(self.file, "{}", line)?;
+        writeln!(self.file, "{line}")?;
         self.file.flush()
     }
 }

--- a/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
@@ -87,7 +87,7 @@ where
         order_statistics.add(&order.order);
     }
     println!("Available orders: {}", available_orders.len());
-    println!("Order statistics: {:?}", order_statistics);
+    println!("Order statistics: {order_statistics:?}");
 
     if build_block_cfg.show_orders {
         print_order_and_timestamp(&available_orders, orders_source.block_time_as_unix_ms());
@@ -140,14 +140,13 @@ where
                     NullPartialBlockExecutionTracer{})
                 };
                 if let Err(err) = &build_res {
-                    println!("Error building block: {:?}", err);
+                    println!("Error building block: {err:?}");
                     return None;
                 }
                 let block = build_res.ok()?;
                 println!(
-                    "Built block {} with builder: {:?}",
-                    ctx.block(),
-                    builder_name
+                    "Built block {} with builder: {builder_name:?}",
+                    ctx.block()
                 );
                 println!("Builder profit: {}", format_ether(block.trace.bid_value));
                 println!(
@@ -160,7 +159,7 @@ where
                     println!(
                         "{:>74} gas: {:>8} profit: {}",
                         order_result.order.id().to_string(),
-                        order_result.gas_used,
+                        order_result.space_used.gas(),
                         format_ether(order_result.coinbase_profit),
                     );
                     if let Order::Bundle(_) | Order::ShareBundle(_) = order_result.order {

--- a/crates/rbuilder/src/backtest/build_block/full_partial_block_execution_tracer.rs
+++ b/crates/rbuilder/src/backtest/build_block/full_partial_block_execution_tracer.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 use alloy_primitives::{utils::format_ether, TxHash, U256};
 
+use crate::building::BlockBuildingSpaceState;
 use crate::{
     building::{
         CriticalCommitOrderError, ExecutionError, ExecutionResult, PartialBlockExecutionTracer,
@@ -247,9 +248,7 @@ impl PartialBlockForkExecutionTracer for FullPartialBlockExecutionTracer {
     fn update_commit_tx_about_to_execute(
         &mut self,
         _tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        _cumulative_gas_used: u64,
-        _gas_reserved: u64,
-        _cumulative_blob_gas_used: u64,
+        _space_state: BlockBuildingSpaceState,
     ) {
         self.last_tx_start_time = Instant::now();
         if self.execution_start.is_none() {
@@ -260,9 +259,7 @@ impl PartialBlockForkExecutionTracer for FullPartialBlockExecutionTracer {
     fn update_commit_tx_executed(
         &mut self,
         tx_with_blobs: &crate::primitives::TransactionSignedEcRecoveredWithBlobs,
-        _cumulative_gas_used: u64,
-        _gas_reserved: u64,
-        _cumulative_blob_gas_used: u64,
+        _space_state: BlockBuildingSpaceState,
         res: &Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError>,
     ) {
         let base = BaseExecutionSummary {

--- a/crates/rbuilder/src/backtest/build_block/landed_block_from_db.rs
+++ b/crates/rbuilder/src/backtest/build_block/landed_block_from_db.rs
@@ -268,10 +268,10 @@ fn print_onchain_block_data(tx_sim_results: Vec<ExecutedTxs>, block_data: &Block
                     order.error
                 );
                 for (other, tx) in &order.overlapping_txs {
-                    println!("    overlap with: {:>74} tx {:?}", other, tx);
+                    println!("    overlap with: {other:>74} tx {tx:?}");
                 }
             } else {
-                println!("{:>74} included order not found: ", included_order);
+                println!("{included_order:>74} included order not found: ");
             }
         }
     }
@@ -286,7 +286,7 @@ fn show_missing_txs(block_data: &BlockData) {
             missing_txs.len()
         );
         for missing_tx in missing_txs.iter() {
-            println!("Tx: {:?}", missing_tx);
+            println!("Tx: {missing_tx:?}");
         }
     }
     let missing_nonce_txs = block_data.search_missing_account_nonce_on_available_orders();

--- a/crates/rbuilder/src/backtest/fetch/flashbots_db.rs
+++ b/crates/rbuilder/src/backtest/fetch/flashbots_db.rs
@@ -76,7 +76,7 @@ impl RelayDB {
                         .map(Bytes::from_str)
                         .collect::<Result<Vec<_>, _>>()
                         .wrap_err_with(|| {
-                            format!("Failed to parse txs for bundle {}", bundle_hash)
+                            format!("Failed to parse txs for bundle {bundle_hash}")
                         })?;
                     let reverting_tx_hashes = reverting_tx_hashes
                         .split(',')
@@ -84,10 +84,7 @@ impl RelayDB {
                         .map(B256::from_str)
                         .collect::<Result<_, _>>()
                         .wrap_err_with(|| {
-                            format!(
-                                "Failed to parse reverting tx hashes for bundle {}",
-                                bundle_hash
-                            )
+                            format!("Failed to parse reverting tx hashes for bundle {bundle_hash}")
                         })?;
 
                     if txs.is_empty() {
@@ -96,7 +93,7 @@ impl RelayDB {
 
                     let signing_address = if let Some(address) = signing_address {
                         Some(address.parse().wrap_err_with(|| {
-                            format!("Failed to parse signing address for bundle {}", bundle_hash)
+                            format!("Failed to parse signing address for bundle {bundle_hash}")
                         })?)
                     } else {
                         None
@@ -122,7 +119,7 @@ impl RelayDB {
 
                     let order = RawOrder::Bundle(raw_bundle)
                         .decode(TxEncoding::NoBlobData)
-                        .wrap_err_with(|| format!("Failed to parse bundle {}", bundle_hash))?;
+                        .wrap_err_with(|| format!("Failed to parse bundle {bundle_hash}"))?;
 
                     Ok(OrdersWithTimestamp {
                         timestamp_ms: (inserted_at.unix_timestamp_nanos() / 1_000_000)
@@ -196,7 +193,7 @@ impl RelayDB {
                     let hash = (hash.len() == 32).then(|| B256::from_slice(&hash)).ok_or_else(|| eyre::eyre!("Invalid hash length"))?;
                     let mut bundle = serde_json::from_value::<RawShareBundle>(body)
                         .wrap_err_with(|| {
-                            format!("Failed to parse share bundle {:?}", hash)
+                            format!("Failed to parse share bundle {hash:?}")
                         })?;
                     // if it was used by the live builder we are sure that it has correct block range
                     // so we modify it here to correct db overwrites
@@ -237,7 +234,7 @@ impl RelayDB {
 
             let order: Order = raw_order
                 .decode(TxEncoding::NoBlobData)
-                .wrap_err_with(|| format!("Failed to parse share bundle: {:?}", hash))?;
+                .wrap_err_with(|| format!("Failed to parse share bundle: {hash:?}"))?;
 
             result.push(OrdersWithTimestamp {
                 timestamp_ms,
@@ -253,7 +250,7 @@ impl RelayDB {
         &self,
         block_hash: B256,
     ) -> eyre::Result<Option<BuiltBlockData>> {
-        let block_hash = format!("{:?}", block_hash);
+        let block_hash = format!("{block_hash:?}");
 
         let mut built_blocks = sqlx::query_as::<
             _,
@@ -357,7 +354,7 @@ impl DataSource for RelayDB {
             self.get_built_block_data(block_hash)
                 .await
                 .with_context(|| {
-                    format!("Failed to fetch built block data for block {}", block_hash)
+                    format!("Failed to fetch built block data for block {block_hash:?}")
                 })?
         } else {
             None

--- a/crates/rbuilder/src/backtest/fetch/mempool.rs
+++ b/crates/rbuilder/src/backtest/fetch/mempool.rs
@@ -62,7 +62,7 @@ pub fn get_mempool_transactions(
 }
 
 fn path_transactions(data_dir: &Path, day: &str) -> PathBuf {
-    data_dir.join(format!("transactions/{}.parquet", day))
+    data_dir.join(format!("transactions/{day}.parquet"))
 }
 
 /// Downloads missing files to data_dir for the given interval

--- a/crates/rbuilder/src/backtest/fetch/mod.rs
+++ b/crates/rbuilder/src/backtest/fetch/mod.rs
@@ -100,8 +100,8 @@ impl HistoricalDataFetcher {
             .get_block_by_number(BlockNumberOrTag::Number(block_number))
             .full()
             .await
-            .wrap_err_with(|| format!("Failed to fetch block {}", block_number))?
-            .ok_or_else(|| eyre::eyre!("Block {} not found", block_number))?;
+            .wrap_err_with(|| format!("Failed to fetch block {block_number}"))?
+            .ok_or_else(|| eyre::eyre!("Block {block_number} not found"))?;
         Ok(block)
     }
 

--- a/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
@@ -1,7 +1,8 @@
 use crate::{
     building::{
         evm_inspector::SlotKey, tracers::AccumulatorSimulationTracer, BlockBuildingContext,
-        BlockState, PartialBlock, PartialBlockFork, ThreadBlockBuildingContext,
+        BlockBuildingSpaceState, BlockState, PartialBlock, PartialBlockFork,
+        ThreadBlockBuildingContext,
     },
     provider::StateProviderFactory,
     utils::{extract_onchain_block_txs, find_suggested_fee_recipient, signed_uint_delta},
@@ -66,8 +67,7 @@ where
         .pre_block_call(&ctx, &mut local_ctx, &mut state)
         .with_context(|| "Failed to pre_block_call")?;
 
-    let mut cumulative_gas_used = 0;
-    let mut cumulative_blob_gas_used = 0;
+    let mut space_state = BlockBuildingSpaceState::ZERO;
     let mut written_slots: HashMap<SlotKey, Vec<B256>> = HashMap::default();
 
     for (idx, tx) in txs.into_iter().enumerate() {
@@ -80,7 +80,7 @@ where
         let result = {
             let mut fork = PartialBlockFork::new(&mut state, &ctx, &mut local_ctx)
                 .with_tracer(&mut accumulator_tracer);
-            fork.commit_tx(&tx, cumulative_gas_used, 0, cumulative_blob_gas_used)?
+            fork.commit_tx(&tx, space_state)?
                 .with_context(|| format!("Failed to commit tx: {} {:?}", idx, tx.hash()))?
         };
         let coinbase_balance_after = state.balance(
@@ -89,9 +89,7 @@ where
             &mut local_ctx.cached_reads,
         )?;
         let coinbase_profit = signed_uint_delta(coinbase_balance_after, coinbase_balance_before);
-
-        cumulative_gas_used += result.tx_info.gas_used;
-        cumulative_blob_gas_used += result.blob_gas_used;
+        space_state.use_space(result.space_used(), result.blob_gas_used);
 
         let mut conflicting_txs: HashMap<B256, Vec<SlotKey>> = HashMap::default();
         for (slot, _) in accumulator_tracer.used_state_trace.read_slot_values {

--- a/crates/rbuilder/src/backtest/store.rs
+++ b/crates/rbuilder/src/backtest/store.rs
@@ -631,6 +631,7 @@ fn group_rows_into_block_data(
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum RawReplaceableOrderPoolCommand {
     /// New or update order
     Order(RawOrder),

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -7,7 +7,7 @@ use eyre::Context;
 use itertools::Itertools;
 use rbuilder::{
     building::{
-        BlockBuildingContext, BlockState, PartialBlock, PartialBlockFork,
+        BlockBuildingContext, BlockBuildingSpaceState, BlockState, PartialBlock, PartialBlockFork,
         ThreadBlockBuildingContext,
     },
     live_builder::{base_config::load_config_toml_and_env, cli::LiveBuilderConfig, config::Config},
@@ -97,18 +97,15 @@ async fn main() -> eyre::Result<()> {
 
                 let build_time = Instant::now();
 
-                let mut cumulative_gas_used = 0;
-                let mut cumulative_blob_gas_used = 0;
+                let mut space_state = BlockBuildingSpaceState::ZERO;
                 for (idx, tx) in txs.into_iter().enumerate() {
                     let result = {
                         let mut fork = PartialBlockFork::new(&mut state, &ctx, &mut local_ctx);
-                        fork.commit_tx(&tx, cumulative_gas_used, 0, cumulative_blob_gas_used)?
-                            .with_context(|| {
-                                format!("Failed to commit tx: {} {:?}", idx, tx.hash())
-                            })?
+                        fork.commit_tx(&tx, space_state)?.with_context(|| {
+                            format!("Failed to commit tx: {} {:?}", idx, tx.hash())
+                        })?
                     };
-                    cumulative_gas_used += result.tx_info.gas_used;
-                    cumulative_blob_gas_used += result.blob_gas_used;
+                    space_state.use_space(result.space_used(), result.blob_gas_used);
                 }
 
                 let build_time = build_time.elapsed();

--- a/crates/rbuilder/src/bin/misc-relays-slot.rs
+++ b/crates/rbuilder/src/bin/misc-relays-slot.rs
@@ -38,11 +38,11 @@ async fn main() -> eyre::Result<()> {
     println!("block_hash     {:?}", payload.block_hash);
     println!("timestamp_ms   {}", payload.timestamp_ms);
     println!("timestamp      {}", payload.timestamp);
-    println!("timestamp_diff {}", ts_diff);
+    println!("timestamp_diff {ts_diff}");
     println!("num_tx         {}", payload.num_tx);
     println!("gas_used       {}", payload.gas_used);
     println!("builder        {:?}", payload.builder_pubkey);
-    println!("value          {}", value);
+    println!("value          {value}");
     println!("optimistic     {}", payload.optimistic_submission);
 
     Ok(())

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -12,7 +12,7 @@ use tracing::{debug, error, trace};
 use crate::{
     building::{
         estimate_payout_gas_limit, tracers::GasUsedSimulationTracer, BlockBuildingContext,
-        BlockState, BuiltBlockTrace, BuiltBlockTraceError, CriticalCommitOrderError,
+        BlockSpace, BlockState, BuiltBlockTrace, BuiltBlockTraceError, CriticalCommitOrderError,
         EstimatePayoutGasErr, ExecutionError, ExecutionResult, FinalizeError, FinalizeResult,
         NullPartialBlockExecutionTracer, PartialBlock, PartialBlockExecutionTracer,
         ThreadBlockBuildingContext,
@@ -241,15 +241,15 @@ impl<
         let payout_tx_gas = if building_ctx.coinbase_is_suggested_fee_recipient() {
             None
         } else {
-            let payout_tx_gas = estimate_payout_gas_limit(
+            let payout_tx_space = estimate_payout_gas_limit(
                 building_ctx.attributes.suggested_fee_recipient,
                 &building_ctx,
                 local_ctx,
                 &mut block_state,
-                0,
+                BlockSpace::ZERO,
             )?;
-            partial_block.reserve_gas(payout_tx_gas);
-            Some(payout_tx_gas)
+            partial_block.reserve_block_space(payout_tx_space);
+            Some(payout_tx_space.gas())
         };
 
         let mut built_block_trace = BuiltBlockTrace::new();

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -289,7 +289,7 @@ impl<
         );
 
         trace!(
-            block = building_ctx.evm_env.block_env.number,
+            block = building_ctx.block(),
             build_time_mus = built_block_trace.fill_time.as_micros(),
             finalize_time_mus = built_block_trace.finalize_time.as_micros(),
             root_hash_time_mus = built_block_trace.root_hash_time.as_micros(),

--- a/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
@@ -58,7 +58,7 @@ impl BlockBuildingHelperCommitLog {
             Some(ExecutionResult {
                 landed_tx_count: exec_ok.tx_infos.len(),
                 coinbase_profit: exec_ok.coinbase_profit,
-                gas_used: exec_ok.gas_used,
+                gas_used: exec_ok.space_used.gas(),
             })
         } else {
             None

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     utils::{is_provider_factory_health_error, NonceCache},
 };
 use ahash::HashSet;
-use alloy_eips::eip4844::BlobTransactionSidecar;
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_primitives::{Address, Bytes};
 use block_building_helper::BiddableUnfinishedBlock;
 use reth::primitives::SealedBlock;
@@ -36,7 +36,7 @@ pub struct Block {
     pub trace: BuiltBlockTrace,
     pub sealed_block: SealedBlock,
     /// Sidecars for the txs included in SealedBlock
-    pub txs_blobs_sidecars: Vec<Arc<BlobTransactionSidecar>>,
+    pub txs_blobs_sidecars: Vec<Arc<BlobTransactionSidecarVariant>>,
     /// The Pectra execution requests for this bid.
     pub execution_requests: Vec<Bytes>,
     pub builder_name: String,

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -169,7 +169,7 @@ where
     let use_suggested_fee_recipient_as_coinbase = ordering_config.coinbase_payment;
     let state_provider = input
         .provider
-        .history_by_block_number(input.ctx.evm_env.block_env.number - 1)?;
+        .history_by_block_number(input.ctx.block() - 1)?;
     let block_orders =
         block_orders_from_sim_orders::<OrderPriorityType>(input.sim_orders, &state_provider)?;
     let mut local_ctx = ThreadBlockBuildingContext::default();

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -329,7 +329,7 @@ impl OrderingBuilderContext {
             let success = commit_result.is_ok();
             match commit_result {
                 Ok(res) => {
-                    gas_used = res.gas_used;
+                    gas_used = res.space_used.gas();
                     // This intermediate step is needed until we replace all (Address, u64) for AccountNonce
                     let nonces_updated: Vec<_> = res
                         .nonces_updated

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -242,7 +242,7 @@ impl BlockBuildingResultAssembler {
                 let success = commit_result.is_ok();
                 match commit_result {
                     Ok(res) => {
-                        gas_used = res.gas_used;
+                        gas_used = res.space_used.gas();
                     }
                     Err(err) => execution_error = Some(err),
                 }
@@ -312,7 +312,7 @@ impl BlockBuildingResultAssembler {
                         tracing::trace!(
                             order_id = ?sim_order.id(),
                             success = true,
-                            gas_used = res.gas_used,
+                            gas_used = res.space_used.gas(),
                             "Executed order in backtest"
                         );
                     }

--- a/crates/rbuilder/src/building/conflict.rs
+++ b/crates/rbuilder/src/building/conflict.rs
@@ -1,5 +1,8 @@
 use super::{BlockBuildingContext, BlockState, PartialBlockFork, ThreadBlockBuildingContext};
-use crate::primitives::{Order, OrderId};
+use crate::{
+    building::BlockBuildingSpaceState,
+    primitives::{Order, OrderId},
+};
 use alloy_primitives::{Address, U256};
 use itertools::Itertools;
 use reth::providers::StateProviderBox;
@@ -39,7 +42,12 @@ pub fn find_conflict_slow(
         for order in orders {
             let mut state = BlockState::new_arc(state_provider);
             let mut fork = PartialBlockFork::new(&mut state, ctx, &mut local_ctx);
-            if let Ok(res) = fork.commit_order(order, 0, 0, 0, true, &combined_refunds)? {
+            if let Ok(res) = fork.commit_order(
+                order,
+                BlockBuildingSpaceState::ZERO,
+                true,
+                &combined_refunds,
+            )? {
                 profits_alone.insert(order.id(), res.coinbase_profit);
             };
             state_provider = state.into_provider();
@@ -77,18 +85,16 @@ pub fn find_conflict_slow(
 
         let mut state = BlockState::new_arc(state_provider);
         let mut fork = PartialBlockFork::new(&mut state, ctx, &mut local_ctx);
-        let mut gas_used = 0;
-        let mut blob_gas_used = 0;
-        match fork.commit_order(order1, gas_used, 0, blob_gas_used, true, &combined_refunds)? {
+        let mut space_state = BlockBuildingSpaceState::ZERO;
+        match fork.commit_order(order1, space_state, true, &combined_refunds)? {
             Ok(res) => {
-                gas_used += res.gas_used;
-                blob_gas_used += res.blob_gas_used;
+                space_state.use_space(res.space_used, res.blob_gas_used);
             }
             Err(_) => {
                 results.insert(pair, Conflict::Fatal);
             }
         };
-        match fork.commit_order(order2, gas_used, 0, blob_gas_used, true, &combined_refunds)? {
+        match fork.commit_order(order2, space_state, true, &combined_refunds)? {
             Ok(re) => {
                 let profit_alone = *profits_alone.get(&order2.id()).unwrap();
                 let profit_with_conflict = re.coinbase_profit;

--- a/crates/rbuilder/src/building/evm.rs
+++ b/crates/rbuilder/src/building/evm.rs
@@ -1,4 +1,5 @@
 use crate::building::precompile_cache::{PrecompileCache, WrappedPrecompile};
+use alloy_evm::Database;
 use parking_lot::Mutex;
 use reth_evm::{
     eth::EthEvmContext, EthEvm, EthEvmFactory, Evm, EvmEnv, EvmFactory as RethEvmFactory,
@@ -12,7 +13,7 @@ use revm::{
     inspector::NoOpInspector,
     interpreter::interpreter::EthInterpreter,
     primitives::hardfork::SpecId,
-    Database, Inspector,
+    Inspector,
 };
 use std::sync::Arc;
 

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -28,6 +28,7 @@ use alloy_eips::{
 };
 use alloy_evm::{block::system_calls::SystemCaller, env::EvmEnv, eth::eip6110};
 use alloy_primitives::{Address, BlockNumber, Bytes, B256, I256, U256};
+use alloy_rlp::Encodable as _;
 use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
 use cached_reads::{LocalCachedReads, SharedCachedReads};
 use eth_sparse_mpt::SparseTrieLocalCache;
@@ -90,6 +91,9 @@ pub use self::{
 
 #[cfg(test)]
 pub use conflict::*;
+
+/// Estimated overhead for the whole block header rlp length
+const BLOCK_HEADER_RLP_OVERHEAD: usize = 1024;
 
 #[derive(Debug, Clone)]
 pub struct BlockBuildingContext {
@@ -1150,12 +1154,22 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         Ok(result)
     }
 
+    /// Standard pre block ETH stuff + space allocation for rlp length
     pub fn pre_block_call(
         &mut self,
         ctx: &BlockBuildingContext,
         local_ctx: &mut ThreadBlockBuildingContext,
         state: &mut BlockState,
     ) -> eyre::Result<()> {
+        // We "pre-use" the RLP overhead for the withdrawals and the block header.
+        self.space_state.use_space(
+            BlockSpace::new(
+                0,
+                ctx.attributes.withdrawals.length() + BLOCK_HEADER_RLP_OVERHEAD,
+            ),
+            0,
+        );
+
         let mut db = state.new_db_ref(&ctx.shared_cached_reads, &mut local_ctx.cached_reads);
         let mut system_caller = SystemCaller::new(ctx.chain_spec.clone());
         let mut evm = EthEvmConfig::new(ctx.chain_spec.clone())

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -20,14 +20,14 @@ use crate::{
 use alloy_consensus::{constants::KECCAK_EMPTY, Header, EMPTY_OMMER_ROOT_HASH};
 use alloy_eips::{
     eip1559::{calculate_block_gas_limit, ETHEREUM_BLOCK_GAS_LIMIT_30M},
-    eip4844::BlobTransactionSidecar,
     eip4895::Withdrawals,
+    eip7594::BlobTransactionSidecarVariant,
     eip7685::Requests,
     eip7840::BlobParams,
     merge::BEACON_NONCE,
 };
 use alloy_evm::{block::system_calls::SystemCaller, env::EvmEnv, eth::eip6110};
-use alloy_primitives::{Address, Bytes, B256, I256, U256};
+use alloy_primitives::{Address, BlockNumber, Bytes, B256, I256, U256};
 use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
 use cached_reads::{LocalCachedReads, SharedCachedReads};
 use eth_sparse_mpt::SparseTrieLocalCache;
@@ -115,12 +115,16 @@ pub struct BlockBuildingContext {
     pub tx_execution_cache: Arc<TxExecutionCache>,
     pub mempool_tx_detector: Arc<MempoolTxsDetector>,
     pub faster_finalize: bool,
+
+    /// Cached from evm_env.block_env.number but as BlockNumber. Avoid conversions all over the code.
+    block_number: BlockNumber,
 }
 
 impl BlockBuildingContext {
     #[allow(clippy::too_many_arguments)]
     /// spec_id None: we use the proper SpecId for the block timestamp.
     /// We are forced to return Option since next_cfg_and_block_env returns Result although it never fails! (reth v1.1.1)
+    /// None if block does not fit on u64.
     pub fn from_attributes(
         attributes: PayloadAttributesEvent,
         parent: &Header,
@@ -165,13 +169,11 @@ impl BlockBuildingContext {
 
         let excess_blob_gas = if chain_spec.is_cancun_active_at_timestamp(attributes.timestamp) {
             if chain_spec.is_cancun_active_at_timestamp(parent.timestamp) {
-                let blob_params = if chain_spec.is_prague_active_at_timestamp(attributes.timestamp)
-                {
-                    BlobParams::prague()
-                } else {
-                    BlobParams::cancun()
-                };
-                parent.next_block_excess_blob_gas(blob_params)
+                parent.next_block_excess_blob_gas(
+                    chain_spec
+                        .blob_params_at_timestamp(attributes.timestamp)
+                        .unwrap_or(BlobParams::cancun()),
+                )
             } else {
                 // for the first post-fork block, both parent.blob_gas_used and
                 // parent.excess_blob_gas are evaluated as 0
@@ -190,6 +192,7 @@ impl BlockBuildingContext {
         });
         let max_blob_gas_per_block =
             Self::max_blob_gas_per_block_at(&chain_spec, attributes.timestamp());
+        let block_number = evm_env.block_env.number.try_into().ok()?;
         Some(BlockBuildingContext {
             evm_factory: EthCachedEvmFactory::default(),
             evm_env,
@@ -207,6 +210,7 @@ impl BlockBuildingContext {
             max_blob_gas_per_block,
             mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
             faster_finalize,
+            block_number,
         })
     }
 
@@ -238,15 +242,20 @@ impl BlockBuildingContext {
             if chain_spec.is_cancun_active_at_timestamp(onchain_block.header.timestamp) {
                 Some(BlobExcessGasAndPrice::new(
                     onchain_block.header.excess_blob_gas.unwrap_or_default(),
-                    chain_spec.is_prague_active_at_timestamp(onchain_block.header.timestamp),
+                    chain_spec
+                        .blob_params_at_timestamp(onchain_block.header.timestamp)
+                        .unwrap_or(BlobParams::cancun())
+                        .update_fraction
+                        .try_into()
+                        .expect("update_fraction too large for u64"),
                 ))
             } else {
                 None
             };
         let block_env = BlockEnv {
-            number: block_number,
+            number: U256::from(block_number),
             beneficiary,
-            timestamp: onchain_block.header.timestamp,
+            timestamp: U256::from(onchain_block.header.timestamp),
             difficulty: onchain_block.header.difficulty,
             prevrandao: Some(onchain_block.header.mix_hash),
             basefee: onchain_block
@@ -305,6 +314,7 @@ impl BlockBuildingContext {
             max_blob_gas_per_block,
             mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
             faster_finalize: true,
+            block_number,
         }
     }
 
@@ -338,8 +348,12 @@ impl BlockBuildingContext {
             .expect("Payload attributes timestamp")
     }
 
+    pub fn timestamp_u64(&self) -> u64 {
+        self.attributes.timestamp
+    }
+
     pub fn block(&self) -> u64 {
-        self.evm_env.block_env.number
+        self.block_number
     }
 
     pub fn coinbase_is_suggested_fee_recipient(&self) -> bool {
@@ -553,7 +567,7 @@ impl ExecutionError {
 pub struct FinalizeResult {
     pub sealed_block: SealedBlock,
     // sidecars for all txs in SealedBlock
-    pub txs_blob_sidecars: Vec<Arc<BlobTransactionSidecar>>,
+    pub txs_blob_sidecars: Vec<Arc<BlobTransactionSidecarVariant>>,
     /// The Pectra execution requests for this bid.
     pub execution_requests: Vec<Bytes>,
 
@@ -884,7 +898,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
 
         let step_start = Instant::now();
         let (requests, withdrawals_root) = self.process_requests(&mut state, ctx, local_ctx)?;
-        let block_number = ctx.evm_env.block_env.number;
+        let block_number = ctx.block();
 
         let request_processsing_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
@@ -941,13 +955,26 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             }
         }
 
-        let mut txs_blob_sidecars = Vec::new();
+        let mut txs_blob_sidecars: Vec<Arc<BlobTransactionSidecarVariant>> = Vec::new();
         let (excess_blob_gas, blob_gas_used) = if ctx
             .chain_spec
             .is_cancun_active_at_timestamp(ctx.attributes.timestamp)
         {
+            // We should NEVER get the wrong sidecar types but we double check here just in case....
+            let valid_blobs_count = if ctx
+                .chain_spec
+                .is_osaka_active_at_timestamp(ctx.attributes.timestamp)
+            {
+                |side_car: &BlobTransactionSidecarVariant| {
+                    side_car.as_eip7594().map_or(0, |sc| sc.blobs.len())
+                }
+            } else {
+                |side_car: &BlobTransactionSidecarVariant| {
+                    side_car.as_eip4844().map_or(0, |sc| sc.blobs.len())
+                }
+            };
             for tx_with_blob in self.executed_tx_infos.iter().map(|info| &info.tx) {
-                if !tx_with_blob.blobs_sidecar.blobs.is_empty() {
+                if valid_blobs_count(tx_with_blob.blobs_sidecar.as_ref()) > 0 {
                     txs_blob_sidecars.push(tx_with_blob.blobs_sidecar.clone());
                 }
             }

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -54,8 +54,9 @@ use revm::{
 };
 use serde::Deserialize;
 use std::{
-    collections::{hash_map, HashMap},
+    collections::HashMap,
     hash::Hash,
+    ops::{Add, AddAssign},
     str::FromStr,
     sync::Arc,
     time::{Duration, Instant},
@@ -422,11 +423,11 @@ impl FromStr for Sorting {
 impl std::fmt::Display for Sorting {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Sorting::MevGasPrice => write!(f, "{}", MEV_GAS_PRICE_NAME),
-            Sorting::MaxProfit => write!(f, "{}", MAX_PROFIT_NAME),
-            Sorting::TypeMaxProfit => write!(f, "{}", TYPE_MAX_PROFIT_NAME),
-            Sorting::LengthThreeMaxProfit => write!(f, "{}", LENGTH_THREE_MAX_PROFIT_NAME),
-            Sorting::LengthThreeMevGasPrice => write!(f, "{}", LENGTH_THREE_MEV_GAS_PRICE_NAME),
+            Sorting::MevGasPrice => write!(f, "{MEV_GAS_PRICE_NAME}"),
+            Sorting::MaxProfit => write!(f, "{MAX_PROFIT_NAME}"),
+            Sorting::TypeMaxProfit => write!(f, "{TYPE_MAX_PROFIT_NAME}"),
+            Sorting::LengthThreeMaxProfit => write!(f, "{LENGTH_THREE_MAX_PROFIT_NAME}"),
+            Sorting::LengthThreeMevGasPrice => write!(f, "{LENGTH_THREE_MEV_GAS_PRICE_NAME}"),
         }
     }
 }
@@ -456,19 +457,125 @@ impl PartialBlockForkExecutionTracer for NullPartialBlockExecutionTracer {
     fn update_commit_tx_about_to_execute(
         &mut self,
         _tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        _cumulative_gas_used: u64,
-        _gas_reserved: u64,
-        _cumulative_blob_gas_used: u64,
+        _space_state: BlockBuildingSpaceState,
     ) {
     }
     fn update_commit_tx_executed(
         &mut self,
         _tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        _cumulative_gas_used: u64,
-        _gas_reserved: u64,
-        _cumulative_blob_gas_used: u64,
+        _space_state: BlockBuildingSpaceState,
         _res: &Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError>,
     ) {
+    }
+}
+
+/// Models consumed/reserved space on a block to be able to insert payout tx when finished filling the block.
+/// @Pending: Add blob gas?
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct BlockSpace {
+    pub gas: u64,
+    /// EIP-7934 limits the size of the final rlp block.
+    /// Estimation of the sum of the rlp txs sizes.
+    pub rlp_length: usize,
+}
+
+impl BlockSpace {
+    pub fn new(gas: u64, rlp_length: usize) -> Self {
+        Self { gas, rlp_length }
+    }
+
+    pub const ZERO: Self = Self {
+        gas: 0,
+        rlp_length: 0,
+    };
+
+    pub fn gas(&self) -> u64 {
+        self.gas
+    }
+
+    pub fn rlp_length(&self) -> usize {
+        self.rlp_length
+    }
+}
+
+impl AddAssign for BlockSpace {
+    fn add_assign(&mut self, other: Self) {
+        self.gas += other.gas;
+        self.rlp_length += other.rlp_length;
+    }
+}
+
+impl Add for BlockSpace {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            gas: self.gas + other.gas,
+            rlp_length: self.rlp_length + other.rlp_length,
+        }
+    }
+}
+
+/// Models the current state of the block building space.
+#[derive(Debug, Clone, Copy)]
+pub struct BlockBuildingSpaceState {
+    space_used: BlockSpace,
+    /// Reserved gas/size for later use (usually final payout tx). When simulating we subtract this from the block gas limit.
+    reserved_block_space: BlockSpace,
+    blob_gas_used: u64,
+}
+
+impl BlockBuildingSpaceState {
+    pub fn new(
+        space_used: BlockSpace,
+        reserved_block_space: BlockSpace,
+        blob_gas_used: u64,
+    ) -> Self {
+        Self {
+            space_used,
+            reserved_block_space,
+            blob_gas_used,
+        }
+    }
+
+    pub const ZERO: Self = Self {
+        space_used: BlockSpace::ZERO,
+        reserved_block_space: BlockSpace::ZERO,
+        blob_gas_used: 0,
+    };
+
+    pub fn free_reserved_block_space(&mut self) {
+        self.reserved_block_space = BlockSpace::ZERO;
+    }
+
+    pub fn reserved_block_space(&self) -> BlockSpace {
+        self.reserved_block_space
+    }
+
+    /// Used+Reserved
+    pub fn total_consumed_space(&self) -> BlockSpace {
+        self.space_used + self.reserved_block_space
+    }
+
+    pub fn gas_used(&self) -> u64 {
+        self.space_used.gas()
+    }
+
+    pub fn blob_gas_used(&self) -> u64 {
+        self.blob_gas_used
+    }
+
+    pub fn space_used(&self) -> BlockSpace {
+        self.space_used
+    }
+
+    pub fn reserve_block_space(&mut self, space: BlockSpace) {
+        self.reserved_block_space += space;
+    }
+
+    pub fn use_space(&mut self, space: BlockSpace, blob_gas_used: u64) {
+        self.space_used += space;
+        self.blob_gas_used += blob_gas_used;
     }
 }
 
@@ -479,10 +586,8 @@ pub struct PartialBlock<
 > {
     /// Value used as allow_tx_skip on calls to [`PartialBlockFork`]
     pub discard_txs: bool,
-    pub gas_used: u64,
-    /// Reserved gas for later use (usually final payout tx). When simulating we subtract this from the block gas limit.
-    pub gas_reserved: u64,
-    pub blob_gas_used: u64,
+    /// What we consumed so far.
+    pub space_state: BlockBuildingSpaceState,
     /// Updated after each order.
     pub coinbase_profit: U256,
     /// Tx execution info belonging to successfully executed orders.
@@ -497,7 +602,7 @@ pub struct PartialBlock<
 pub struct ExecutionResult {
     pub coinbase_profit: U256,
     pub inplace_sim: SimValue,
-    pub gas_used: u64,
+    pub space_used: BlockSpace,
     pub order: Order,
     pub tx_infos: Vec<TransactionExecutionInfo>,
     /// Patch to get the executed OrderIds for merged sbundles (see: [`BundleOk::original_order_ids`],[`ShareBundleMerger`] )
@@ -604,9 +709,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
     ) -> PartialBlock<NewTracer, PartialBlockExecutionTracerType> {
         PartialBlock {
             discard_txs: self.discard_txs,
-            gas_used: self.gas_used,
-            gas_reserved: self.gas_reserved,
-            blob_gas_used: self.blob_gas_used,
+            space_state: self.space_state,
             coinbase_profit: self.coinbase_profit,
             executed_tx_infos: self.executed_tx_infos,
             combined_refunds: self.combined_refunds,
@@ -615,12 +718,12 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         }
     }
 
-    pub fn reserve_gas(&mut self, gas: u64) {
-        self.gas_reserved = gas;
+    pub fn reserve_block_space(&mut self, space: BlockSpace) {
+        self.space_state.reserve_block_space(space);
     }
 
-    pub fn free_reserved_gas(&mut self) {
-        self.gas_reserved = 0;
+    pub fn free_reserved_block_space(&mut self) {
+        self.space_state.free_reserved_block_space();
     }
 
     pub fn commit_order(
@@ -668,9 +771,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         let rollback = fork.rollback_point();
         let exec_result = fork.commit_order(
             &order.order,
-            self.gas_used,
-            self.gas_reserved,
-            self.blob_gas_used,
+            self.space_state,
             self.discard_txs,
             &self.combined_refunds,
         )?;
@@ -692,8 +793,8 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             }
         }
 
-        self.gas_used += ok_result.gas_used;
-        self.blob_gas_used += ok_result.blob_gas_used;
+        self.space_state
+            .use_space(ok_result.space_used, ok_result.blob_gas_used);
         self.coinbase_profit += ok_result.coinbase_profit;
         self.executed_tx_infos.extend(ok_result.tx_infos.clone());
 
@@ -701,22 +802,18 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         if let Some(DelayedKickback {
             recipient,
             payout_value,
+            payout_tx_space_needed,
             ..
         }) = ok_result.delayed_kickback
         {
-            let entry = self.combined_refunds.entry(recipient);
-            if matches!(entry, hash_map::Entry::Vacant(_)) {
-                // This is the first refund for the recipient,
-                // so we need to reserve the gas for the refund tx.
-                self.gas_reserved += 21_000;
-            }
-            *entry.or_default() += payout_value;
+            self.space_state.reserve_block_space(payout_tx_space_needed);
+            *self.combined_refunds.entry(recipient).or_default() += payout_value;
         }
 
         Ok(Ok(ExecutionResult {
             coinbase_profit: ok_result.coinbase_profit,
             inplace_sim: inplace_sim_result,
-            gas_used: ok_result.gas_used,
+            space_used: ok_result.space_used,
             order: order.order.clone(),
             tx_infos: ok_result.tx_infos,
             original_order_ids: ok_result.original_order_ids,
@@ -750,7 +847,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             .builder_signer
             .as_ref()
             .ok_or(InsertPayoutTxErr::NoSigner)?;
-        self.free_reserved_gas();
+        self.free_reserved_block_space();
         let mut nonce = state
             .nonce(
                 builder_signer.address,
@@ -785,14 +882,13 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
                 *refund_amount,
             )?)
             .unwrap();
-            let refund_result =
-                fork.commit_tx(&refund_tx, self.gas_used, 0, self.blob_gas_used)??;
+            let refund_result = fork.commit_tx(&refund_tx, self.space_state)??;
             if !refund_result.tx_info.receipt.success {
                 return Err(InsertPayoutTxErr::CombinedRefundTxReverted);
             }
 
-            self.gas_used += refund_result.tx_info.gas_used;
-            self.blob_gas_used += refund_result.blob_gas_used;
+            self.space_state
+                .use_space(refund_result.space_used(), refund_result.blob_gas_used);
             self.executed_tx_infos.push(refund_result.tx_info);
 
             nonce += 1;
@@ -809,14 +905,14 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         )?;
         // payout tx has no blobs so it's safe to unwrap
         let tx = TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx).unwrap();
-        let exec_result = fork.commit_tx(&tx, self.gas_used, 0, self.blob_gas_used)?;
+        let exec_result = fork.commit_tx(&tx, self.space_state)?;
         let ok_result = exec_result?;
         if !ok_result.tx_info.receipt.success {
             return Err(InsertPayoutTxErr::PayoutTxReverted);
         }
 
-        self.gas_used += ok_result.tx_info.gas_used;
-        self.blob_gas_used += ok_result.blob_gas_used;
+        self.space_state
+            .use_space(ok_result.space_used(), ok_result.blob_gas_used);
         self.executed_tx_infos.push(ok_result.tx_info);
 
         Ok(())
@@ -978,7 +1074,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
                     txs_blob_sidecars.push(tx_with_blob.blobs_sidecar.clone());
                 }
             }
-            (ctx.excess_blob_gas, Some(self.blob_gas_used))
+            (ctx.excess_blob_gas, Some(self.space_state.blob_gas_used()))
         } else {
             (None, None)
         };
@@ -1002,7 +1098,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             number: block_number,
             gas_limit: ctx.evm_env.block_env.gas_limit,
             difficulty: U256::ZERO,
-            gas_used: self.gas_used,
+            gas_used: self.space_state.gas_used(),
             extra_data: ctx.extra_data.clone().into(),
             parent_beacon_block_root: ctx.attributes.parent_beacon_block_root,
             blob_gas_used,
@@ -1076,9 +1172,7 @@ impl PartialBlock<(), NullPartialBlockExecutionTracer> {
     pub fn new(discard_txs: bool) -> Self {
         Self {
             discard_txs,
-            gas_used: 0,
-            gas_reserved: 0,
-            blob_gas_used: 0,
+            space_state: BlockBuildingSpaceState::ZERO,
             coinbase_profit: U256::ZERO,
             executed_tx_infos: Vec::new(),
             combined_refunds: HashMap::default(),
@@ -1097,9 +1191,7 @@ impl<PartialBlockExecutionTracerType: PartialBlockExecutionTracer>
     ) -> Self {
         Self {
             discard_txs,
-            gas_used: 0,
-            gas_reserved: 0,
-            blob_gas_used: 0,
+            space_state: BlockBuildingSpaceState::ZERO,
             coinbase_profit: U256::ZERO,
             executed_tx_infos: Vec::new(),
             combined_refunds: HashMap::default(),
@@ -1150,7 +1242,7 @@ pub fn create_sim_value(
     SimValue::new(
         order_ok.coinbase_profit,
         non_mempool_coinbase_profit,
-        order_ok.gas_used,
+        order_ok.space_used,
         order_ok.blob_gas_used,
         order_ok.paid_kickbacks.clone(),
     )
@@ -1181,8 +1273,8 @@ mod test {
         let profit_2 = I256::unchecked_from(10000);
         let order_ok = OrderOk {
             coinbase_profit: Default::default(),
-            gas_used: Default::default(),
-            cumulative_gas_used: Default::default(),
+            space_used: Default::default(),
+            cumulative_space_used: Default::default(),
             blob_gas_used: Default::default(),
             cumulative_blob_gas_used: Default::default(),
             tx_infos: vec![
@@ -1232,8 +1324,8 @@ mod test {
         let profit = I256::unchecked_from(1000);
         let order_ok = OrderOk {
             coinbase_profit: profit.unsigned_abs(),
-            gas_used: Default::default(),
-            cumulative_gas_used: Default::default(),
+            space_used: Default::default(),
+            cumulative_space_used: Default::default(),
             blob_gas_used: Default::default(),
             cumulative_blob_gas_used: Default::default(),
             tx_infos: vec![TransactionExecutionInfo {

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -10,6 +10,7 @@ use crate::{
         estimate_payout_gas_limit,
         evm::EvmFactory,
         evm_inspector::{RBuilderEVMInspector, UsedStateTrace},
+        BlockBuildingSpaceState, BlockSpace,
     },
     primitives::{
         Bundle, Order, OrderId, RefundConfig, ShareBundle, ShareBundleBody, ShareBundleInner,
@@ -19,11 +20,13 @@ use crate::{
 };
 use ahash::HashSet;
 use alloy_consensus::{constants::KECCAK_EMPTY, Transaction};
-use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
 use alloy_evm::Database;
 use alloy_primitives::{Address, B256, I256, U256};
+use alloy_rlp::Encodable;
 use itertools::Itertools;
-use reth::revm::database::StateProviderDatabase;
+use reth::{
+    consensus_common::validation::MAX_RLP_BLOCK_SIZE, revm::database::StateProviderDatabase,
+};
 use reth_errors::ProviderError;
 use reth_evm::{Evm, EvmEnv};
 use reth_primitives::Receipt;
@@ -194,13 +197,19 @@ pub struct TransactionExecutionInfo {
 #[derive(Debug, Clone)]
 pub struct TransactionOk {
     pub exec_result: ExecutionResult,
-    pub cumulative_gas_used: u64,
+    pub cumulative_space_used: BlockSpace,
     pub blob_gas_used: u64,
     pub cumulative_blob_gas_used: u64,
     pub tx_info: TransactionExecutionInfo,
     /// nonces_updates is nonce after tx was applied.
     /// account nonce was 0, tx was included, nonce is 1. => nonce_updated.1 == 1
     pub nonce_updated: (Address, u64),
+}
+
+impl TransactionOk {
+    pub fn space_used(&self) -> BlockSpace {
+        BlockSpace::new(self.tx_info.gas_used, self.tx_info.tx.length_eip7934())
+    }
 }
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
@@ -213,6 +222,8 @@ pub enum TransactionErr {
     GasLeft,
     #[error("Blob Gas left is too low")]
     BlobGasLeft,
+    #[error("Block space (EIP-7934) left is too low")]
+    BlockSpaceLeft,
 }
 
 #[derive(Debug, Clone)]
@@ -220,12 +231,13 @@ pub struct DelayedKickback {
     pub recipient: Address,
     pub payout_value: U256,
     pub payout_tx_fee: U256,
+    pub payout_tx_space_needed: BlockSpace,
 }
 
 #[derive(Debug, Clone)]
 pub struct BundleOk {
-    pub gas_used: u64,
-    pub cumulative_gas_used: u64,
+    pub space_used: BlockSpace,
+    pub cumulative_space_used: BlockSpace,
     pub blob_gas_used: u64,
     pub cumulative_blob_gas_used: u64,
     pub tx_infos: Vec<TransactionExecutionInfo>,
@@ -238,6 +250,17 @@ pub struct BundleOk {
     /// Its original use is for only one level or orders with original_order_id but if nesting happens the parent order original_order_id goes before its children (pre-order DFS)
     /// Fully dropped orders (TxRevertBehavior::AllowedExcluded allows it!) are not included.
     pub original_order_ids: Vec<OrderId>,
+}
+
+impl BundleOk {
+    /// Creates the current space state by adding the reserved block space to the cumulative space used.
+    pub fn space_state(&self, reserved_block_space: BlockSpace) -> BlockBuildingSpaceState {
+        BlockBuildingSpaceState::new(
+            self.cumulative_space_used,
+            reserved_block_space,
+            self.cumulative_blob_gas_used,
+        )
+    }
 }
 
 #[derive(Error, Debug, PartialEq, Eq)]
@@ -289,8 +312,8 @@ pub struct OrderOk {
     /// Profit used for sorting orders on building algorithms.
     /// Real profit for s/bundles (they fail on negative profit) and capped to 0 for txs with negative profit.
     pub coinbase_profit: U256,
-    pub gas_used: u64,
-    pub cumulative_gas_used: u64,
+    pub space_used: BlockSpace,
+    pub cumulative_space_used: BlockSpace,
     pub blob_gas_used: u64,
     pub cumulative_blob_gas_used: u64,
     pub tx_infos: Vec<TransactionExecutionInfo>,
@@ -319,18 +342,14 @@ pub trait PartialBlockForkExecutionTracer {
     fn update_commit_tx_about_to_execute(
         &mut self,
         tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
     );
 
     /// commit_tx parameters redundant with update_commit_tx_about_to_execute but practical....
     fn update_commit_tx_executed(
         &mut self,
         tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
         res: &Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError>,
     );
 }
@@ -339,32 +358,17 @@ impl<T: PartialBlockForkExecutionTracer> PartialBlockForkExecutionTracer for &mu
     fn update_commit_tx_about_to_execute(
         &mut self,
         tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
     ) {
-        (*self).update_commit_tx_about_to_execute(
-            tx_with_blobs,
-            cumulative_gas_used,
-            gas_reserved,
-            cumulative_blob_gas_used,
-        )
+        (*self).update_commit_tx_about_to_execute(tx_with_blobs, space_state)
     }
     fn update_commit_tx_executed(
         &mut self,
         tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
         res: &Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError>,
     ) {
-        (*self).update_commit_tx_executed(
-            tx_with_blobs,
-            cumulative_gas_used,
-            gas_reserved,
-            cumulative_blob_gas_used,
-            res,
-        )
+        (*self).update_commit_tx_executed(tx_with_blobs, space_state, res)
     }
 }
 
@@ -374,18 +378,14 @@ impl PartialBlockForkExecutionTracer for NullPartialBlockForkExecutionTracer {
     fn update_commit_tx_about_to_execute(
         &mut self,
         _tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        _cumulative_gas_used: u64,
-        _gas_reserved: u64,
-        _cumulative_blob_gas_used: u64,
+        _space_state: BlockBuildingSpaceState,
     ) {
     }
     #[inline]
     fn update_commit_tx_executed(
         &mut self,
         _tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        _cumulative_gas_used: u64,
-        _gas_reserved: u64,
-        _cumulative_blob_gas_used: u64,
+        _space_state: BlockBuildingSpaceState,
         _res: &Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError>,
     ) {
     }
@@ -414,7 +414,7 @@ pub struct PartialBlockRollobackPoint {
 
 #[derive(Debug, Clone)]
 pub struct ReservedPayout {
-    pub gas_limit: u64,
+    pub space_limit: BlockSpace,
     pub tx_value: U256,
     pub total_refundable_value: U256,
     pub base_fee: U256,
@@ -523,48 +523,54 @@ impl<
     pub fn commit_tx(
         &mut self,
         tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
     ) -> Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError> {
         self.partial_block_fork_execution_tracer
-            .update_commit_tx_about_to_execute(
-                tx_with_blobs,
-                cumulative_gas_used,
-                gas_reserved,
-                cumulative_blob_gas_used,
-            );
-        let res = self.commit_tx_inner(
-            tx_with_blobs,
-            cumulative_gas_used,
-            gas_reserved,
-            cumulative_blob_gas_used,
-        );
+            .update_commit_tx_about_to_execute(tx_with_blobs, space_state);
+        let res = self.commit_tx_inner(tx_with_blobs, space_state);
         self.partial_block_fork_execution_tracer
-            .update_commit_tx_executed(
-                tx_with_blobs,
-                cumulative_gas_used,
-                gas_reserved,
-                cumulative_blob_gas_used,
-                &res,
-            );
+            .update_commit_tx_executed(tx_with_blobs, space_state, &res);
         res
     }
+
+    /// Checks if the tx can fit in the block by checking:
+    /// - Gas left
+    /// - Blob gas left
+    /// - RLP size limit
+    fn can_fit_tx(
+        &self,
+        space_needed: BlockSpace,
+        blob_gas_needed: u64,
+        space_state: BlockBuildingSpaceState,
+    ) -> Result<(), TransactionErr> {
+        let total_consumed_space = space_state.total_consumed_space();
+        if space_needed.rlp_length() + total_consumed_space.rlp_length() > MAX_RLP_BLOCK_SIZE {
+            return Err(TransactionErr::BlockSpaceLeft);
+        }
+
+        if space_needed.gas() + total_consumed_space.gas() > self.ctx.evm_env.block_env.gas_limit {
+            return Err(TransactionErr::GasLeft);
+        }
+
+        if blob_gas_needed + space_state.blob_gas_used() > self.ctx.max_blob_gas_per_block() {
+            return Err(TransactionErr::BlobGasLeft);
+        }
+        Ok(())
+    }
+
     /// The state is updated ONLY when we return Ok(Ok)
     fn commit_tx_inner(
         &mut self,
         tx_with_blobs: &TransactionSignedEcRecoveredWithBlobs,
-        mut cumulative_gas_used: u64,
-        gas_reserved: u64,
-        mut cumulative_blob_gas_used: u64,
+        mut space_state: BlockBuildingSpaceState,
     ) -> Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError> {
-        let coinbase_balance_before = I256::try_from(self.coinbase_balance()?)?;
-        // Use blobs.len() instead of checking for tx type just in case in the future some other new txs have blobs
-        let blob_gas_used = tx_with_blobs.blobs_len() as u64 * DATA_GAS_PER_BLOB;
-        if cumulative_blob_gas_used + blob_gas_used > self.ctx.max_blob_gas_per_block() {
-            return Ok(Err(TransactionErr::BlobGasLeft));
+        let blob_gas_used = tx_with_blobs.blobs_gas_used();
+        if let Err(err) = self.can_fit_tx(tx_with_blobs.space_needed(), blob_gas_used, space_state)
+        {
+            return Ok(Err(err));
         }
 
+        let coinbase_balance_before = I256::try_from(self.coinbase_balance()?)?;
         let mut db = self.state.new_db_ref(
             &self.ctx.shared_cached_reads,
             &mut self.local_ctx.cached_reads,
@@ -577,21 +583,6 @@ impl<
                 .unwrap_or(false)
         {
             return Ok(Err(TransactionErr::Blocklist));
-        }
-
-        match self
-            .ctx
-            .evm_env
-            .block_env
-            .gas_limit
-            .checked_sub(cumulative_gas_used + gas_reserved)
-        {
-            Some(gas_left) => {
-                if tx.gas_limit() > gas_left {
-                    return Ok(Err(TransactionErr::GasLeft));
-                }
-            }
-            None => return Ok(Err(TransactionErr::GasLeft)),
         }
 
         // evm start
@@ -675,28 +666,30 @@ impl<
         self.rollbacks += 1;
 
         // add gas used by the transaction to cumulative gas used, before creating the receipt
-        let gas_used = res.result.gas_used();
+        let space_used = BlockSpace::new(
+            res.result.gas_used(),
+            tx_with_blobs.internal_tx_unsecure().length(),
+        );
 
-        cumulative_gas_used += gas_used;
-        cumulative_blob_gas_used += blob_gas_used;
+        space_state.use_space(space_used, blob_gas_used);
 
         let success = res.result.is_success();
         let receipt = Receipt {
             tx_type: tx.tx_type(),
             success,
-            cumulative_gas_used,
+            cumulative_gas_used: space_state.gas_used(),
             logs: res.result.logs().to_vec(),
         };
         let coinbase_balance_after = I256::try_from(self.coinbase_balance()?)?;
         Ok(Ok(TransactionOk {
             exec_result: res.result,
             blob_gas_used,
-            cumulative_blob_gas_used,
-            cumulative_gas_used,
+            cumulative_blob_gas_used: space_state.blob_gas_used(),
+            cumulative_space_used: space_state.space_used(),
             tx_info: TransactionExecutionInfo {
                 tx: tx_with_blobs.clone(),
                 receipt,
-                gas_used,
+                gas_used: space_used.gas(),
                 coinbase_profit: coinbase_balance_after - coinbase_balance_before,
             },
             nonce_updated: (tx.signer(), tx.nonce() + 1),
@@ -707,9 +700,7 @@ impl<
     fn commit_bundle(
         &mut self,
         bundle: &Bundle,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
         allow_tx_skip: bool,
         combined_refunds: &HashMap<Address, U256>,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
@@ -739,20 +730,13 @@ impl<
         }
 
         self.execute_with_rollback(|s| {
-            s.commit_bundle_no_rollback(
-                bundle,
-                cumulative_gas_used,
-                gas_reserved,
-                cumulative_blob_gas_used,
-                allow_tx_skip,
-                combined_refunds,
-            )
+            s.commit_bundle_no_rollback(bundle, space_state, allow_tx_skip, combined_refunds)
         })
     }
 
     fn accumulate_tx_execution(transaction_ok: TransactionOk, bundle_ok: &mut BundleOk) {
-        bundle_ok.gas_used += transaction_ok.tx_info.gas_used;
-        bundle_ok.cumulative_gas_used = transaction_ok.cumulative_gas_used;
+        bundle_ok.space_used += transaction_ok.space_used();
+        bundle_ok.cumulative_space_used = transaction_ok.cumulative_space_used;
         bundle_ok.blob_gas_used += transaction_ok.blob_gas_used;
         bundle_ok.cumulative_blob_gas_used = transaction_ok.cumulative_blob_gas_used;
         bundle_ok.tx_infos.push(transaction_ok.tx_info);
@@ -763,16 +747,17 @@ impl<
         &mut self,
         to: Address,
         refundable_value: U256,
-        gas_used: u64,
+        space_used: BlockSpace,
     ) -> Result<ReservedPayout, BundleErr> {
-        let gas_limit =
-            match estimate_payout_gas_limit(to, self.ctx, self.local_ctx, self.state, gas_used) {
-                Ok(gas_limit) => gas_limit,
+        let space_limit =
+            match estimate_payout_gas_limit(to, self.ctx, self.local_ctx, self.state, space_used) {
+                Ok(space_limit) => space_limit,
                 Err(err) => {
                     return Err(BundleErr::EstimatePayoutGas(err));
                 }
             };
-        let base_fee = U256::from(self.ctx.evm_env.block_env.basefee) * U256::from(gas_limit);
+        let base_fee =
+            U256::from(self.ctx.evm_env.block_env.basefee) * U256::from(space_limit.gas());
         if base_fee > refundable_value {
             return Err(BundleErr::NotEnoughRefundForGas {
                 to,
@@ -782,7 +767,7 @@ impl<
         }
         let tx_value = refundable_value - base_fee;
         Ok(ReservedPayout {
-            gas_limit,
+            space_limit,
             tx_value,
             base_fee,
             total_refundable_value: refundable_value,
@@ -795,7 +780,7 @@ impl<
         &mut self,
         payout: ReservedPayout,
         to: Address,
-        gas_reserved: u64,
+        reserved_block_space: BlockSpace,
         insert_result: &mut BundleOk,
     ) -> Result<Result<(), BundleErr>, CriticalCommitOrderError> {
         let builder_signer = if let Some(signer) = self.ctx.builder_signer.as_ref() {
@@ -815,7 +800,7 @@ impl<
             builder_signer,
             nonce,
             to,
-            payout.gas_limit,
+            payout.space_limit.gas(),
             payout.tx_value,
         ) {
             // payout tx has no blobs so it's safe to unwrap
@@ -824,18 +809,13 @@ impl<
                 return Ok(Err(BundleErr::PayoutTx(err)));
             }
         };
-        let res = self.commit_tx(
-            &payout_tx,
-            insert_result.cumulative_gas_used,
-            gas_reserved,
-            insert_result.cumulative_blob_gas_used,
-        )?;
+        let res = self.commit_tx(&payout_tx, insert_result.space_state(reserved_block_space))?;
         match res {
             Ok(res) => {
                 if !res.tx_info.receipt.success {
                     return Ok(Err(BundleErr::FailedToCommitPayoutTx {
                         to,
-                        gas_limit: payout.gas_limit,
+                        gas_limit: payout.space_limit.gas(),
                         value: payout.tx_value,
                         err: None,
                     }));
@@ -846,7 +826,7 @@ impl<
             Err(err) => {
                 return Ok(Err(BundleErr::FailedToCommitPayoutTx {
                     to,
-                    gas_limit: payout.gas_limit,
+                    gas_limit: payout.space_limit.gas(),
                     value: payout.tx_value,
                     err: Some(err),
                 }));
@@ -858,18 +838,16 @@ impl<
     fn commit_bundle_no_rollback(
         &mut self,
         bundle: &Bundle,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
         allow_tx_skip: bool,
         combined_refunds: &HashMap<Address, U256>,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
         let mut refundable_profit = U256::ZERO;
         let mut insert = BundleOk {
-            gas_used: 0,
-            cumulative_gas_used,
+            space_used: BlockSpace::ZERO,
+            cumulative_space_used: space_state.space_used(),
             blob_gas_used: 0,
-            cumulative_blob_gas_used,
+            cumulative_blob_gas_used: space_state.blob_gas_used(),
             tx_infos: Vec::new(),
             nonces_updated: Vec::new(),
             paid_kickbacks: Vec::new(),
@@ -881,9 +859,7 @@ impl<
             let rollback_point = self.rollback_point();
             let result = self.commit_tx(
                 tx_with_blobs,
-                insert.cumulative_gas_used,
-                gas_reserved,
-                insert.cumulative_blob_gas_used,
+                insert.space_state(space_state.reserved_block_space()),
             )?;
             match result {
                 Ok(res) => {
@@ -915,7 +891,7 @@ impl<
                 }
             }
         }
-        if insert.gas_used == 0 {
+        if insert.space_used.gas() == 0 {
             return Ok(Err(BundleErr::EmptyBundle));
         }
 
@@ -935,6 +911,7 @@ impl<
                     recipient: refunds_cfg.recipient,
                     payout_value: refundable_value,
                     payout_tx_fee: U256::ZERO,
+                    payout_tx_space_needed: BlockSpace::ZERO,
                 });
                 break 'refund;
             }
@@ -943,32 +920,30 @@ impl<
             let payout = match self.estimate_refund_payout_tx(
                 refunds_cfg.recipient,
                 refundable_value,
-                insert.cumulative_gas_used,
+                insert.cumulative_space_used,
             ) {
                 Ok(payout) => payout,
                 Err(err) => return Ok(Err(err)),
             };
 
-            let gas_limit = self.ctx.evm_env.block_env.gas_limit;
-            if payout.gas_limit == BASE_TX_GAS
-                && gas_limit
-                    .checked_sub(insert.cumulative_gas_used + gas_reserved)
-                    .is_some_and(|remaining| remaining > payout.gas_limit)
+            let space_state = insert.space_state(space_state.reserved_block_space());
+            if payout.space_limit.gas() == BASE_TX_GAS
+                && self.can_fit_tx(payout.space_limit, 0, space_state).is_ok()
             {
                 // This refund recipient is eligible for a combined refund at the end of the block.
                 insert.delayed_kickback = Some(DelayedKickback {
                     recipient: refunds_cfg.recipient,
                     payout_value: payout.tx_value,
                     payout_tx_fee: payout.base_fee,
+                    payout_tx_space_needed: payout.space_limit,
                 });
                 break 'refund;
             }
-
             // Refund the recipient immediately.
             if let Err(err) = self.insert_refund_payout_tx(
                 payout,
                 refunds_cfg.recipient,
-                gas_reserved,
+                space_state.reserved_block_space(),
                 &mut insert,
             )? {
                 return Ok(Err(err));
@@ -982,9 +957,7 @@ impl<
     fn commit_share_bundle(
         &mut self,
         bundle: &ShareBundle,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
         allow_tx_skip: bool,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
         let current_block = self.ctx.block();
@@ -996,13 +969,7 @@ impl<
             }));
         }
         self.execute_with_rollback(|s| {
-            s.commit_share_bundle_no_rollback(
-                bundle,
-                cumulative_gas_used,
-                gas_reserved,
-                cumulative_blob_gas_used,
-                allow_tx_skip,
-            )
+            s.commit_share_bundle_no_rollback(bundle, space_state, allow_tx_skip)
         })
     }
 
@@ -1010,18 +977,11 @@ impl<
     fn commit_share_bundle_no_rollback(
         &mut self,
         bundle: &ShareBundle,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
         allow_tx_skip: bool,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
-        let res = self.commit_share_bundle_inner(
-            bundle.inner_bundle(),
-            cumulative_gas_used,
-            gas_reserved,
-            cumulative_blob_gas_used,
-            allow_tx_skip,
-        )?;
+        let res =
+            self.commit_share_bundle_inner(bundle.inner_bundle(), space_state, allow_tx_skip)?;
         let res = match res {
             Ok(r) => r,
             Err(e) => {
@@ -1033,7 +993,12 @@ impl<
 
         // now pay all kickbacks
         for (to, payout) in res.payouts_promissed.into_iter().sorted_by_key(|(a, _)| *a) {
-            if let Err(err) = self.insert_refund_payout_tx(payout, to, gas_reserved, &mut insert)? {
+            if let Err(err) = self.insert_refund_payout_tx(
+                payout,
+                to,
+                space_state.reserved_block_space,
+                &mut insert,
+            )? {
                 return Ok(Err(err));
             }
         }
@@ -1044,35 +1009,25 @@ impl<
     fn commit_share_bundle_inner(
         &mut self,
         bundle: &ShareBundleInner,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
         allow_tx_skip: bool,
     ) -> Result<Result<ShareBundleCommitResult, BundleErr>, CriticalCommitOrderError> {
         self.execute_with_rollback(|s| {
-            s.commit_share_bundle_inner_no_rollback(
-                bundle,
-                cumulative_gas_used,
-                gas_reserved,
-                cumulative_blob_gas_used,
-                allow_tx_skip,
-            )
+            s.commit_share_bundle_inner_no_rollback(bundle, space_state, allow_tx_skip)
         })
     }
 
     fn commit_share_bundle_inner_no_rollback(
         &mut self,
         bundle: &ShareBundleInner,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
         allow_tx_skip: bool,
     ) -> Result<Result<ShareBundleCommitResult, BundleErr>, CriticalCommitOrderError> {
         let mut insert = BundleOk {
-            gas_used: 0,
-            cumulative_gas_used,
+            space_used: BlockSpace::ZERO,
+            cumulative_space_used: space_state.space_used(),
             blob_gas_used: 0,
-            cumulative_blob_gas_used,
+            cumulative_blob_gas_used: space_state.blob_gas_used(),
             tx_infos: Vec::new(),
             nonces_updated: Vec::new(),
             paid_kickbacks: Vec::new(),
@@ -1092,12 +1047,8 @@ impl<
                 ShareBundleBody::Tx(sbundle_tx) => {
                     let rollback_point = self.rollback_point();
                     let tx = &sbundle_tx.tx;
-                    let result = self.commit_tx(
-                        tx,
-                        insert.cumulative_gas_used,
-                        gas_reserved,
-                        insert.cumulative_blob_gas_used,
-                    )?;
+                    let result =
+                        self.commit_tx(tx, insert.space_state(space_state.reserved_block_space()))?;
                     match result {
                         Ok(res) => {
                             if !res.tx_info.receipt.success {
@@ -1132,9 +1083,7 @@ impl<
                 ShareBundleBody::Bundle(inner_bundle) => {
                     let inner_res = self.commit_share_bundle_inner(
                         inner_bundle,
-                        insert.cumulative_gas_used,
-                        gas_reserved,
-                        insert.cumulative_blob_gas_used,
+                        insert.space_state(space_state.reserved_block_space()),
                         allow_tx_skip,
                     )?;
                     match inner_res {
@@ -1154,8 +1103,8 @@ impl<
                             insert
                                 .original_order_ids
                                 .extend(res.bundle_ok.original_order_ids);
-                            insert.gas_used += res.bundle_ok.gas_used;
-                            insert.cumulative_gas_used = res.bundle_ok.cumulative_gas_used;
+                            insert.space_used += res.bundle_ok.space_used;
+                            insert.cumulative_space_used = res.bundle_ok.cumulative_space_used;
                             insert.blob_gas_used += res.bundle_ok.blob_gas_used;
                             insert.cumulative_blob_gas_used =
                                 res.bundle_ok.cumulative_blob_gas_used;
@@ -1212,7 +1161,7 @@ impl<
             let payout = match self.estimate_refund_payout_tx(
                 to,
                 refundable_value,
-                insert.cumulative_gas_used,
+                insert.cumulative_space_used,
             ) {
                 Ok(payout) => payout,
                 Err(err) => return Ok(Err(err)),
@@ -1246,41 +1195,25 @@ impl<
     pub fn commit_order(
         &mut self,
         order: &Order,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
         allow_tx_skip: bool,
         combined_refunds: &HashMap<Address, U256>,
     ) -> Result<Result<OrderOk, OrderErr>, CriticalCommitOrderError> {
         self.execute_with_rollback(|s| {
-            s.commit_order_no_rollback(
-                order,
-                cumulative_gas_used,
-                gas_reserved,
-                cumulative_blob_gas_used,
-                allow_tx_skip,
-                combined_refunds,
-            )
+            s.commit_order_no_rollback(order, space_state, allow_tx_skip, combined_refunds)
         })
     }
 
     fn commit_order_no_rollback(
         &mut self,
         order: &Order,
-        cumulative_gas_used: u64,
-        gas_reserved: u64,
-        cumulative_blob_gas_used: u64,
+        space_state: BlockBuildingSpaceState,
         allow_tx_skip: bool,
         combined_refunds: &HashMap<Address, U256>,
     ) -> Result<Result<OrderOk, OrderErr>, CriticalCommitOrderError> {
         match order {
             Order::Tx(tx) => {
-                let res = self.commit_tx(
-                    &tx.tx_with_blobs,
-                    cumulative_gas_used,
-                    gas_reserved,
-                    cumulative_blob_gas_used,
-                )?;
+                let res = self.commit_tx(&tx.tx_with_blobs, space_state)?;
                 match res {
                     Ok(ok) => {
                         let coinbase_profit = if ok.tx_info.coinbase_profit.is_positive() {
@@ -1290,8 +1223,8 @@ impl<
                         };
                         Ok(Ok(OrderOk {
                             coinbase_profit,
-                            gas_used: ok.tx_info.gas_used,
-                            cumulative_gas_used: ok.cumulative_gas_used,
+                            space_used: ok.space_used(),
+                            cumulative_space_used: ok.cumulative_space_used,
                             blob_gas_used: ok.blob_gas_used,
                             cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
                             tx_infos: vec![ok.tx_info],
@@ -1307,25 +1240,13 @@ impl<
             }
             Order::Bundle(bundle) => {
                 let coinbase_balance_before = self.coinbase_balance()?;
-                let res = self.commit_bundle(
-                    bundle,
-                    cumulative_gas_used,
-                    gas_reserved,
-                    cumulative_blob_gas_used,
-                    allow_tx_skip,
-                    combined_refunds,
-                )?;
+                let res =
+                    self.commit_bundle(bundle, space_state, allow_tx_skip, combined_refunds)?;
                 self.bundle_to_order_result(res, coinbase_balance_before)
             }
             Order::ShareBundle(bundle) => {
                 let coinbase_balance_before = self.coinbase_balance()?;
-                let res = self.commit_share_bundle(
-                    bundle,
-                    cumulative_gas_used,
-                    gas_reserved,
-                    cumulative_blob_gas_used,
-                    allow_tx_skip,
-                )?;
+                let res = self.commit_share_bundle(bundle, space_state, allow_tx_skip)?;
                 self.bundle_to_order_result(res, coinbase_balance_before)
             }
         }
@@ -1355,8 +1276,8 @@ impl<
 
                 Ok(Ok(OrderOk {
                     coinbase_profit,
-                    gas_used: ok.gas_used,
-                    cumulative_gas_used: ok.cumulative_gas_used,
+                    space_used: ok.space_used,
+                    cumulative_space_used: ok.cumulative_space_used,
                     blob_gas_used: ok.blob_gas_used,
                     cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
                     tx_infos: ok.tx_infos,

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -20,6 +20,7 @@ use crate::{
 use ahash::HashSet;
 use alloy_consensus::{constants::KECCAK_EMPTY, Transaction};
 use alloy_eips::eip4844::DATA_GAS_PER_BLOB;
+use alloy_evm::Database;
 use alloy_primitives::{Address, B256, I256, U256};
 use itertools::Itertools;
 use reth::revm::database::StateProviderDatabase;
@@ -31,7 +32,7 @@ use revm::{
     context::result::{ExecutionResult, ResultAndState},
     context_interface::result::{EVMError, InvalidTransaction},
     database::{states::bundle_state::BundleRetention, BundleState, State},
-    Database, DatabaseCommit,
+    Database as _, DatabaseCommit,
 };
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
@@ -559,7 +560,7 @@ impl<
     ) -> Result<Result<TransactionOk, TransactionErr>, CriticalCommitOrderError> {
         let coinbase_balance_before = I256::try_from(self.coinbase_balance()?)?;
         // Use blobs.len() instead of checking for tx type just in case in the future some other new txs have blobs
-        let blob_gas_used = tx_with_blobs.blobs_sidecar.blobs.len() as u64 * DATA_GAS_PER_BLOB;
+        let blob_gas_used = tx_with_blobs.blobs_len() as u64 * DATA_GAS_PER_BLOB;
         if cumulative_blob_gas_used + blob_gas_used > self.ctx.max_blob_gas_per_block() {
             return Ok(Err(TransactionErr::BlobGasLeft));
         }
@@ -712,7 +713,7 @@ impl<
         allow_tx_skip: bool,
         combined_refunds: &HashMap<Address, U256>,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
-        let current_block = self.ctx.evm_env.block_env.number;
+        let current_block = self.ctx.block();
         // None is good for any block
         if let Some(block) = bundle.block {
             if block != current_block {
@@ -727,7 +728,7 @@ impl<
         let (min_ts, max_ts, block_ts) = (
             bundle.min_timestamp.unwrap_or(0),
             bundle.max_timestamp.unwrap_or(u64::MAX),
-            self.ctx.evm_env.block_env.timestamp,
+            self.ctx.timestamp_u64(),
         );
         if !(min_ts <= block_ts && block_ts <= max_ts) {
             return Ok(Err(BundleErr::IncorrectTimestamp {
@@ -986,7 +987,7 @@ impl<
         cumulative_blob_gas_used: u64,
         allow_tx_skip: bool,
     ) -> Result<Result<BundleOk, BundleErr>, CriticalCommitOrderError> {
-        let current_block = self.ctx.evm_env.block_env.number;
+        let current_block = self.ctx.block();
         if !(bundle.block <= current_block && current_block <= bundle.max_block) {
             return Ok(Err(BundleErr::TargetBlockIncorrect {
                 block: current_block,

--- a/crates/rbuilder/src/building/payout_tx.rs
+++ b/crates/rbuilder/src/building/payout_tx.rs
@@ -1,7 +1,11 @@
 use super::{evm::EvmFactory, BlockBuildingContext, BlockState, ThreadBlockBuildingContext};
-use crate::utils::Signer;
+use crate::{
+    building::BlockSpace,
+    utils::{constants::BASE_TX_GAS, Signer},
+};
 use alloy_consensus::{constants::KECCAK_EMPTY, TxEip1559};
 use alloy_primitives::{Address, TxKind as TransactionKind, U256};
+use alloy_rlp::Encodable as _;
 use reth_chainspec::ChainSpec;
 use reth_errors::ProviderError;
 use reth_evm::Evm;
@@ -82,7 +86,6 @@ pub fn insert_test_payout_tx(
         gas_limit,
         U256::from(tx_value),
     )?;
-
     let mut db = state.new_db_ref(&ctx.shared_cached_reads, &mut local_ctx.cached_reads);
     let mut evm = ctx.evm_factory.create_evm(db.as_mut(), ctx.evm_env.clone());
 
@@ -126,29 +129,57 @@ impl PartialEq for EstimatePayoutGasErr {
 
 impl Eq for EstimatePayoutGasErr {}
 
+fn estimate_payout_tx_space(ctx: &BlockBuildingContext) -> Result<BlockSpace, secp256k1::Error> {
+    let res = if let Some(builder_signer) = &ctx.builder_signer {
+        let tx = create_payout_tx(
+            ctx.chain_spec.as_ref(),
+            ctx.evm_env.block_env.basefee,
+            builder_signer,
+            0,
+            Address::ZERO,
+            ctx.evm_env.block_env.gas_limit,
+            U256::ZERO,
+        )?;
+        BlockSpace::new(
+            BASE_TX_GAS,
+            tx.inner().length() + 32 * 4, /* To account for any possible length encoding on ZERO fields */
+        )
+    } else {
+        BlockSpace::ZERO
+    };
+    Ok(res)
+}
+
 pub fn estimate_payout_gas_limit(
     to: Address,
     ctx: &BlockBuildingContext,
     local_ctx: &mut ThreadBlockBuildingContext,
     state: &mut BlockState,
-    gas_used: u64,
-) -> Result<u64, EstimatePayoutGasErr> {
+    space_used: BlockSpace,
+) -> Result<BlockSpace, EstimatePayoutGasErr> {
     tracing::trace!(address = ?to, "Estimating payout gas");
+    // To simplify we compute the default payout tx rlp_length only once here. It's not worth computing the exact rlp_length for each estimation.
+    let default_payout_tx_space =
+        estimate_payout_tx_space(ctx).map_err(|_| EstimatePayoutGasErr::FailedToEstimate)?;
     if state.code_hash(to, &ctx.shared_cached_reads, &mut local_ctx.cached_reads)? == KECCAK_EMPTY {
-        return Ok(21_000);
+        return Ok(default_payout_tx_space);
     }
 
+    // We probably have a bug here since no reserved space was propagated but with a little bit of luck it will work because we call can_fit_tx later?
     let gas_left = ctx
         .evm_env
         .block_env
         .gas_limit
-        .checked_sub(gas_used)
+        .checked_sub(space_used.gas())
         .unwrap_or_default();
     let estimation = insert_test_payout_tx(to, ctx, local_ctx, state, gas_left)?
         .ok_or(EstimatePayoutGasErr::FailedToEstimate)?;
 
     if insert_test_payout_tx(to, ctx, local_ctx, state, estimation)?.is_some() {
-        return Ok(estimation);
+        return Ok(BlockSpace::new(
+            estimation,
+            default_payout_tx_space.rlp_length(),
+        ));
     }
 
     let mut left = estimation;
@@ -158,7 +189,7 @@ pub fn estimate_payout_gas_limit(
     loop {
         let mid = (left + right) / 2;
         if mid == left || mid == right {
-            return Ok(right);
+            return Ok(BlockSpace::new(right, default_payout_tx_space.rlp_length()));
         }
 
         if insert_test_payout_tx(to, ctx, local_ctx, state, mid)?.is_some() {
@@ -229,8 +260,8 @@ mod tests {
         let mut local_ctx = ThreadBlockBuildingContext::default();
 
         let estimate_result =
-            estimate_payout_gas_limit(proposer, &ctx, &mut local_ctx, &mut state, 0);
+            estimate_payout_gas_limit(proposer, &ctx, &mut local_ctx, &mut state, BlockSpace::ZERO);
         assert_matches!(estimate_result, Ok(_));
-        assert_eq!(estimate_result.unwrap(), 21_000);
+        assert_eq!(estimate_result.unwrap().gas(), 21_000);
     }
 }

--- a/crates/rbuilder/src/building/sim.rs
+++ b/crates/rbuilder/src/building/sim.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{
     building::{
-        BlockBuildingContext, BlockState, CriticalCommitOrderError,
+        BlockBuildingContext, BlockBuildingSpaceState, BlockState, CriticalCommitOrderError,
         NullPartialBlockForkExecutionTracer,
     },
     live_builder::order_input::mempool_txs_detector::MempoolTxsDetector,
@@ -28,6 +28,7 @@ use std::{
 use tracing::{error, trace};
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum OrderSimResult {
     Success(SimulatedOrder, Vec<(Address, u64)>),
     Failed(OrderErr),
@@ -440,18 +441,15 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
 ) -> Result<OrderSimResult, CriticalCommitOrderError> {
     let start = Instant::now();
     // simulate parents
-    let mut gas_used = 0;
-    let mut blob_gas_used = 0;
+    let mut space_state = BlockBuildingSpaceState::ZERO;
     // We use empty combined refunds because the value of the bundle will
     // not change from batching.
     let combined_refunds = std::collections::HashMap::default();
     for parent in parent_orders {
-        let result =
-            fork.commit_order(&parent, gas_used, 0, blob_gas_used, true, &combined_refunds)?;
+        let result = fork.commit_order(&parent, space_state, true, &combined_refunds)?;
         match result {
             Ok(res) => {
-                gas_used += res.gas_used;
-                blob_gas_used += res.blob_gas_used;
+                space_state.use_space(res.space_used, res.blob_gas_used);
             }
             Err(err) => {
                 tracing::trace!(parent_order = ?parent.id(), ?err, "failed to simulate parent order");
@@ -461,7 +459,7 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
     }
 
     // simulate
-    let result = fork.commit_order(&order, gas_used, 0, blob_gas_used, true, &combined_refunds)?;
+    let result = fork.commit_order(&order, space_state, true, &combined_refunds)?;
     let sim_time = start.elapsed();
     add_order_simulation_time(sim_time, "sim", result.is_ok()); // we count parent sim time + order sim time time here
 

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -797,7 +797,7 @@ fn bundle_revert_modes_tests(share_bundle: bool) -> eyre::Result<()> {
     // Bundles behave different to sbundles on empty execution
     if share_bundle {
         let res = test_setup.commit_order_ok();
-        assert_eq!(res.gas_used, 0);
+        assert_eq!(res.space_used.gas(), 0);
     } else {
         test_setup.commit_order_err_check(|err| {
             assert!(matches!(err, OrderErr::Bundle(BundleErr::EmptyBundle)));
@@ -808,27 +808,27 @@ fn bundle_revert_modes_tests(share_bundle: bool) -> eyre::Result<()> {
     begin_bundle(&mut test_setup);
     test_setup.add_revert(tx_sender0, TxRevertBehavior::AllowedIncluded)?;
     let res = test_setup.commit_order_ok();
-    let reverting_gas = res.gas_used;
+    let reverting_gas = res.space_used.gas();
 
     // Measure reverting tx
     begin_bundle(&mut test_setup);
     test_setup.add_send_to_coinbase_tx(tx_sender0, 0)?;
     let res = test_setup.commit_order_ok();
-    let send_gas = res.gas_used;
+    let send_gas = res.space_used.gas();
 
     // send + rev on AllowedIncluded pay both gases
     begin_bundle(&mut test_setup);
     test_setup.add_send_to_coinbase_tx(tx_sender1, 0)?;
     test_setup.add_revert(tx_sender0, TxRevertBehavior::AllowedIncluded)?;
     let res = test_setup.commit_order_ok();
-    assert_eq!(res.gas_used, send_gas + reverting_gas);
+    assert_eq!(res.space_used.gas(), send_gas + reverting_gas);
 
     // send + rev on AllowedExcluded pay send
     begin_bundle(&mut test_setup);
     test_setup.add_send_to_coinbase_tx(tx_sender0, 0)?;
     test_setup.add_revert(tx_sender1, TxRevertBehavior::AllowedExcluded)?;
     let res = test_setup.commit_order_ok();
-    assert_eq!(res.gas_used, send_gas);
+    assert_eq!(res.space_used.gas(), send_gas);
 
     Ok(())
 }

--- a/crates/rbuilder/src/integration/playground.rs
+++ b/crates/rbuilder/src/integration/playground.rs
@@ -56,10 +56,7 @@ impl Playground {
             .map_err(|_| PlaygroundError::SetupError)?;
 
         let mut log_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        log_path.push(format!(
-            "../../integration_logs/{}_{}.log",
-            format_str, name,
-        ));
+        log_path.push(format!("../../integration_logs/{format_str}_{name}.log"));
 
         let log = open_log_file(log_path.clone()).map_err(|_| PlaygroundError::SetupError)?;
         let stdout = log.try_clone().map_err(|_| PlaygroundError::SetupError)?;

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -107,10 +107,9 @@ where
                 block_ctx.mempool_tx_detector.clone(),
             );
         // sink removal is automatic via OrderSink::is_alive false
-        let _block_sub = self.orderpool_subscriber.add_sink(
-            block_ctx.evm_env.block_env.number,
-            Box::new(mempool_txs_detector_sniffer),
-        );
+        let _block_sub = self
+            .orderpool_subscriber
+            .add_sink(block_ctx.block(), Box::new(mempool_txs_detector_sniffer));
 
         let simulations_for_block = self.order_simulation_pool.spawn_simulation_job(
             block_ctx.clone(),
@@ -137,7 +136,7 @@ where
         let (broadcast_input, _) = broadcast::channel(10_000);
         let muxer = Arc::new(UnfinishedBlockBuildingSinkMuxer::new(builder_sink));
 
-        let block_number = ctx.evm_env.block_env.number;
+        let block_number = ctx.block();
 
         for builder in self.builders.iter() {
             let builder_name = builder.name();

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -8,11 +8,15 @@ use crate::{
         multi_share_bundle_merger::MultiShareBundleMerger,
         simulated_order_command_to_sink, BlockBuildingContext, SimulatedOrderSink,
     },
-    live_builder::{payload_events::MevBoostSlotData, simulation::SlotOrderSimResults},
+    live_builder::{
+        order_input::replaceable_order_sink::ReplaceableOrderSink,
+        payload_events::MevBoostSlotData, simulation::SlotOrderSimResults,
+    },
     primitives::{OrderId, SimulatedOrder},
     provider::StateProviderFactory,
 };
 use alloy_primitives::Address;
+use reth_chainspec::EthereumHardforks as _;
 use std::{cell::RefCell, rc::Rc, sync::Arc, thread, time::Duration};
 use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
@@ -66,7 +70,10 @@ where
         }
     }
 
-    /// Connects OrdersForBlock->OrderReplacementManager->Simulations and calls start_building_job
+    /// Connects OrdersForBlock (source of orders) ->
+    /// ReplaceableOrderStreamSniffer (notifies mempool txs to MempoolTxsDetector) ->
+    /// BlobTypeOrderFilter (filters out Orders with incorrect blobs (pre/post fusaka)) ->
+    /// OrderReplacementManager (Handles cancellations and replacements) -> Simulations and calls start_building_job
     pub fn start_block_building(
         &mut self,
         payload: payload_events::MevBoostSlotData,
@@ -101,9 +108,22 @@ where
         // add OrderReplacementManager to manage replacements and cancellations
         let order_replacement_manager = OrderReplacementManager::new(Box::new(sink));
 
+        let blob_type_order_filter: Box<dyn ReplaceableOrderSink> = if block_ctx
+            .chain_spec
+            .is_osaka_active_at_timestamp(block_ctx.attributes.timestamp)
+        {
+            Box::new(order_input::blob_type_order_filter::new_fusaka(Box::new(
+                order_replacement_manager,
+            )))
+        } else {
+            Box::new(order_input::blob_type_order_filter::new_pre_fusaka(
+                Box::new(order_replacement_manager),
+            ))
+        };
+
         let mempool_txs_detector_sniffer =
             order_input::mempool_txs_detector::ReplaceableOrderStreamSniffer::new(
-                Box::new(order_replacement_manager),
+                blob_type_order_filter,
                 block_ctx.mempool_tx_detector.clone(),
             );
         // sink removal is automatic via OrderSink::is_alive false

--- a/crates/rbuilder/src/live_builder/building/unfinished_block_building_sink_muxer.rs
+++ b/crates/rbuilder/src/live_builder/building/unfinished_block_building_sink_muxer.rs
@@ -135,7 +135,7 @@ mod tests {
                 .push(ExecutionResult {
                     coinbase_profit: Default::default(),
                     inplace_sim: Default::default(),
-                    gas_used: Default::default(),
+                    space_used: Default::default(),
                     order: Order::Tx(order),
                     tx_infos: vec![TransactionExecutionInfo {
                         tx,

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -91,7 +91,7 @@ where
         Cli::Run(cli) => cli,
         Cli::Config(cli) => {
             let config: ConfigType = load_config_toml_and_env(cli.config)?;
-            println!("{:#?}", config);
+            println!("{config:#?}");
             return Ok(());
         }
         Cli::Version => {
@@ -108,7 +108,7 @@ where
         }
         Cli::GenBls => {
             let address = generate_random_bls_address();
-            println!("0x{}", address);
+            println!("0x{address}");
             return Ok(());
         }
     };

--- a/crates/rbuilder/src/live_builder/order_input/blob_type_order_filter.rs
+++ b/crates/rbuilder/src/live_builder/order_input/blob_type_order_filter.rs
@@ -1,0 +1,75 @@
+use alloy_eips::eip7594::BlobTransactionSidecarVariant;
+
+use crate::{
+    live_builder::order_input::replaceable_order_sink::ReplaceableOrderSink,
+    primitives::{BundleReplacementData, Order, ShareBundleReplacementKey},
+};
+
+/// Filters out Orders with incorrect blobs (pre/post fusaka).
+/// Since it's very unlikely what we have many wrong blobs we only filter on insert_order without take note of filtered orders.
+/// If remove_bundle/remove_sbundle is called we just forward the call to the sink so it might try to remove a filtered order.
+pub struct BlobTypeOrderFilter<FilterFunc> {
+    sink: Box<dyn ReplaceableOrderSink>,
+    ///true if it likes the blob sidecar, false if it doesn't (Order gets filtered).
+    filter_func: FilterFunc,
+}
+
+impl<FilterFunc> std::fmt::Debug for BlobTypeOrderFilter<FilterFunc> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlobTypeOrderFilter")
+            .field("sink", &"<dyn ReplaceableOrderSink>")
+            .finish()
+    }
+}
+
+/// Filters out EIP-7594 style blobs, supports only EIP-4844 style.
+pub fn new_pre_fusaka(
+    sink: Box<dyn ReplaceableOrderSink>,
+) -> BlobTypeOrderFilter<impl Fn(&BlobTransactionSidecarVariant) -> bool + Send + Sync> {
+    BlobTypeOrderFilter::new(sink, |blob| {
+        matches!(blob, BlobTransactionSidecarVariant::Eip4844(_))
+    })
+}
+
+/// Filters out EIP-4844 style, supports only EIP-7594 style blobs.
+pub fn new_fusaka(
+    sink: Box<dyn ReplaceableOrderSink>,
+) -> BlobTypeOrderFilter<impl Fn(&BlobTransactionSidecarVariant) -> bool + Send + Sync> {
+    BlobTypeOrderFilter::new(sink, |blob| {
+        matches!(blob, BlobTransactionSidecarVariant::Eip7594(_))
+    })
+}
+
+impl<FilterFunc: Fn(&BlobTransactionSidecarVariant) -> bool> BlobTypeOrderFilter<FilterFunc> {
+    fn new(sink: Box<dyn ReplaceableOrderSink>, filter_func: FilterFunc) -> Self {
+        Self { sink, filter_func }
+    }
+}
+
+impl<FilterFunc: Fn(&BlobTransactionSidecarVariant) -> bool + Send + Sync> ReplaceableOrderSink
+    for BlobTypeOrderFilter<FilterFunc>
+{
+    fn insert_order(&mut self, order: Order) -> bool {
+        if order
+            .list_txs()
+            .iter()
+            .all(|(tx, _)| (self.filter_func)(tx.blobs_sidecar.as_ref()))
+        {
+            self.sink.insert_order(order)
+        } else {
+            true
+        }
+    }
+
+    fn remove_bundle(&mut self, replacement_data: BundleReplacementData) -> bool {
+        self.sink.remove_bundle(replacement_data)
+    }
+
+    fn remove_sbundle(&mut self, key: ShareBundleReplacementKey) -> bool {
+        self.sink.remove_sbundle(key)
+    }
+
+    fn is_alive(&self) -> bool {
+        self.sink.is_alive()
+    }
+}

--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -1,5 +1,6 @@
 //! order_input handles receiving new orders from the ipc mempool subscription and json rpc server
 //!
+pub mod blob_type_order_filter;
 pub mod mempool_txs_detector;
 pub mod order_replacement_manager;
 pub mod order_sink;

--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -177,6 +177,7 @@ impl OrderInputConfig {
 /// Commands we can get from RPC or mempool fetcher.
 #[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
+#[allow(clippy::large_enum_variant)]
 pub enum ReplaceableOrderPoolCommand {
     /// New or update order
     Order(Order),

--- a/crates/rbuilder/src/live_builder/order_input/order_sink.rs
+++ b/crates/rbuilder/src/live_builder/order_input/order_sink.rs
@@ -51,6 +51,7 @@ impl Drop for OrderPrinter {
 ///////////////////////
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum OrderPoolCommand {
     //OrderSink::insert_order
     Insert(Order),

--- a/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
+++ b/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
@@ -183,7 +183,7 @@ mod test {
         .unwrap();
 
         assert_eq!(tx_with_blobs.hash(), *pending_tx.tx_hash());
-        assert_eq!(tx_with_blobs.blobs_sidecar.blobs.len(), 1);
+        assert_eq!(tx_with_blobs.blobs_len(), 1);
 
         // send another tx without blobs
         let tx = TransactionRequest::default()
@@ -205,6 +205,6 @@ mod test {
         .unwrap();
 
         assert_eq!(tx_without_blobs.hash(), *pending_tx.tx_hash());
-        assert_eq!(tx_without_blobs.blobs_sidecar.blobs.len(), 0);
+        assert_eq!(tx_without_blobs.blobs_len(), 0);
     }
 }

--- a/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
@@ -172,8 +172,8 @@ fn resolve_relay_slot_data(
     let (latest_slot_data, mut selected_registrations) = registrations_by_slot_data
         .iter()
         .max_by_key(|(_, v)| {
-            v.iter()
-                .map(|(_, r)| r.entry.message.timestamp)
+            v.values()
+                .map(|r| r.entry.message.timestamp)
                 .max()
                 .unwrap_or_default()
         })

--- a/crates/rbuilder/src/live_builder/simulation/mod.rs
+++ b/crates/rbuilder/src/live_builder/simulation/mod.rs
@@ -130,7 +130,7 @@ where
         let provider = self.provider.clone();
         let current_contexts = Arc::clone(&self.current_contexts);
         let block_context: BlockContextId = gen_uid();
-        let span = info_span!("sim_ctx", block = ctx.evm_env.block_env.number, parent = ?ctx.attributes.parent);
+        let span = info_span!("sim_ctx", block = ctx.block(), parent = ?ctx.attributes.parent);
 
         let handle = tokio::spawn(
             async move {

--- a/crates/rbuilder/src/live_builder/simulation/mod.rs
+++ b/crates/rbuilder/src/live_builder/simulation/mod.rs
@@ -92,7 +92,7 @@ where
             let provider = result.provider.clone();
             let cancel = global_cancellation.clone();
             let handle = std::thread::Builder::new()
-                .name(format!("sim_thread:{}", i))
+                .name(format!("sim_thread:{i}"))
                 .spawn(move || {
                     sim_worker::run_sim_worker(i, ctx, provider, cancel);
                 })

--- a/crates/rbuilder/src/mev_boost/bloxroute_grpc.rs
+++ b/crates/rbuilder/src/mev_boost/bloxroute_grpc.rs
@@ -1,3 +1,5 @@
+use crate::mev_boost::submission::FuluSubmitBlockRequest;
+
 use super::submission::{
     CapellaSubmitBlockRequest, DenebSubmitBlockRequest, ElectraSubmitBlockRequest,
     SubmitBlockRequest,
@@ -7,7 +9,10 @@ use alloy_eips::{
     eip7251::ConsolidationRequest,
 };
 use alloy_rpc_types_beacon::{
-    relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
+    relay::{
+        BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4,
+        SignedBidSubmissionV5,
+    },
     requests::ExecutionRequestsV4,
 };
 use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
@@ -30,6 +35,8 @@ pub enum DataVersion {
     Deneb = 5,
     /// Electra CL hardfork.
     Electra = 6,
+    /// Fulu CL hardfork.
+    Fulu = 7,
 }
 
 /// gRPC relay client type.
@@ -95,7 +102,7 @@ impl From<&SubmitBlockRequest> for types::SubmitBlockRequest {
                     execution_payload,
                     bid_trace,
                     signature,
-                    Some(blobs_bundle),
+                    Some(types::BlobsBundle::from(blobs_bundle)),
                     None,
                     adjustment_data,
                 )
@@ -125,13 +132,42 @@ impl From<&SubmitBlockRequest> for types::SubmitBlockRequest {
                     execution_payload,
                     bid_trace,
                     signature,
-                    Some(blobs_bundle),
+                    Some(types::BlobsBundle::from(blobs_bundle)),
+                    Some(execution_requests),
+                    adjustment_data,
+                )
+            }
+            SubmitBlockRequest::Fulu(request) => {
+                let FuluSubmitBlockRequest {
+                    submission:
+                        SignedBidSubmissionV5 {
+                            execution_payload,
+                            message,
+                            signature,
+                            blobs_bundle,
+                            execution_requests,
+                        },
+                    adjustment_data,
+                } = request;
+
+                let version = DataVersion::Electra;
+                let execution_payload = types::ExecutionPayload::from_v3(execution_payload);
+                let bid_trace = types::BidTrace::new(
+                    message,
+                    Some(execution_payload.blob_gas_used),
+                    Some(execution_payload.excess_blob_gas),
+                );
+                (
+                    version,
+                    execution_payload,
+                    bid_trace,
+                    signature,
+                    Some(types::BlobsBundle::from(blobs_bundle)),
                     Some(execution_requests),
                     adjustment_data,
                 )
             }
         };
-        let blobs_bundle = blobs_bundle.map(types::BlobsBundle::from);
         let execution_requests = execution_requests.map(types::ExecutionRequests::from);
         let adjustment_data = adjustment_data
             .as_ref()
@@ -270,6 +306,16 @@ impl types::BidTrace {
 
 impl From<&alloy_rpc_types_engine::BlobsBundleV1> for types::BlobsBundle {
     fn from(value: &alloy_rpc_types_engine::BlobsBundleV1) -> Self {
+        Self {
+            commitments: value.commitments.iter().map(|c| c.0.to_vec()).collect(),
+            proofs: value.proofs.iter().map(|p| p.0.to_vec()).collect(),
+            blobs: value.blobs.iter().map(|b| b.0.to_vec()).collect(),
+        }
+    }
+}
+
+impl From<&alloy_rpc_types_engine::BlobsBundleV2> for types::BlobsBundle {
+    fn from(value: &alloy_rpc_types_engine::BlobsBundleV2) -> Self {
         Self {
             commitments: value.commitments.iter().map(|c| c.0.to_vec()).collect(),
             proofs: value.proofs.iter().map(|p| p.0.to_vec()).collect(),

--- a/crates/rbuilder/src/mev_boost/error.rs
+++ b/crates/rbuilder/src/mev_boost/error.rs
@@ -31,7 +31,7 @@ pub enum RelayError {
 
 impl Debug for RelayError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -400,7 +400,7 @@ pub enum SubmitBlockErr {
 
 impl std::fmt::Debug for SubmitBlockErr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 
@@ -437,7 +437,7 @@ impl RelayClient {
         &self,
         slot: u64,
     ) -> Result<Option<ProposerPayloadDelivered>, RelayError> {
-        self.get_one_delivered_payload(&format!("slot={}", slot))
+        self.get_one_delivered_payload(&format!("slot={slot}"))
             .await
     }
 
@@ -445,7 +445,7 @@ impl RelayClient {
         &self,
         block_number: u64,
     ) -> Result<Option<ProposerPayloadDelivered>, RelayError> {
-        self.get_one_delivered_payload(&format!("block_number={}", block_number))
+        self.get_one_delivered_payload(&format!("block_number={block_number}"))
             .await
     }
 
@@ -453,7 +453,7 @@ impl RelayClient {
         &self,
         block_hash: BlockHash,
     ) -> Result<Option<ProposerPayloadDelivered>, RelayError> {
-        self.get_one_delivered_payload(&format!("block_hash={:?}", block_hash))
+        self.get_one_delivered_payload(&format!("block_hash={block_hash:?}"))
             .await
     }
 
@@ -488,7 +488,7 @@ impl RelayClient {
         &self,
         block_hash: BlockHash,
     ) -> Result<Option<BuilderBlockReceived>, RelayError> {
-        self.get_one_builder_block_received(&format!("block_hash={:?}", block_hash))
+        self.get_one_builder_block_received(&format!("block_hash={block_hash:?}"))
             .await
     }
 
@@ -499,7 +499,7 @@ impl RelayClient {
         let url = {
             let mut url = self.url.clone();
             url.set_path("/relay/v1/data/validator_registration");
-            url.set_query(Some(&format!("pubkey={:?}", pubkey)));
+            url.set_query(Some(&format!("pubkey={pubkey:?}")));
             url
         };
 
@@ -674,7 +674,7 @@ impl RelayClient {
                 let mut bundle_ids = bundle_ids
                     .iter()
                     .take(MAX_BUNDLE_IDS)
-                    .map(|uuid| format!("{:?}", uuid));
+                    .map(|uuid| format!("{uuid:?}"));
                 let bundle_ids = if total_bundles > MAX_BUNDLE_IDS {
                     bundle_ids.join(",") + ",CAPPED"
                 } else {

--- a/crates/rbuilder/src/mev_boost/sign_payload.rs
+++ b/crates/rbuilder/src/mev_boost/sign_payload.rs
@@ -1,18 +1,21 @@
 use super::submission::{
     CapellaSubmitBlockRequest, DenebSubmitBlockRequest, ElectraSubmitBlockRequest,
-    SubmitBlockRequest,
+    FuluSubmitBlockRequest, SubmitBlockRequest,
 };
 use crate::utils::u256decimal_serde_helper;
-use alloy_eips::{eip2718::Encodable2718, eip4844::BlobTransactionSidecar, eip7685::Requests};
+use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant};
+use alloy_eips::eip7685::Requests;
+use alloy_eips::{eip2718::Encodable2718, eip4844::BlobTransactionSidecar};
 use alloy_primitives::{Address, BlockHash, Bytes, FixedBytes, B256, U256};
+use alloy_rpc_types_beacon::relay::SignedBidSubmissionV5;
+use alloy_rpc_types_beacon::requests::ExecutionRequestsV4;
 use alloy_rpc_types_beacon::{
     events::PayloadAttributesData,
     relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
-    requests::ExecutionRequestsV4,
     BlsPublicKey,
 };
 use alloy_rpc_types_engine::{
-    BlobsBundleV1, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
+    BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
 };
 use alloy_rpc_types_eth::Withdrawal;
 use ethereum_consensus::{
@@ -119,7 +122,7 @@ fn a2e_address(a: &Address) -> ExecutionAddress {
 pub fn sign_block_for_relay(
     signer: &BLSBlockSigner,
     sealed_block: &SealedBlock,
-    blobs_bundle: &[Arc<BlobTransactionSidecar>],
+    blobs_bundle: &[Arc<BlobTransactionSidecarVariant>],
     execution_requests: &[Bytes], // The Pectra execution requests for this bid.
     chain_spec: &ChainSpec,
     attrs: &PayloadAttributesData,
@@ -198,10 +201,24 @@ pub fn sign_block_for_relay(
                 .expect("deneb block does not have excess blob gas"),
         };
 
-        let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
         let execution_requests =
             ExecutionRequestsV4::try_from(Requests::new(execution_requests.to_vec()))?;
-        if chain_spec.is_prague_active_at_timestamp(sealed_block.timestamp) {
+
+        if chain_spec.is_osaka_active_at_timestamp(sealed_block.timestamp) {
+            let blobs_bundle_v2 = marshall_txs_blobs_sidecars_v2(blobs_bundle);
+
+            let submission = SignedBidSubmissionV5 {
+                message,
+                execution_payload,
+                blobs_bundle: blobs_bundle_v2,
+                signature,
+                execution_requests,
+            };
+
+            SubmitBlockRequest::fulu(FuluSubmitBlockRequest::new(submission, adjustment_data))
+        } else if chain_spec.is_prague_active_at_timestamp(sealed_block.timestamp) {
+            let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
+
             let submission = SignedBidSubmissionV4 {
                 message,
                 execution_payload,
@@ -211,6 +228,8 @@ pub fn sign_block_for_relay(
             };
             SubmitBlockRequest::electra(ElectraSubmitBlockRequest::new(submission, adjustment_data))
         } else {
+            let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
+
             let submission = SignedBidSubmissionV3 {
                 message,
                 execution_payload,
@@ -231,23 +250,67 @@ pub fn sign_block_for_relay(
     Ok(request)
 }
 
-fn flatten_marshal<Source>(
-    txs_blobs_sidecars: &[Arc<BlobTransactionSidecar>],
-    vec_getter: impl Fn(&Arc<BlobTransactionSidecar>) -> Vec<Source>,
-) -> Vec<Source> {
-    let flatten_data = txs_blobs_sidecars.iter().flat_map(vec_getter);
-    flatten_data.collect::<Vec<Source>>()
-}
+fn marshal_txs_blobs_sidecars(
+    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarVariant>],
+) -> BlobsBundleV1 {
+    // Instead of collecting Arc<BlobTransactionSidecar>, just collect references to the inner struct.
+    let eip4844_sidecars: Vec<&BlobTransactionSidecar> = txs_blobs_sidecars
+        .iter()
+        .filter_map(|blob| blob.as_ref().as_eip4844())
+        .collect();
 
-fn marshal_txs_blobs_sidecars(txs_blobs_sidecars: &[Arc<BlobTransactionSidecar>]) -> BlobsBundleV1 {
-    let rpc_commitments = flatten_marshal(txs_blobs_sidecars, |t| t.commitments.clone());
-    let rpc_proofs = flatten_marshal(txs_blobs_sidecars, |t| t.proofs.clone());
-    let rpc_blobs = flatten_marshal(txs_blobs_sidecars, |t| t.blobs.clone());
+    // Now flatten the fields, only cloning the inner data, not the whole struct or Arc.
+    let commitments = eip4844_sidecars
+        .iter()
+        .flat_map(|t| t.commitments.iter().cloned())
+        .collect();
+
+    let proofs = eip4844_sidecars
+        .iter()
+        .flat_map(|t| t.proofs.iter().cloned())
+        .collect();
+
+    let blobs = eip4844_sidecars
+        .iter()
+        .flat_map(|t| t.blobs.iter().cloned())
+        .collect();
 
     BlobsBundleV1 {
-        commitments: rpc_commitments,
-        proofs: rpc_proofs,
-        blobs: rpc_blobs,
+        commitments,
+        proofs,
+        blobs,
+    }
+}
+
+fn marshall_txs_blobs_sidecars_v2(
+    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarVariant>],
+) -> BlobsBundleV2 {
+    // Instead of collecting Arc<BlobTransactionSidecarEip7594>, just collect references to the inner struct.
+    let eip7594_sidecars: Vec<&BlobTransactionSidecarEip7594> = txs_blobs_sidecars
+        .iter()
+        .filter_map(|blob| blob.as_ref().as_eip7594())
+        .collect();
+
+    // Now flatten the fields, only cloning the inner data, not the whole struct or Arc.
+    let commitments = eip7594_sidecars
+        .iter()
+        .flat_map(|t| t.commitments.iter().cloned())
+        .collect();
+
+    let proofs = eip7594_sidecars
+        .iter()
+        .flat_map(|t| t.cell_proofs.iter().cloned())
+        .collect();
+
+    let blobs = eip7594_sidecars
+        .iter()
+        .flat_map(|t| t.blobs.iter().cloned())
+        .collect();
+
+    BlobsBundleV2 {
+        commitments,
+        proofs,
+        blobs,
     }
 }
 

--- a/crates/rbuilder/src/mev_boost/submission.rs
+++ b/crates/rbuilder/src/mev_boost/submission.rs
@@ -1,10 +1,13 @@
 use alloy_primitives::U256;
+use alloy_rpc_types_beacon::relay::SignedBidSubmissionV5;
 use alloy_rpc_types_beacon::{
     relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
     requests::ExecutionRequestsV4,
     BlsSignature,
 };
-use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV2, ExecutionPayloadV3};
+use alloy_rpc_types_engine::{
+    BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV2, ExecutionPayloadV3,
+};
 use derive_more::Deref;
 use serde::{Deserialize, Serialize};
 use ssz::DecodeError;
@@ -16,6 +19,7 @@ use crate::primitives::OrderId;
 #[ssz(enum_behaviour = "transparent")]
 #[serde(untagged)]
 pub enum SubmitBlockRequest {
+    Fulu(FuluSubmitBlockRequest),
     Capella(CapellaSubmitBlockRequest),
     Deneb(DenebSubmitBlockRequest),
     Electra(ElectraSubmitBlockRequest),
@@ -37,8 +41,14 @@ impl SubmitBlockRequest {
         Self::Electra(request)
     }
 
+    #[inline]
+    pub fn fulu(request: FuluSubmitBlockRequest) -> Self {
+        Self::Fulu(request)
+    }
+
     pub fn bid_trace(&self) -> &BidTrace {
         match self {
+            SubmitBlockRequest::Fulu(req) => &req.message,
             SubmitBlockRequest::Capella(req) => &req.message,
             SubmitBlockRequest::Deneb(req) => &req.message,
             SubmitBlockRequest::Electra(req) => &req.message,
@@ -52,6 +62,9 @@ impl ssz::Decode for SubmitBlockRequest {
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        if let Ok(result) = FuluSubmitBlockRequest::from_ssz_bytes(bytes) {
+            return Ok(Self::fulu(result));
+        }
         if let Ok(result) = ElectraSubmitBlockRequest::from_ssz_bytes(bytes) {
             return Ok(Self::electra(result));
         }
@@ -61,6 +74,27 @@ impl ssz::Decode for SubmitBlockRequest {
 
         let result = CapellaSubmitBlockRequest::from_ssz_bytes(bytes)?;
         Ok(Self::capella(result))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Deref)]
+pub struct FuluSubmitBlockRequest {
+    #[deref]
+    #[serde(flatten)]
+    pub submission: SignedBidSubmissionV5,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adjustment_data: Option<BidAdjustmentData>,
+}
+
+impl FuluSubmitBlockRequest {
+    pub fn new(
+        submission: SignedBidSubmissionV5,
+        adjustment_data: Option<BidAdjustmentData>,
+    ) -> Self {
+        Self {
+            submission,
+            adjustment_data,
+        }
     }
 }
 
@@ -84,6 +118,88 @@ impl ElectraSubmitBlockRequest {
         Self {
             submission,
             adjustment_data,
+        }
+    }
+}
+
+impl ssz::Encode for FuluSubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        let mut offset = <BidTrace as ssz::Encode>::ssz_fixed_len()
+            + <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
+            + <BlobsBundleV2 as ssz::Encode>::ssz_fixed_len()
+            + <ExecutionRequestsV4 as ssz::Encode>::ssz_fixed_len()
+            + <BlsSignature as ssz::Encode>::ssz_fixed_len();
+        if self.adjustment_data.is_some() {
+            offset += <BidAdjustmentData as ssz::Encode>::ssz_fixed_len();
+        }
+
+        let mut encoder = ssz::SszEncoder::container(buf, offset);
+
+        encoder.append(&self.message);
+        encoder.append(&self.execution_payload);
+        encoder.append(&self.blobs_bundle);
+        encoder.append(&self.execution_requests);
+        encoder.append(&self.signature);
+        if let Some(adjustment) = &self.adjustment_data {
+            encoder.append(&adjustment);
+        }
+
+        encoder.finalize();
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        let mut len = <BidTrace as ssz::Encode>::ssz_bytes_len(&self.message)
+            + <ExecutionPayloadV3 as ssz::Encode>::ssz_bytes_len(&self.execution_payload)
+            + <BlobsBundleV2 as ssz::Encode>::ssz_bytes_len(&self.blobs_bundle)
+            + <ExecutionRequestsV4 as ssz::Encode>::ssz_bytes_len(&self.execution_requests)
+            + <BlsSignature as ssz::Encode>::ssz_bytes_len(&self.signature);
+        if let Some(adjustment) = &self.adjustment_data {
+            len += <BidAdjustmentData as ssz::Encode>::ssz_bytes_len(adjustment);
+        }
+        len
+    }
+}
+
+impl ssz::Decode for FuluSubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        #[derive(ssz_derive::Decode)]
+        struct FuluSubmitBlockRequestSszHelper {
+            message: BidTrace,
+            execution_payload: ExecutionPayloadV3,
+            blobs_bundle: BlobsBundleV2,
+            execution_requests: ExecutionRequestsV4,
+            signature: BlsSignature,
+            adjustment_data: BidAdjustmentData,
+        }
+
+        if let Ok(request) = FuluSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
+            let FuluSubmitBlockRequestSszHelper {
+                message,
+                execution_payload,
+                blobs_bundle,
+                execution_requests,
+                signature,
+                adjustment_data,
+            } = request;
+            let submission = SignedBidSubmissionV5 {
+                message,
+                execution_payload,
+                blobs_bundle,
+                execution_requests,
+                signature,
+            };
+            Ok(Self::new(submission, Some(adjustment_data)))
+        } else {
+            let submission = SignedBidSubmissionV5::from_ssz_bytes(bytes)?;
+            Ok(Self::new(submission, None))
         }
     }
 }
@@ -433,6 +549,26 @@ impl serde::Serialize for SubmitBlockRequestNoBlobs<'_> {
                     signature: &v4.signature,
                     execution_requests: &v4.execution_requests,
                     adjustment_data: &v4.adjustment_data,
+                }
+                .serialize(serializer)
+            }
+            SubmitBlockRequest::Fulu(v5) => {
+                #[derive(serde::Serialize)]
+                struct SignedBidSubmissionV5Ref<'a> {
+                    message: &'a BidTrace,
+                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
+                    execution_payload: &'a ExecutionPayloadV3,
+                    blobs_bundle: &'a BlobsBundleV2,
+                    execution_requests: &'a ExecutionRequestsV4,
+                    signature: &'a BlsSignature,
+                }
+
+                SignedBidSubmissionV5Ref {
+                    message: &v5.message,
+                    execution_payload: &v5.execution_payload,
+                    blobs_bundle: &BlobsBundleV2::new([]), // override blobs bundle with empty one
+                    signature: &v5.signature,
+                    execution_requests: &v5.execution_requests,
                 }
                 .serialize(serializer)
             }

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -7,15 +7,16 @@ pub mod order_statistics;
 pub mod serialize;
 mod test_data_generator;
 
-use crate::building::evm_inspector::UsedStateTrace;
+use crate::building::{evm_inspector::UsedStateTrace, BlockSpace};
 use alloy_consensus::Transaction as _;
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Encodable2718},
-    eip4844::{Blob, BlobTransactionSidecar, Bytes48},
+    eip4844::{Blob, BlobTransactionSidecar, Bytes48, DATA_GAS_PER_BLOB},
     eip7594::BlobTransactionSidecarVariant,
     Typed2718,
 };
 use alloy_primitives::{keccak256, Address, Bytes, TxHash, B256, U256};
+use alloy_rlp::Encodable as _;
 use derivative::Derivative;
 use integer_encoding::VarInt;
 use reth::transaction_pool::{
@@ -354,6 +355,7 @@ impl ShareBundleTx {
 /// Body element of a mev share bundle.
 /// [`ShareBundleInner::body`] is formed by several of these.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[allow(clippy::large_enum_variant)]
 pub enum ShareBundleBody {
     Tx(ShareBundleTx),
     Bundle(ShareBundleInner),
@@ -732,11 +734,24 @@ impl TransactionSignedEcRecoveredWithBlobs {
         }
     }
 
+    /// Estimated length used to measure block space so avoid reaching EIP-7934 limit.
+    pub fn length_eip7934(&self) -> usize {
+        self.tx.inner().length()
+    }
+
+    pub fn space_needed(&self) -> BlockSpace {
+        BlockSpace::new(self.tx.gas_limit(), self.length_eip7934())
+    }
+
     pub fn blobs_len(&self) -> usize {
         match self.blobs_sidecar.as_ref() {
             BlobTransactionSidecarVariant::Eip4844(sidecar) => sidecar.blobs.len(),
             BlobTransactionSidecarVariant::Eip7594(sidecar) => sidecar.blobs.len(),
         }
+    }
+
+    pub fn blobs_gas_used(&self) -> u64 {
+        self.blobs_len() as u64 * DATA_GAS_PER_BLOB
     }
 
     /// For when we don't have a sidecar. Not sure if Eip4844 is the right choice.
@@ -1135,7 +1150,7 @@ pub struct SimValue {
     /// ProfitInfo considering profit only from non mempool txs on the s/bundles.
     /// For mempool orders it should match ProfitInfo
     non_mempool_profit_info: ProfitInfo,
-    gas_used: u64,
+    space_used: BlockSpace,
     blob_gas_used: u64,
     /// Kickbacks paid during simulation as (receiver, amount)
     paid_kickbacks: Vec<(Address, U256)>,
@@ -1147,14 +1162,14 @@ impl SimValue {
         full_coinbase_profit: U256,
         // for s/bundles profit from non-mempool txs.
         non_mempool_coinbase_profit: U256,
-        gas_used: u64,
+        space_used: BlockSpace,
         blob_gas_used: u64,
         paid_kickbacks: Vec<(Address, U256)>,
     ) -> Self {
         Self {
-            full_profit_info: ProfitInfo::new(full_coinbase_profit, gas_used),
-            non_mempool_profit_info: ProfitInfo::new(non_mempool_coinbase_profit, gas_used),
-            gas_used,
+            full_profit_info: ProfitInfo::new(full_coinbase_profit, space_used.gas()),
+            non_mempool_profit_info: ProfitInfo::new(non_mempool_coinbase_profit, space_used.gas()),
+            space_used,
             blob_gas_used,
             paid_kickbacks,
         }
@@ -1174,7 +1189,7 @@ impl SimValue {
         Self {
             full_profit_info: ProfitInfo::new(full_coinbase_profit, gas_used),
             non_mempool_profit_info: ProfitInfo::new(non_mempool_profit, gas_used),
-            gas_used,
+            space_used: BlockSpace::new(gas_used, 0),
             ..Default::default()
         }
     }
@@ -1188,7 +1203,7 @@ impl SimValue {
     }
 
     pub fn gas_used(&self) -> u64 {
-        self.gas_used
+        self.space_used.gas()
     }
 
     pub fn blob_gas_used(&self) -> u64 {
@@ -1277,9 +1292,9 @@ impl FromStr for OrderId {
 impl Display for OrderId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Tx(hash) => write!(f, "tx:{:?}", hash),
-            Self::Bundle(uuid) => write!(f, "bundle:{:?}", uuid),
-            Self::ShareBundle(hash) => write!(f, "sbundle:{:?}", hash),
+            Self::Tx(hash) => write!(f, "tx:{hash:?}"),
+            Self::Bundle(uuid) => write!(f, "bundle:{uuid:?}"),
+            Self::ShareBundle(hash) => write!(f, "sbundle:{hash:?}"),
         }
     }
 }

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -12,6 +12,7 @@ use alloy_consensus::Transaction as _;
 use alloy_eips::{
     eip2718::{Decodable2718, Eip2718Error, Encodable2718},
     eip4844::{Blob, BlobTransactionSidecar, Bytes48},
+    eip7594::BlobTransactionSidecarVariant,
     Typed2718,
 };
 use alloy_primitives::{keccak256, Address, Bytes, TxHash, B256, U256};
@@ -21,10 +22,11 @@ use reth::transaction_pool::{
     BlobStore, BlobStoreError, EthPooledTransaction, Pool, TransactionOrdering, TransactionPool,
     TransactionValidator,
 };
+use reth_ethereum_primitives::PooledTransactionVariant;
 use reth_node_core::primitives::SignedTransaction;
 use reth_primitives::{
     kzg::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT, BYTES_PER_PROOF},
-    PooledTransaction, Recovered, Transaction, TransactionSigned,
+    Recovered, Transaction, TransactionSigned,
 };
 use reth_primitives_traits::{InMemorySize, SignerRecoverable};
 use serde::{Deserialize, Serialize};
@@ -637,8 +639,8 @@ impl ShareBundle {
 #[derivative(Clone, PartialEq, Eq)]
 pub struct TransactionSignedEcRecoveredWithBlobs {
     tx: Recovered<TransactionSigned>,
-    /// Will have a non empty BlobTransactionSidecar if Recovered<TransactionSigned> is 4844
-    pub blobs_sidecar: Arc<BlobTransactionSidecar>,
+    /// Will have a non empty BlobTransactionSidecarVariant if Recovered<TransactionSigned> is 4844
+    pub blobs_sidecar: Arc<BlobTransactionSidecarVariant>,
 
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub metadata: Metadata,
@@ -710,7 +712,7 @@ impl TransactionSignedEcRecoveredWithBlobs {
     /// or blobs without an eip4844.
     pub fn new(
         tx: Recovered<TransactionSigned>,
-        blob_sidecar: Option<BlobTransactionSidecar>,
+        blob_sidecar: Option<BlobTransactionSidecarVariant>,
         metadata: Option<Metadata>,
     ) -> Result<Self, TxWithBlobsCreateError> {
         // Check for an eip4844 tx passed without blobs
@@ -721,12 +723,25 @@ impl TransactionSignedEcRecoveredWithBlobs {
             Err(TxWithBlobsCreateError::BlobsMissingEip4844)
         // Groovy!
         } else {
+            let sidecar = blob_sidecar.unwrap_or(Self::default_blob_sidecar());
             Ok(Self {
                 tx,
-                blobs_sidecar: Arc::new(blob_sidecar.unwrap_or_default()),
+                blobs_sidecar: Arc::new(sidecar),
                 metadata: metadata.unwrap_or_default(),
             })
         }
+    }
+
+    pub fn blobs_len(&self) -> usize {
+        match self.blobs_sidecar.as_ref() {
+            BlobTransactionSidecarVariant::Eip4844(sidecar) => sidecar.blobs.len(),
+            BlobTransactionSidecarVariant::Eip7594(sidecar) => sidecar.blobs.len(),
+        }
+    }
+
+    /// For when we don't have a sidecar. Not sure if Eip4844 is the right choice.
+    fn default_blob_sidecar() -> BlobTransactionSidecarVariant {
+        BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar::default())
     }
 
     /// Shorthand for `new(tx, None, None)`
@@ -751,9 +766,12 @@ impl TransactionSignedEcRecoveredWithBlobs {
         T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
         S: BlobStore,
     {
+        /* At aprox 2025-08 get_blob was failing so we switched to get_all_blobs.
         let blob_sidecar = pool
-            .get_blob(*tx.inner().hash())?
-            .and_then(|b| b.as_eip4844().cloned());
+        .get_blob(*tx.inner().hash())?
+        .map(|b| b.as_ref().clone());*/
+        let mut blobs = pool.get_all_blobs(vec![*tx.inner().hash()])?;
+        let blob_sidecar = blobs.pop().map(|(_, arc)| arc.as_ref().clone());
         Self::new(tx, blob_sidecar, None)
     }
 
@@ -761,7 +779,7 @@ impl TransactionSignedEcRecoveredWithBlobs {
     pub fn new_for_testing(tx: Recovered<TransactionSigned>) -> Self {
         Self {
             tx,
-            blobs_sidecar: Default::default(),
+            blobs_sidecar: Arc::new(Self::default_blob_sidecar()),
             metadata: Default::default(),
         }
     }
@@ -810,20 +828,20 @@ impl TransactionSignedEcRecoveredWithBlobs {
         raw_tx: Bytes,
     ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
         let raw_tx = &mut raw_tx.as_ref();
-        let pooled_tx = PooledTransaction::decode_2718(raw_tx)
+        let pooled_tx = PooledTransactionVariant::decode_2718(raw_tx)
             .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
         let signer = pooled_tx
             .recover_signer()
             .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?;
         match pooled_tx {
-            PooledTransaction::Legacy(_)
-            | PooledTransaction::Eip2930(_)
-            | PooledTransaction::Eip1559(_)
-            | PooledTransaction::Eip7702(_) => {
+            PooledTransactionVariant::Legacy(_)
+            | PooledTransactionVariant::Eip2930(_)
+            | PooledTransactionVariant::Eip1559(_)
+            | PooledTransactionVariant::Eip7702(_) => {
                 let tx_signed = TransactionSigned::from(pooled_tx);
                 TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx_signed.with_signer(signer))
             }
-            PooledTransaction::Eip4844(blob_tx) => {
+            PooledTransactionVariant::Eip4844(blob_tx) => {
                 let (blob_tx, signature, hash) = blob_tx.into_parts();
                 let (blob_tx, sidecar) = blob_tx.into_parts();
                 let tx_signed = TransactionSigned::new_unchecked(
@@ -859,7 +877,7 @@ impl TransactionSignedEcRecoveredWithBlobs {
         }
         Ok(TransactionSignedEcRecoveredWithBlobs {
             tx,
-            blobs_sidecar: Arc::new(fake_sidecar),
+            blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(fake_sidecar)),
             metadata: Metadata::default(),
         })
     }
@@ -1043,9 +1061,7 @@ impl Order {
     }
 
     pub fn has_blobs(&self) -> bool {
-        self.list_txs()
-            .iter()
-            .any(|(tx, _)| !tx.blobs_sidecar.blobs.is_empty())
+        self.list_txs().iter().any(|(tx, _)| tx.blobs_len() > 0)
     }
 
     pub fn target_block(&self) -> Option<u64> {

--- a/crates/rbuilder/src/primitives/order_builder.rs
+++ b/crates/rbuilder/src/primitives/order_builder.rs
@@ -8,6 +8,7 @@ use super::{
 
 /// Helper object to build Orders for testing.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum OrderBuilder {
     MempoolTx(Option<TransactionSignedEcRecoveredWithBlobs>),
     Bundle(BundleBuilder),

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -18,7 +18,7 @@ use reipc::rpc_provider::RpcProvider;
 use reth_errors::{ProviderError, ProviderResult};
 use reth_primitives::{Account, Bytecode};
 use reth_provider::{
-    errors::any::AnyError, AccountReader, BlockHashReader, HashedPostStateProvider,
+    errors::any::AnyError, AccountReader, BlockHashReader, BytecodeReader, HashedPostStateProvider,
     StateProofProvider, StateProvider, StateProviderBox, StateRootProvider, StorageRootProvider,
 };
 use reth_trie::{
@@ -242,24 +242,7 @@ impl IpcStateProvider {
     }
 }
 
-impl StateProvider for IpcStateProvider {
-    /// Get storage of given account
-    fn storage(
-        &self,
-        account: Address,
-        storage_key: StorageKey,
-    ) -> ProviderResult<Option<StorageValue>> {
-        if let Some(storage) = self.storage_cache.get(&(account, storage_key)) {
-            return Ok(*storage);
-        }
-
-        let key: U256 = storage_key.into();
-        let storage = rpc_call(&self.ipc_provider, "eth_getStorageAt", (account, key))?;
-        self.storage_cache.insert((account, storage_key), storage);
-
-        Ok(storage)
-    }
-
+impl BytecodeReader for IpcStateProvider {
     /// Get account code by its hash
     /// IMPORTANT: Assumes remote provider (node) has RPC call:"rbuilder_getCodeByHash"
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
@@ -284,6 +267,25 @@ impl StateProvider for IpcStateProvider {
         });
 
         Ok(bytecode)
+    }
+}
+
+impl StateProvider for IpcStateProvider {
+    /// Get storage of given account
+    fn storage(
+        &self,
+        account: Address,
+        storage_key: StorageKey,
+    ) -> ProviderResult<Option<StorageValue>> {
+        if let Some(storage) = self.storage_cache.get(&(account, storage_key)) {
+            return Ok(*storage);
+        }
+
+        let key: U256 = storage_key.into();
+        let storage = rpc_call(&self.ipc_provider, "eth_getStorageAt", (account, key))?;
+        self.storage_cache.insert((account, storage_key), storage);
+
+        Ok(storage)
     }
 }
 

--- a/crates/rbuilder/src/provider/reth_prov.rs
+++ b/crates/rbuilder/src/provider/reth_prov.rs
@@ -4,8 +4,8 @@ use alloy_consensus::Header;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{BlockHash, BlockNumber, B256};
 use reth_errors::ProviderResult;
+use reth_provider::StateProviderBox;
 use reth_provider::{BlockReader, DatabaseProviderFactory, HeaderProvider};
-use reth_provider::{StateCommitmentProvider, StateProviderBox};
 use tracing::error;
 
 use super::{RootHasher, StateProviderFactory};
@@ -31,7 +31,6 @@ where
     P: DatabaseProviderFactory<Provider: BlockReader>
         + reth_provider::StateProviderFactory
         + HeaderProvider<Header = Header>
-        + StateCommitmentProvider
         + Clone
         + 'static,
 {

--- a/crates/rbuilder/src/roothash/mod.rs
+++ b/crates/rbuilder/src/roothash/mod.rs
@@ -4,9 +4,7 @@ use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
 use eth_sparse_mpt::*;
 use reth::providers::{providers::ConsistentDbView, ExecutionOutcome};
-use reth_provider::{
-    BlockReader, DatabaseProviderFactory, HashedPostStateProvider, StateCommitmentProvider,
-};
+use reth_provider::{BlockReader, DatabaseProviderFactory, HashedPostStateProvider};
 use reth_trie::TrieInput;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use tracing::trace;
@@ -76,12 +74,7 @@ fn calculate_parallel_root_hash<P, HasherType>(
 ) -> Result<B256, ParallelStateRootError>
 where
     HasherType: HashedPostStateProvider,
-    P: DatabaseProviderFactory<Provider: BlockReader>
-        + StateCommitmentProvider
-        + Send
-        + Sync
-        + Clone
-        + 'static,
+    P: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync + Clone + 'static,
 {
     let hashed_post_state = hasher.hashed_post_state(outcome.state());
     let parallel_root_calculator = ParallelStateRoot::new(
@@ -103,12 +96,7 @@ pub fn calculate_state_root<P, HasherType>(
 ) -> Result<B256, RootHashError>
 where
     HasherType: HashedPostStateProvider,
-    P: DatabaseProviderFactory<Provider: BlockReader>
-        + Send
-        + Sync
-        + Clone
-        + StateCommitmentProvider
-        + 'static,
+    P: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync + Clone + 'static,
 {
     let consistent_db_view = match config.mode {
         RootHashMode::CorrectRoot => ConsistentDbView::new(

--- a/crates/rbuilder/src/roothash/prefetcher.rs
+++ b/crates/rbuilder/src/roothash/prefetcher.rs
@@ -5,7 +5,7 @@ use alloy_eips::BlockNumHash;
 use alloy_primitives::Address;
 use eth_sparse_mpt::*;
 use reth::providers::providers::ConsistentDbView;
-use reth_provider::{BlockReader, DatabaseProviderFactory, StateCommitmentProvider};
+use reth_provider::{BlockReader, DatabaseProviderFactory};
 use tokio::sync::broadcast::{
     self,
     error::{RecvError, TryRecvError},
@@ -31,7 +31,6 @@ pub fn run_trie_prefetcher<P>(
     cancel: CancellationToken,
 ) where
     P: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync + Clone,
-    P: StateCommitmentProvider,
 {
     let consistent_db_view = ConsistentDbView::new(
         provider,

--- a/crates/rbuilder/src/utils/build_info.rs
+++ b/crates/rbuilder/src/utils/build_info.rs
@@ -15,10 +15,10 @@ pub fn print_version_info() {
     println!("commit:     {}", GIT_COMMIT_HASH_SHORT.unwrap_or_default());
     println!("dirty:      {}", GIT_DIRTY.unwrap_or_default());
     println!("branch:     {}", GIT_HEAD_REF.unwrap_or_default());
-    println!("build_time: {}", BUILT_TIME_UTC);
-    println!("rustc:      {}", RUSTC_VERSION);
-    println!("features:   {:?}", FEATURES);
-    println!("profile:    {}", PROFILE);
+    println!("build_time: {BUILT_TIME_UTC}");
+    println!("rustc:      {RUSTC_VERSION}");
+    println!("features:   {FEATURES:?}");
+    println!("profile:    {PROFILE}");
 }
 
 #[derive(Debug)]

--- a/crates/rbuilder/src/utils/provider_factory_reopen.rs
+++ b/crates/rbuilder/src/utils/provider_factory_reopen.rs
@@ -17,7 +17,7 @@ use reth_node_api::{NodePrimitives, NodeTypesWithDB};
 use reth_provider::{
     providers::{ProviderNodeTypes, StaticFileProvider},
     BlockNumReader, BlockReader, DatabaseProviderFactory, HashedPostStateProvider, HeaderProvider,
-    StateCommitmentProvider, StateProviderBox, StaticFileProviderFactory,
+    StateProviderBox, StaticFileProviderFactory,
 };
 use std::{ops::DerefMut, path::PathBuf, sync::Arc};
 use tokio::sync::broadcast;
@@ -288,12 +288,7 @@ impl<T, HasherType> RootHasherImpl<T, HasherType> {
 impl<T, HasherType> RootHasher for RootHasherImpl<T, HasherType>
 where
     HasherType: HashedPostStateProvider,
-    T: DatabaseProviderFactory<Provider: BlockReader>
-        + StateCommitmentProvider
-        + Send
-        + Sync
-        + Clone
-        + 'static,
+    T: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync + Clone + 'static,
 {
     fn run_prefetcher(
         &self,

--- a/crates/reth-rbuilder/src/main.rs
+++ b/crates/reth-rbuilder/src/main.rs
@@ -19,7 +19,7 @@ use reth::{
 use reth_node_ethereum::{node::EthereumAddOns, EthereumNode};
 use reth_provider::{
     providers::BlockchainProvider, BlockReader, ChainSpecProvider, DatabaseProviderFactory,
-    HeaderProvider, StateCommitmentProvider,
+    HeaderProvider,
 };
 use reth_transaction_pool::{blobstore::DiskFileBlobStore, EthTransactionPool};
 use std::{
@@ -85,7 +85,6 @@ fn spawn_rbuilder<P>(
     P: DatabaseProviderFactory<Provider: BlockReader>
         + reth_provider::StateProviderFactory
         + HeaderProvider<Header = Header>
-        + StateCommitmentProvider
         + reth_provider::ChainSpecProvider
         + Clone
         + 'static,

--- a/crates/test-relay/src/relay.rs
+++ b/crates/test-relay/src/relay.rs
@@ -64,7 +64,7 @@ impl RelayError {
             RelayError::PayloadAttributesNotKnown => {
                 (6, false, "payload attributes not (yet) known".to_string())
             }
-            RelayError::SimulationFailed(msg) => (7, false, format!("simulation failed: {}", msg)),
+            RelayError::SimulationFailed(msg) => (7, false, format!("simulation failed: {msg}")),
         };
         let json = RelayErrorResponse { code, message };
         let status_code = if internal {

--- a/crates/test-relay/src/validation_api_client.rs
+++ b/crates/test-relay/src/validation_api_client.rs
@@ -43,7 +43,7 @@ pub enum ValidationError {
 
 impl Debug for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/crates/test-relay/src/validation_api_client.rs
+++ b/crates/test-relay/src/validation_api_client.rs
@@ -72,6 +72,7 @@ impl ValidationAPIClient {
             SubmitBlockRequest::Capella(_) => "flashbots_validateBuilderSubmissionV2",
             SubmitBlockRequest::Deneb(_) => "flashbots_validateBuilderSubmissionV3",
             SubmitBlockRequest::Electra(_) => "flashbots_validateBuilderSubmissionV4",
+            SubmitBlockRequest::Fulu(_) => "flashbots_validateBuilderSubmissionV5",
         };
         let request = ValidRequest {
             req: req.clone(),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## 📝 Summary

Changes for Fusaka fork:
- Had to upgrade to rust 1.88: lint hell.
- alloy/nybbles: https://github.com/alloy-rs/nybbles/pull/17 updates the internal representation of Nibble from a SmallVec<[u8; 64]> to a U256. This breaks code in the merkle eth sparse tree as the code indexes a lot into the SmallVec representation.
  For this version we kept the sparse tree internals and adapted the on the interface (we have deps in both nibble versions).
- New Eip7594 blobs: This blobs have more profs so now we use BlobTransactionSidecarVariant instead of BlobTransactionSidecar. BlobTransactionSidecarVariant can model the old blob (BlobTransactionSidecar) and the new one (BlobTransactionSidecarEip7594).
- revm changed BlockNumber and Timestamp from U256 instead of u64. We convert internally to 64 since it's more compatible with the rest.
- Minor traits changes on reth.
- New relay SignedBidSubmissionV5 with new BlobsBundleV2.
- New rlp block encoding limiting as specified by EIP-7934.
- Order filter to avoid mix of blob types before and after the fork.

Thanks @bharath-123 for the help!

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
