### PR TITLE
reject negative profit mempool txs

### DIFF
--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -1216,10 +1216,12 @@ impl<
                 let res = self.commit_tx(&tx.tx_with_blobs, space_state)?;
                 match res {
                     Ok(ok) => {
-                        let coinbase_profit = if ok.tx_info.coinbase_profit.is_positive() {
+                        let coinbase_profit = if !ok.tx_info.coinbase_profit.is_negative() {
                             ok.tx_info.coinbase_profit.unsigned_abs()
                         } else {
-                            U256::ZERO
+                            return Ok(Err(OrderErr::NegativeProfit(
+                                ok.tx_info.coinbase_profit.unsigned_abs(),
+                            )));
                         };
                         Ok(Ok(OrderOk {
                             coinbase_profit,


### PR DESCRIPTION
## 📝 Summary

Reject mempool txs with negative profit. This can happen if our proposer payment tx gets to the mempool and we include it. 
Instead if anyone wants builder to withdraw eth we should add a list of allowed addresses instead.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
