### PR TITLE
feat: bid adjustments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9070,6 +9070,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 1.0.27",
  "alloy-signer-local",
+ "alloy-trie 0.8.1",
  "assert_matches",
  "async-trait",
  "beacon-api-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ ethereum_ssz = "0.9.0"
 alloy-primitives = { version = "1.3.1", default-features = false, features = ["getrandom"] }
 alloy-rlp = "0.3.10"
 alloy-chains = "0.2.5"
+alloy-trie = { version = "0.8.1", default-features = false }
 alloy-evm = { version = "0.20.1", default-features = false }
 alloy-provider = { version = "1.0.27", features = ["ipc", "pubsub", "ws"] }
 alloy-pubsub = { version = "1.0.27" }

--- a/crates/eth-sparse-mpt/Cargo.toml
+++ b/crates/eth-sparse-mpt/Cargo.toml
@@ -16,7 +16,7 @@ serde_with = "3.9.0"
 rustc-hash = "2.0.0"
 rayon = "1.10.0"
 smallvec = "1.13.2"
-alloy-trie = { version = "0.8.1", default-features = false }
+alloy-trie.workspace = true
 nybbles = { version = "0.3.3" }
 
 tracing.workspace = true

--- a/crates/eth-sparse-mpt/src/lib.rs
+++ b/crates/eth-sparse-mpt/src/lib.rs
@@ -6,12 +6,12 @@
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::type_complexity)]
 
-use std::sync::Arc;
-
-use alloy_primitives::{Address, B256};
+use crate::utils::{HashMap, HashSet};
+use alloy_primitives::{Address, Bytes, B256};
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, ExecutionOutcome,
 };
+use std::sync::Arc;
 
 #[cfg(any(test, feature = "benchmark-utils"))]
 pub mod test_utils;
@@ -138,6 +138,48 @@ impl SparseTrieError {
     }
 }
 
+pub fn calculate_account_proofs_with_sparse_trie<Provider>(
+    consistent_db_view: ConsistentDbView<Provider>,
+    outcome: &ExecutionOutcome,
+    proof_targets: &HashSet<Address>,
+    shared_cache: &SparseTrieSharedCache,
+    local_cache: &mut SparseTrieLocalCache,
+    thread_pool: &Option<RootHashThreadPool>,
+    version: ETHSpareMPTVersion,
+) -> (
+    Result<HashMap<Address, Vec<Bytes>>, SparseTrieError>,
+    SparseTrieMetrics,
+)
+where
+    Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
+{
+    let calculate = || match version {
+        ETHSpareMPTVersion::V1 => (
+            Err(SparseTrieError::Other(eyre::eyre!(
+                "proof generation not supported in v1"
+            ))),
+            Default::default(),
+        ),
+        ETHSpareMPTVersion::V2 => {
+            let result = local_cache.calc.calculate_root_hash_with_sparse_trie(
+                consistent_db_view,
+                shared_cache.cache_v2.clone(),
+                outcome,
+                proof_targets,
+            );
+            match result {
+                Ok((_, proofs, metrics)) => (Ok(proofs), metrics),
+                Err(err) => (Err(err), Default::default()),
+            }
+        }
+    };
+    if let Some(thread_pool) = thread_pool {
+        thread_pool.rayon_pool.install(calculate)
+    } else {
+        calculate()
+    }
+}
+
 pub fn calculate_root_hash_with_sparse_trie<Provider>(
     consistent_db_view: ConsistentDbView<Provider>,
     outcome: &ExecutionOutcome,
@@ -197,9 +239,10 @@ where
                 consistent_db_view,
                 shared_cache.cache_v2.clone(),
                 outcome,
+                &Default::default(),
             );
             match result {
-                Ok((res, metrics)) => (Ok(res), metrics),
+                Ok((res, _, metrics)) => (Ok(res), metrics),
                 Err(err) => (Err(err), Default::default()),
             }
         }

--- a/crates/eth-sparse-mpt/src/v2/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/mod.rs
@@ -1,24 +1,22 @@
-use rayon::prelude::*;
-use std::sync::Arc;
-use std::time::Instant;
-
-use alloy_primitives::{keccak256, Address, B256, U256};
+use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use dashmap::DashMap;
 use fetch::MissingNodesFetcher;
 use nybbles::Nibbles;
 use parking_lot::{Mutex, RwLock};
+use rayon::prelude::*;
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, ExecutionOutcome,
 };
 use reth_trie::TrieAccount;
 use revm::state::AccountInfo;
 use rustc_hash::FxBuildHasher;
-use std::ops::Range;
-use trie::proof_store::ProofStore;
-use trie::{DeletionError, InsertValue, NodeNotFound, Trie};
+use std::{ops::Range, sync::Arc, time::Instant};
+use trie::{proof_store::ProofStore, DeletionError, InsertValue, NodeNotFound, Trie};
 
-use crate::utils::HashMap;
-use crate::{ChangedAccountData, SparseTrieError, SparseTrieMetrics};
+use crate::{
+    utils::{HashMap, HashSet},
+    ChangedAccountData, SparseTrieError, SparseTrieMetrics,
+};
 
 pub mod fetch;
 pub mod trie;
@@ -277,7 +275,11 @@ impl RootHashCalculator {
         }
     }
 
-    fn prepare_changes_for_storage_trie(&mut self, outcome: &ExecutionOutcome) -> eyre::Result<()> {
+    fn prepare_changes_for_storage_trie(
+        &mut self,
+        outcome: &ExecutionOutcome,
+        proof_targets: &HashSet<Address>,
+    ) -> eyre::Result<()> {
         self.changed_account.write().clear();
 
         outcome
@@ -354,6 +356,20 @@ impl RootHashCalculator {
                 storage_calc.applied_storage_ops_previous_iteration =
                     applied_storage_ops_previous_iteration;
             });
+
+        for proof_target in proof_targets {
+            if outcome
+                .bundle
+                .state
+                .get(proof_target)
+                .is_none_or(|acc| !acc.status.is_not_modified())
+            {
+                self.changed_account
+                    .write()
+                    .push((*proof_target, StorageTrieStatus::Hashed));
+            }
+        }
+
         Ok(())
     }
 
@@ -564,23 +580,23 @@ impl RootHashCalculator {
         let fetcher = Arc::new(Mutex::new(MissingNodesFetcher::default()));
 
         self.changed_account.read().par_iter().for_each(|(address, status)| {
-	    if !status.needs_processing() {
-		return;
-	    }
+            if !status.needs_processing() {
+                return;
+            }
             let storage_calc = self.get_account_storage(address);
-	    let mut storage_calc = storage_calc.lock();
-	    let storage_calc = &mut *storage_calc;
-	    storage_calc.missing_nodes_requested.clear();
-	    for missing_node in storage_calc.missing_nodes.drain(..) {
-		if storage_calc.proof_store.has_proof(&missing_node) {
-		    let ok = storage_calc.trie.try_add_proof_from_proof_store(&missing_node, &storage_calc.proof_store).expect("should be able to insert proofs from proof store when they are found (storage trie)");
-		    assert!(ok, "proof is not added (storage trie)");
-		} else {
-		    storage_calc.missing_nodes_requested.push(missing_node.clone());
-		    fetcher.lock().add_missing_storage_node(&storage_calc.hashed_address, missing_node);
-		}
-	    }
-	});
+            let mut storage_calc = storage_calc.lock();
+            let storage_calc = &mut *storage_calc;
+            storage_calc.missing_nodes_requested.clear();
+            for missing_node in storage_calc.missing_nodes.drain(..) {
+                if storage_calc.proof_store.has_proof(&missing_node) {
+                    let ok = storage_calc.trie.try_add_proof_from_proof_store(&missing_node, &storage_calc.proof_store).expect("should be able to insert proofs from proof store when they are found (storage trie)");
+                    assert!(ok, "proof is not added (storage trie)");
+                } else {
+                    storage_calc.missing_nodes_requested.push(missing_node.clone());
+                    fetcher.lock().add_missing_storage_node(&storage_calc.hashed_address, missing_node);
+                }
+            }
+        });
 
         let mut fetcher = fetcher.lock();
         if !fetcher.is_empty() {
@@ -591,21 +607,21 @@ impl RootHashCalculator {
         }
 
         self.changed_account.read().par_iter().for_each(|(address, status)| {
-	    if !status.needs_processing() {
-		return;
-	    }
+            if !status.needs_processing() {
+                return;
+            }
             let storage_calc = self.get_account_storage(address);
-	    let mut storage_calc = storage_calc.lock();
-	    let storage_calc = &mut *storage_calc;
-	    for missing_node in storage_calc.missing_nodes_requested.drain(..) {
-		if storage_calc.proof_store.has_proof(&missing_node) {
-		    let ok = storage_calc.trie.try_add_proof_from_proof_store(&missing_node, &storage_calc.proof_store).expect("should be able to insert proofs from proof store when they are found (storage trie)");
-		    assert!(ok, "proof is not added (storage trie)");
-		} else {
-		    panic!("Missing node that was just fetched is not there (storage trie)");
-		}
-	    }
-	});
+            let mut storage_calc = storage_calc.lock();
+            let storage_calc = &mut *storage_calc;
+            for missing_node in storage_calc.missing_nodes_requested.drain(..) {
+                if storage_calc.proof_store.has_proof(&missing_node) {
+                    let ok = storage_calc.trie.try_add_proof_from_proof_store(&missing_node, &storage_calc.proof_store).expect("should be able to insert proofs from proof store when they are found (storage trie)");
+                    assert!(ok, "proof is not added (storage trie)");
+                } else {
+                    panic!("Missing node that was just fetched is not there (storage trie)");
+                }
+            }
+        });
         Ok(())
     }
 
@@ -857,7 +873,8 @@ impl RootHashCalculator {
         consistent_db_view: ConsistentDbView<Provider>,
         shared_cache: SharedCacheV2,
         outcome: &ExecutionOutcome,
-    ) -> Result<(B256, SparseTrieMetrics), SparseTrieError>
+        proof_targets: &HashSet<Address>,
+    ) -> Result<(B256, HashMap<Address, Vec<Bytes>>, SparseTrieMetrics), SparseTrieError>
     where
         Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
     {
@@ -867,7 +884,7 @@ impl RootHashCalculator {
         self.shared_cache = shared_cache.clone();
 
         stats.start();
-        self.prepare_changes_for_storage_trie(outcome)?;
+        self.prepare_changes_for_storage_trie(outcome, proof_targets)?;
         stats.measure_prepare(true);
         self.do_first_fetch(&consistent_db_view, &mut stats)?;
 
@@ -895,7 +912,7 @@ impl RootHashCalculator {
         stats.measure_prepare(false);
 
         let mut loop_break = false;
-        let mut result = B256::ZERO;
+        let mut root_hash = B256::ZERO;
         for _ in 0..10 {
             stats.start();
             let ok = self.process_account_tries_update()?;
@@ -907,17 +924,28 @@ impl RootHashCalculator {
                 continue;
             }
             stats.start();
-            result = self.hash_account_trie(&shared_cache);
+            root_hash = self.hash_account_trie(&shared_cache);
             stats.measure_hash(false);
             loop_break = true;
             break;
         }
         assert!(loop_break, "account trie are not processed after 10 iters");
 
+        let mut proofs = HashMap::default();
+        for proof_target in proof_targets {
+            let nibbles = Nibbles::unpack(keccak256(proof_target));
+            let proof = self
+                .account_trie
+                .trie
+                .proof(&nibbles, &shared_cache.account_trie)
+                .map_err(|err| SparseTrieError::Other(err.into()))?;
+            proofs.insert(*proof_target, proof);
+        }
+
         let mut metrics = SparseTrieMetrics::default();
         metrics.fetched_nodes = stats.fetched_nodes;
         stats.finalize_and_print();
-        Ok((result, metrics))
+        Ok((root_hash, proofs, metrics))
     }
 }
 

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -53,6 +53,7 @@ alloy-rpc-types-eth.workspace = true
 alloy-consensus.workspace = true
 alloy-signer-local.workspace = true
 alloy-eips.workspace = true
+alloy-trie.workspace = true
 
 ethereum_ssz_derive.workspace = true
 ethereum_ssz.workspace = true

--- a/crates/rbuilder/src/bin/dummy-builder.rs
+++ b/crates/rbuilder/src/bin/dummy-builder.rs
@@ -86,6 +86,7 @@ async fn main() -> eyre::Result<()> {
         vec![Client::default()],
         vec![relay],
         Duration::from_millis(1_000),
+        Default::default(),
         blocklist_provider.clone(),
         cancel.clone(),
     );

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -319,29 +319,25 @@ impl<
     ) -> Result<(), BlockBuildingHelperError> {
         self.built_block_trace.coinbase_reward = self.partial_block.coinbase_profit;
 
-        let use_last_tx_payment;
+        let (bid_value, true_value, use_last_tx_payment) =
+            if let Some((payout_tx_gas, payout_tx_value)) = self.payout_tx_gas.zip(payout_tx_value)
+            {
+                self.partial_block.insert_refunds_and_proposer_payout_tx(
+                    payout_tx_gas,
+                    payout_tx_value,
+                    &self.building_ctx,
+                    local_ctx,
+                    &mut self.block_state,
+                )?;
+                (payout_tx_value, self.true_block_value()?, true)
+            } else {
+                (
+                    self.partial_block.coinbase_profit,
+                    self.partial_block.coinbase_profit,
+                    false,
+                )
+            };
 
-        let (bid_value, true_value) = if let (Some(payout_tx_gas), Some(payout_tx_value)) =
-            (self.payout_tx_gas, payout_tx_value)
-        {
-            use_last_tx_payment = true;
-            match self.partial_block.insert_refunds_and_proposer_payout_tx(
-                payout_tx_gas,
-                payout_tx_value,
-                &self.building_ctx,
-                local_ctx,
-                &mut self.block_state,
-            ) {
-                Ok(()) => (payout_tx_value, self.true_block_value()?),
-                Err(err) => return Err(err.into()),
-            }
-        } else {
-            use_last_tx_payment = false;
-            (
-                self.partial_block.coinbase_profit,
-                self.partial_block.coinbase_profit,
-            )
-        };
         // Since some extra money might arrived directly the suggested_fee_recipient (when suggested_fee_recipient != coinbase)
         // we check the fee_recipient delta and make our bid include that! This is supposed to be what the relay will check.
         let fee_recipient_balance_after = self.block_state.balance(
@@ -498,11 +494,12 @@ impl<
         );
 
         let block = Block {
+            builder_name: self.builder_name.clone(),
             trace: self.built_block_trace,
             sealed_block: finalized_block.sealed_block,
             txs_blobs_sidecars: finalized_block.txs_blob_sidecars,
-            builder_name: self.builder_name.clone(),
             execution_requests: finalized_block.execution_requests,
+            bid_adjustments: finalized_block.bid_adjustments,
         };
         Ok(FinalizeBlockResult { block })
     }

--- a/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
@@ -1,18 +1,15 @@
-use crate::building::ThreadBlockBuildingContext;
-use crate::live_builder::simulation::SimulatedOrderCommand;
-use crate::primitives::order_statistics::OrderStatistics;
-use crate::primitives::SimValue;
-use crate::provider::RootHasher;
-use crate::roothash::RootHashError;
 use crate::{
     building::{
         BlockBuildingContext, BuiltBlockTrace, CriticalCommitOrderError, ExecutionError,
-        ExecutionResult,
+        ExecutionResult, ThreadBlockBuildingContext,
     },
-    primitives::SimulatedOrder,
+    live_builder::simulation::SimulatedOrderCommand,
+    primitives::{order_statistics::OrderStatistics, SimValue, SimulatedOrder},
+    provider::RootHasher,
+    roothash::RootHashError,
 };
-use alloy_primitives::B256;
-use alloy_primitives::U256;
+use alloy_primitives::{Address, Bytes, B256, U256};
+use eth_sparse_mpt::utils::{HashMap, HashSet};
 use reth::providers::ExecutionOutcome;
 use reth_primitives::SealedBlock;
 use time::OffsetDateTime;
@@ -104,11 +101,12 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
             self.built_block_trace.true_bid_value
         };
         let block = Block {
+            builder_name: "BlockBuildingHelper".to_string(),
             trace: self.built_block_trace,
             sealed_block: SealedBlock::default(),
             txs_blobs_sidecars: Vec::new(),
-            builder_name: "BlockBuildingHelper".to_string(),
             execution_requests: Default::default(),
+            bid_adjustments: Default::default(),
         };
 
         Ok(FinalizeBlockResult { block })
@@ -145,6 +143,15 @@ impl RootHasher for MockRootHasher {
         _simulated_orders: broadcast::Receiver<SimulatedOrderCommand>,
         _cancel: CancellationToken,
     ) {
+    }
+
+    fn account_proofs(
+        &self,
+        _outcome: &ExecutionOutcome,
+        _addresses: &HashSet<Address>,
+        _local_ctx: &mut ThreadBlockBuildingContext,
+    ) -> Result<HashMap<Address, Vec<Bytes>>, RootHashError> {
+        Ok(Default::default())
     }
 
     fn state_root(

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -12,6 +12,7 @@ use crate::{
         payload_events::{InternalPayloadId, MevBoostSlotData},
         simulation::SimulatedOrderCommand,
     },
+    mev_boost::adjustment::BidAdjustmentData,
     primitives::{AccountNonce, OrderId, SimulatedOrder},
     provider::StateProviderFactory,
     utils::{is_provider_factory_health_error, NonceCache},
@@ -21,7 +22,7 @@ use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_primitives::{Address, Bytes};
 use block_building_helper::BiddableUnfinishedBlock;
 use reth::primitives::SealedBlock;
-use std::{fmt::Debug, sync::Arc};
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
 use tokio::sync::{
     broadcast,
     broadcast::error::{RecvError, TryRecvError},
@@ -34,13 +35,15 @@ use super::{simulated_order_command_to_sink, OrderPriority, PrioritizedOrderStor
 /// Block we built
 #[derive(Debug, Clone)]
 pub struct Block {
+    pub builder_name: String,
     pub trace: BuiltBlockTrace,
     pub sealed_block: SealedBlock,
     /// Sidecars for the txs included in SealedBlock
     pub txs_blobs_sidecars: Vec<Arc<BlobTransactionSidecarVariant>>,
     /// The Pectra execution requests for this bid.
     pub execution_requests: Vec<Bytes>,
-    pub builder_name: String,
+    /// Bid adjustment data by fee payer address.
+    pub bid_adjustments: HashMap<Address, BidAdjustmentData>,
 }
 
 #[derive(Debug)]

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -12,8 +12,8 @@ use crate::{
         constants::BASE_TX_GAS,
         default_cfg_env, elapsed_ms,
         receipts::{
-            calculate_receipt_root_and_block_logs_bloom, calculate_transactions_root, BloomCache,
-            TransactionRootCache,
+            calculate_receipts_data, calculate_tx_root_and_placeholder_proof, ReceiptsData,
+            ReceiptsDataCache, TransactionRootCache,
         },
         timestamp_as_u64, Signer,
     },
@@ -376,7 +376,7 @@ impl BlockBuildingContext {
 #[derive(Debug, Clone, Default)]
 pub struct ThreadBlockBuildingContext {
     pub cached_reads: LocalCachedReads,
-    pub bloom_cache: BloomCache,
+    pub bloom_cache: ReceiptsDataCache,
     pub tx_root_cache: TransactionRootCache,
     pub root_hash_calculator: SparseTrieLocalCache,
 }
@@ -1011,7 +1011,11 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         let exec_outcome_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
-        let (receipts_root, logs_bloom) = calculate_receipt_root_and_block_logs_bloom(
+        let ReceiptsData {
+            logs_bloom,
+            receipts_root,
+            placeholder_receipt_proof,
+        } = calculate_receipts_data(
             &mut local_ctx.bloom_cache,
             &self.executed_tx_infos,
             ctx.faster_finalize,
@@ -1031,11 +1035,12 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         let step_start = Instant::now();
 
         // create the block header
-        let transactions_root = calculate_transactions_root(
-            &mut local_ctx.tx_root_cache,
-            &self.executed_tx_infos,
-            ctx.faster_finalize,
-        );
+        let (transactions_root, placeholder_transaction_proof) =
+            calculate_tx_root_and_placeholder_proof(
+                &mut local_ctx.tx_root_cache,
+                &self.executed_tx_infos,
+                ctx.faster_finalize,
+            );
 
         let transactions_root_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
@@ -1128,16 +1133,22 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             },
         };
 
-        let bid_adjustments =
-            Self::generate_bid_adjustments(&block.header, &execution_outcome, ctx, local_ctx)
-                .inspect_err(|error| {
-                    error!(
-                        block_number = block.number,
-                        ?error,
-                        "Error generating bid adjustment data"
-                    );
-                })
-                .unwrap_or_default();
+        let bid_adjustments = Self::generate_bid_adjustments(
+            &block.header,
+            &execution_outcome,
+            ctx,
+            local_ctx,
+            placeholder_transaction_proof,
+            placeholder_receipt_proof,
+        )
+        .inspect_err(|error| {
+            error!(
+                block_number = block.number,
+                ?error,
+                "Error generating bid adjustment data"
+            );
+        })
+        .unwrap_or_default();
 
         let result = FinalizeResult {
             sealed_block: block.seal_slow(),
@@ -1169,6 +1180,8 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         outcome: &ExecutionOutcome,
         ctx: &BlockBuildingContext,
         local_ctx: &mut ThreadBlockBuildingContext,
+        placeholder_transaction_proof: Vec<Bytes>,
+        placeholder_receipt_proof: Vec<Bytes>,
     ) -> Result<HashMap<Address, BidAdjustmentData>, FinalizeError> {
         let fee_payer_addresses = HashSet::<Address>::default(); // TODO:
         if fee_payer_addresses.is_empty() {
@@ -1231,8 +1244,8 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
                     fee_recipient_proof: fee_recipient_proof.clone(),
                     fee_payer_address,
                     fee_payer_proof,
-                    placeholder_transaction_proof: Vec::new(), // TODO:
-                    placeholder_receipt_proof: Vec::new(),     // TODO:
+                    placeholder_transaction_proof: placeholder_transaction_proof.clone(),
+                    placeholder_receipt_proof: placeholder_receipt_proof.clone(),
                 },
             );
         }

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -3,6 +3,7 @@ use crate::{
         block_list_provider::BlockList, order_input::mempool_txs_detector::MempoolTxsDetector,
         payload_events::InternalPayloadId,
     },
+    mev_boost::adjustment::BidAdjustmentData,
     primitives::{Order, OrderId, SimValue, SimulatedOrder, TransactionSignedEcRecoveredWithBlobs},
     provider::RootHasher,
     roothash::RootHashError,
@@ -55,7 +56,7 @@ use revm::{
 };
 use serde::Deserialize;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     hash::Hash,
     ops::{Add, AddAssign},
     str::FromStr,
@@ -674,12 +675,15 @@ impl ExecutionError {
 }
 
 pub struct FinalizeResult {
+    /// Sealed block.
     pub sealed_block: SealedBlock,
     // sidecars for all txs in SealedBlock
     pub txs_blob_sidecars: Vec<Arc<BlobTransactionSidecarVariant>>,
     /// The Pectra execution requests for this bid.
     pub execution_requests: Vec<Bytes>,
-
+    /// Bid adjustment data.
+    pub bid_adjustments: HashMap<Address, BidAdjustmentData>,
+    /// Duration of root hash calculation.
     pub root_hash_time: Duration,
 }
 
@@ -987,7 +991,6 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
     }
 
     /// Mostly based on reth's (v1.2) default_ethereum_payload_builder.
-    #[allow(clippy::too_many_arguments)]
     pub fn finalize(
         self,
         mut state: BlockState,
@@ -1018,20 +1021,16 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         let step_start = Instant::now();
 
         // calculate the state root
-        let state_root = {
-            let (bundle, _) = state.into_parts();
-            // we use execution outcome here only for interface compatibility, its just a wrapper around bundle
-            let execution_outcome =
-                ExecutionOutcome::new(bundle, Vec::new(), block_number, Vec::new());
-            ctx.root_hasher.state_root(&execution_outcome, local_ctx)?
-        };
+        let (bundle, _) = state.into_parts();
+        // we use execution outcome here only for interface compatibility, its just a wrapper around bundle
+        let execution_outcome = ExecutionOutcome::new(bundle, Vec::new(), block_number, Vec::new());
+        let state_root = ctx.root_hasher.state_root(&execution_outcome, local_ctx)?;
         let root_hash_time = step_start.elapsed();
 
         let root_hash_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
         // create the block header
-        // let transactions_root = proofs::calculate_transaction_root(&self.executed_tx);
         let transactions_root = calculate_transactions_root(
             &mut local_ctx.tx_root_cache,
             &self.executed_tx_infos,
@@ -1128,15 +1127,26 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
                 withdrawals,
             },
         };
+
+        let bid_adjustments =
+            Self::generate_bid_adjustments(&block.header, &execution_outcome, ctx, local_ctx)
+                .inspect_err(|error| {
+                    error!(
+                        block_number = block.number,
+                        ?error,
+                        "Error generating bid adjustment data"
+                    );
+                })
+                .unwrap_or_default();
+
         let result = FinalizeResult {
             sealed_block: block.seal_slow(),
             txs_blob_sidecars,
             root_hash_time,
-            execution_requests: requests.map(|er| er.take()).unwrap_or_default(),
+            execution_requests: requests.map(Requests::take).unwrap_or_default(),
+            bid_adjustments,
         };
-
         let block_seal_time_ms = elapsed_ms(step_start);
-
         let total_time_ms = elapsed_ms(start);
 
         trace!(
@@ -1152,6 +1162,82 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         );
 
         Ok(result)
+    }
+
+    fn generate_bid_adjustments(
+        header: &Header,
+        outcome: &ExecutionOutcome,
+        ctx: &BlockBuildingContext,
+        local_ctx: &mut ThreadBlockBuildingContext,
+    ) -> Result<HashMap<Address, BidAdjustmentData>, FinalizeError> {
+        let fee_payer_addresses = HashSet::<Address>::default(); // TODO:
+        if fee_payer_addresses.is_empty() {
+            return Ok(Default::default());
+        }
+
+        let Some(builder_signer) = ctx
+            .builder_signer
+            .filter(|signer| signer.address == header.beneficiary)
+        else {
+            trace!(
+                block_number = header.number,
+                "Builder is not block coinbase"
+            );
+            return Ok(Default::default());
+        };
+
+        let builder_address = builder_signer.address;
+        let fee_recipient_address = ctx.attributes.suggested_fee_recipient;
+
+        let proof_targets = HashSet::from_iter(
+            [builder_address, fee_recipient_address]
+                .into_iter()
+                .chain(fee_payer_addresses.clone()),
+        );
+        let mut account_proofs =
+            ctx.root_hasher
+                .account_proofs(outcome, &proof_targets, local_ctx)?;
+
+        let Some(builder_proof) = account_proofs.remove(&builder_address) else {
+            return Err(FinalizeError::Other(eyre::eyre!(
+                "account proof for builder {builder_address} is missing"
+            )));
+        };
+        let Some(fee_recipient_proof) = account_proofs.remove(&fee_recipient_address) else {
+            return Err(FinalizeError::Other(eyre::eyre!(
+                "account proof for proposer {fee_recipient_address} is missing"
+            )));
+        };
+
+        let mut bid_adjustments = HashMap::default();
+        for fee_payer_address in fee_payer_addresses {
+            let Some(fee_payer_proof) = account_proofs.remove(&fee_payer_address) else {
+                error!(
+                    %fee_payer_address,
+                    "Fee payer proof is missing"
+                );
+                continue;
+            };
+
+            bid_adjustments.insert(
+                fee_payer_address,
+                BidAdjustmentData {
+                    state_root: header.state_root,
+                    transactions_root: header.transactions_root,
+                    receipts_root: header.receipts_root,
+                    builder_address,
+                    builder_proof: builder_proof.clone(),
+                    fee_recipient_address,
+                    fee_recipient_proof: fee_recipient_proof.clone(),
+                    fee_payer_address,
+                    fee_payer_proof,
+                    placeholder_transaction_proof: Vec::new(), // TODO:
+                    placeholder_receipt_proof: Vec::new(),     // TODO:
+                },
+            );
+        }
+
+        Ok(bid_adjustments)
     }
 
     /// Standard pre block ETH stuff + space allocation for rlp length

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -121,7 +121,7 @@ pub struct BlockBuildingContext {
     pub tx_execution_cache: Arc<TxExecutionCache>,
     pub mempool_tx_detector: Arc<MempoolTxsDetector>,
     pub faster_finalize: bool,
-
+    pub adjustment_fee_payers: ahash::HashSet<Address>,
     /// Cached from evm_env.block_env.number but as BlockNumber. Avoid conversions all over the code.
     block_number: BlockNumber,
 }
@@ -144,6 +144,7 @@ impl BlockBuildingContext {
         payload_id: InternalPayloadId,
         evm_caching_enable: bool,
         faster_finalize: bool,
+        adjustment_fee_payers: ahash::HashSet<Address>,
     ) -> Option<BlockBuildingContext> {
         let attributes = EthPayloadBuilderAttributes::try_new(
             attributes.data.parent_block_hash,
@@ -216,6 +217,7 @@ impl BlockBuildingContext {
             max_blob_gas_per_block,
             mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
             faster_finalize,
+            adjustment_fee_payers,
             block_number,
         })
     }
@@ -320,6 +322,7 @@ impl BlockBuildingContext {
             max_blob_gas_per_block,
             mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
             faster_finalize: true,
+            adjustment_fee_payers: Default::default(),
             block_number,
         }
     }
@@ -1183,8 +1186,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         placeholder_transaction_proof: Vec<Bytes>,
         placeholder_receipt_proof: Vec<Bytes>,
     ) -> Result<HashMap<Address, BidAdjustmentData>, FinalizeError> {
-        let fee_payer_addresses = HashSet::<Address>::default(); // TODO:
-        if fee_payer_addresses.is_empty() {
+        if ctx.adjustment_fee_payers.is_empty() {
             return Ok(Default::default());
         }
 
@@ -1205,7 +1207,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         let proof_targets = HashSet::from_iter(
             [builder_address, fee_recipient_address]
                 .into_iter()
-                .chain(fee_payer_addresses.clone()),
+                .chain(ctx.adjustment_fee_payers.clone()),
         );
         let mut account_proofs =
             ctx.root_hasher
@@ -1223,8 +1225,8 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         };
 
         let mut bid_adjustments = HashMap::default();
-        for fee_payer_address in fee_payer_addresses {
-            let Some(fee_payer_proof) = account_proofs.remove(&fee_payer_address) else {
+        for fee_payer_address in &ctx.adjustment_fee_payers {
+            let Some(fee_payer_proof) = account_proofs.remove(fee_payer_address) else {
                 error!(
                     %fee_payer_address,
                     "Fee payer proof is missing"
@@ -1233,7 +1235,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             };
 
             bid_adjustments.insert(
-                fee_payer_address,
+                *fee_payer_address,
                 BidAdjustmentData {
                     state_root: header.state_root,
                     transactions_root: header.transactions_root,
@@ -1242,7 +1244,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
                     builder_proof: builder_proof.clone(),
                     fee_recipient_address,
                     fee_recipient_proof: fee_recipient_proof.clone(),
-                    fee_payer_address,
+                    fee_payer_address: *fee_payer_address,
                     fee_payer_proof,
                     placeholder_transaction_proof: placeholder_transaction_proof.clone(),
                     placeholder_receipt_proof: placeholder_receipt_proof.clone(),

--- a/crates/rbuilder/src/building/testing/test_chain_state.rs
+++ b/crates/rbuilder/src/building/testing/test_chain_state.rs
@@ -422,6 +422,7 @@ impl TestBlockContextBuilder {
             0,
             true,
             true,
+            Default::default(),
         )
         .unwrap();
         if self.use_suggested_fee_recipient_as_coinbase {

--- a/crates/rbuilder/src/live_builder/block_output/bid_observer.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bid_observer.rs
@@ -1,10 +1,7 @@
 use alloy_primitives::U256;
 use reth_primitives::SealedBlock;
 
-use crate::{
-    building::BuiltBlockTrace, live_builder::payload_events::MevBoostSlotData,
-    mev_boost::submission::SubmitBlockRequest,
-};
+use crate::{building::BuiltBlockTrace, live_builder::payload_events::MevBoostSlotData};
 
 /// Trait that receives every bid made by us to the relays.
 pub trait BidObserver: std::fmt::Debug {
@@ -14,7 +11,6 @@ pub trait BidObserver: std::fmt::Debug {
         &self,
         slot_data: &MevBoostSlotData,
         sealed_block: &SealedBlock,
-        submit_block_request: &SubmitBlockRequest,
         built_block_trace: &BuiltBlockTrace,
         builder_name: String,
         best_bid_value: U256,
@@ -29,7 +25,6 @@ impl BidObserver for NullBidObserver {
         &self,
         _slot_data: &MevBoostSlotData,
         _sealed_block: &SealedBlock,
-        _submit_block_request: &SubmitBlockRequest,
         _built_block_trace: &BuiltBlockTrace,
         _builder_name: String,
         _best_bid_value: U256,

--- a/crates/rbuilder/src/live_builder/block_output/bid_observer_multiplexer.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bid_observer_multiplexer.rs
@@ -1,9 +1,6 @@
 use reth_primitives::SealedBlock;
 
-use crate::{
-    building::BuiltBlockTrace, live_builder::payload_events::MevBoostSlotData,
-    mev_boost::submission::SubmitBlockRequest,
-};
+use crate::{building::BuiltBlockTrace, live_builder::payload_events::MevBoostSlotData};
 
 use super::bid_observer::BidObserver;
 
@@ -30,7 +27,6 @@ impl BidObserver for BidObserverMultiplexer {
         &self,
         slot_data: &MevBoostSlotData,
         sealed_block: &SealedBlock,
-        submit_block_request: &SubmitBlockRequest,
         built_block_trace: &BuiltBlockTrace,
         builder_name: String,
         best_bid_value: alloy_primitives::U256,
@@ -39,7 +35,6 @@ impl BidObserver for BidObserverMultiplexer {
             obs.block_submitted(
                 slot_data,
                 sealed_block,
-                submit_block_request,
                 built_block_trace,
                 builder_name.clone(),
                 best_bid_value,

--- a/crates/rbuilder/src/live_builder/block_output/bidding/sequential_sealer_bid_maker.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding/sequential_sealer_bid_maker.rs
@@ -183,10 +183,6 @@ fn run_finalize_worker(tasks: flume::Receiver<FinalizeTask>) {
         };
 
         let result = block.finalize_block(&mut local_ctx, payout_tx_val, seen_competition_bid);
-        // if result.is_err() {
-        //     result.expect("fin error");
-        //     unreachable!();
-        // }
-        result_sender.send(result).unwrap_or_default();
+        let _ = result_sender.send(result);
     }
 }

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -2,11 +2,15 @@ use crate::{
     building::builders::Block,
     live_builder::{block_output::bid_observer::BidObserver, payload_events::MevBoostSlotData},
     mev_boost::{
+        adjustment::BidAdjustmentData,
         sign_block_for_relay,
         submission::{BidMetadata, BidValueMetadata, SubmitBlockRequestWithMetadata},
-        BLSBlockSigner, RelayError, SubmitBlockErr, ValidatorSlotData,
+        BLSBlockSigner, RelayError, RelaySlotData, SubmitBlockErr, ValidatorSlotData,
     },
-    primitives::mev_boost::{MevBoostRelayBidSubmitter, MevBoostRelayID},
+    primitives::{
+        built_block::{block_to_execution_payload, SignedBuiltBlock},
+        mev_boost::{MevBoostRelayBidSubmitter, MevBoostRelayID},
+    },
     telemetry::{
         add_relay_submit_time, add_subsidy_value, inc_conn_relay_errors,
         inc_failed_block_simulations, inc_initiated_submissions, inc_other_relay_errors,
@@ -16,14 +20,14 @@ use crate::{
     utils::{duration_ms, error_storage::store_error_event},
 };
 use ahash::HashMap;
-use alloy_primitives::{utils::format_ether, U256};
+use alloy_primitives::{utils::format_ether, Address, U256};
 use mockall::automock;
 use parking_lot::Mutex;
 use reth_chainspec::ChainSpec;
 use std::sync::Arc;
 use tokio::{sync::Notify, time::Instant};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, info_span, trace, warn, Instrument, Span};
+use tracing::{error, error_span, info, info_span, trace, warn, Instrument, Span};
 
 const SIM_ERROR_CATEGORY: &str = "submit_block_simulation";
 
@@ -233,20 +237,25 @@ async fn run_submit_to_relays_job(
         inc_initiated_submissions(optimistic_config.is_some());
         let relay_filter = get_relay_filter(&block);
 
-        let (normal_signed_submission, optimistic_signed_submission) = {
-            let normal_signed_submission = match sign_block_for_relay(
+        let execution_payload = block_to_execution_payload(
+            &config.chain_spec,
+            &slot_data.payload_attributes_event.data,
+            &block.sealed_block,
+        );
+        let (normal_signed_block, optimistic_signed_block) = {
+            let normal_signed_block = match sign_block_for_relay(
                 &config.signer,
                 &block.sealed_block,
-                &block.txs_blobs_sidecars,
-                &block.execution_requests,
-                &config.chain_spec,
                 &slot_data.payload_attributes_event.data,
                 slot_data.slot_data.pubkey,
                 block.trace.bid_value,
             ) {
-                Ok(res) => SubmitBlockRequestWithMetadata {
-                    submission: res,
-                    metadata: bid_metadata.clone(),
+                Ok((message, signature)) => SignedBuiltBlock {
+                    message,
+                    signature,
+                    execution_payload: execution_payload.clone(),
+                    blob_sidecars: block.txs_blobs_sidecars.clone(),
+                    execution_requests: block.execution_requests.clone(),
                 },
                 Err(err) => {
                     error!(parent: &submission_span, err = ?err, "Error signing block for relay");
@@ -254,21 +263,21 @@ async fn run_submit_to_relays_job(
                 }
             };
 
-            let optimistic_signed_submission = if let Some(optimistic_config) = optimistic_config {
+            let optimistic_signed_block = if let Some(optimistic_config) = optimistic_config {
                 match sign_block_for_relay(
                     &optimistic_config.signer,
                     &block.sealed_block,
-                    &block.txs_blobs_sidecars,
-                    &block.execution_requests,
-                    &config.chain_spec,
                     &slot_data.payload_attributes_event.data,
                     slot_data.slot_data.pubkey,
                     block.trace.bid_value,
                 ) {
-                    Ok(res) => Some((
-                        SubmitBlockRequestWithMetadata {
-                            submission: res,
-                            metadata: bid_metadata.clone(),
+                    Ok((message, signature)) => Some((
+                        SignedBuiltBlock {
+                            message,
+                            signature,
+                            execution_payload,
+                            blob_sidecars: block.txs_blobs_sidecars.clone(),
+                            execution_requests: block.execution_requests.clone(),
                         },
                         optimistic_config,
                     )),
@@ -281,13 +290,16 @@ async fn run_submit_to_relays_job(
                 None
             };
 
-            (normal_signed_submission, optimistic_signed_submission)
+            (normal_signed_block, optimistic_signed_block)
         };
 
         mark_submission_start_time(block.trace.orders_sealed_at);
         submit_block_to_relays(
+            &config.chain_spec,
+            &normal_signed_block,
+            &bid_metadata,
+            &block.bid_adjustments,
             &normal_relays,
-            &normal_signed_submission,
             &slot_data.relay_registrations,
             &relay_filter,
             false,
@@ -295,10 +307,13 @@ async fn run_submit_to_relays_job(
             &cancel,
         );
 
-        if let Some((optimistic_signed_submission, _)) = &optimistic_signed_submission {
+        if let Some((optimistic_signed_block, _)) = optimistic_signed_block {
             submit_block_to_relays(
+                &config.chain_spec,
+                &optimistic_signed_block,
+                &bid_metadata,
+                &block.bid_adjustments,
                 &optimistic_relays,
-                optimistic_signed_submission,
                 &slot_data.relay_registrations,
                 &relay_filter,
                 true,
@@ -308,8 +323,11 @@ async fn run_submit_to_relays_job(
         } else {
             // non-optimistic submission to optimistic relays
             submit_block_to_relays(
+                &config.chain_spec,
+                &normal_signed_block,
+                &bid_metadata,
+                &block.bid_adjustments,
                 &optimistic_relays,
-                &normal_signed_submission,
                 &slot_data.relay_registrations,
                 &relay_filter,
                 false,
@@ -323,7 +341,6 @@ async fn run_submit_to_relays_job(
             config.bid_observer.block_submitted(
                 &slot_data,
                 &block.sealed_block,
-                &normal_signed_submission.submission,
                 &block.trace,
                 builder_name,
                 bid_metadata.value.top_competitor_bid.unwrap_or_default(),
@@ -332,10 +349,14 @@ async fn run_submit_to_relays_job(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn submit_block_to_relays(
+    chain_spec: &ChainSpec,
+    signed_block: &SignedBuiltBlock,
+    bid_metadata: &BidMetadata,
+    bid_adjustments: &std::collections::HashMap<Address, BidAdjustmentData>,
     relays: &Vec<MevBoostRelayBidSubmitter>,
-    submission: &SubmitBlockRequestWithMetadata,
-    registrations: &HashMap<MevBoostRelayID, ValidatorSlotData>,
+    registrations: &HashMap<MevBoostRelayID, RelaySlotData>,
     relay_filter: &impl Fn(&MevBoostRelayBidSubmitter) -> bool,
     optimistic: bool,
     submission_span: &Span,
@@ -352,17 +373,33 @@ fn submit_block_to_relays(
                 }
             };
 
+            let adjustment_data = registration
+                .adjustment_fee_payer
+                .and_then(|fee_payer| bid_adjustments.get(&fee_payer).cloned());
+            let submission = match signed_block
+                .clone()
+                .into_request(chain_spec, adjustment_data)
+            {
+                Ok(submission) => SubmitBlockRequestWithMetadata {
+                    submission,
+                    metadata: bid_metadata.clone(),
+                },
+                Err(error) => {
+                    error_span!(parent: submission_span, "request_convert_error", relay = &relay.id(), ?error);
+                    continue;
+                }
+            };
+
             let span = info_span!(parent: submission_span, "relay_submit", relay = &relay.id(), optimistic);
             let relay = relay.clone();
             let cancel = cancel.clone();
-            let submission = submission.clone();
             tokio::spawn(
                 async move {
                     submit_bid_to_the_relay(
                         &relay,
                         cancel.clone(),
                         submission,
-                        registration,
+                        registration.registration,
                         optimistic,
                     )
                     .await;

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -45,8 +45,8 @@ use crate::{
     },
     mev_boost::{bloxroute_grpc, BLSBlockSigner, RelayClient},
     primitives::mev_boost::{
-        MevBoostRelayBidSubmitter, MevBoostRelaySlotInfoProvider, RelayConfig, RelayMode,
-        RelaySubmitConfig,
+        MevBoostRelayBidSubmitter, MevBoostRelayID, MevBoostRelaySlotInfoProvider, RelayConfig,
+        RelayMode, RelaySubmitConfig,
     },
     provider::StateProviderFactory,
     roothash::RootHashContext,
@@ -56,7 +56,7 @@ use alloy_chains::ChainKind;
 use alloy_primitives::{
     hex,
     utils::{format_ether, parse_ether},
-    FixedBytes, B256, U256,
+    Address, FixedBytes, B256, U256,
 };
 use bid_scraper::bid_scraper_client::run_nng_subscriber_with_retries;
 use ethereum_consensus::{
@@ -358,6 +358,7 @@ impl L1Config {
     }
 
     /// Creates the RelaySubmitSinkFactory and also returns the associated relays (MevBoostRelaySlotInfoProvider).
+    #[allow(clippy::type_complexity)]
     pub fn create_relays_sealed_sink_factory(
         &self,
         chain_spec: Arc<ChainSpec>,
@@ -365,6 +366,7 @@ impl L1Config {
     ) -> eyre::Result<(
         Box<dyn BuilderSinkFactory>,
         Vec<MevBoostRelaySlotInfoProvider>,
+        ahash::HashMap<MevBoostRelayID, Address>,
     )> {
         let submission_config = self.submission_config(chain_spec, bid_observer)?;
         info!(
@@ -389,7 +391,17 @@ impl L1Config {
             submission_config,
             submitters.clone(),
         ));
-        Ok((sink_factory, slot_info_providers))
+
+        let adjustment_fee_payers = self
+            .relays
+            .iter()
+            .filter_map(|r| {
+                r.adjustment_fee_payer
+                    .map(|fee_payer| (r.name.clone(), fee_payer))
+            })
+            .collect();
+
+        Ok((sink_factory, slot_info_providers, adjustment_fee_payers))
     }
 
     pub fn registration_update_interval(&self) -> Duration {
@@ -439,15 +451,16 @@ impl LiveBuilderConfig for Config {
                 as Pin<Box<dyn Future<Output = eyre::Result<Arc<dyn BiddingService>>> + Send>>
         };
 
-        let (sink_factory, slot_info_provider, _) = create_sink_factory_and_relays(
-            &self.base_config,
-            &self.l1_config,
-            provider.clone(),
-            Box::new(NullBidObserver {}),
-            bidding_service_factory,
-            cancellation_token.clone(),
-        )
-        .await?;
+        let (sink_factory, slot_info_provider, adjustment_fee_payers, _) =
+            create_sink_factory_and_relays(
+                &self.base_config,
+                &self.l1_config,
+                provider.clone(),
+                Box::new(NullBidObserver {}),
+                bidding_service_factory,
+                cancellation_token.clone(),
+            )
+            .await?;
 
         let live_builder = create_builder_from_sink(
             &self.base_config,
@@ -455,6 +468,7 @@ impl LiveBuilderConfig for Config {
             provider,
             sink_factory,
             slot_info_provider,
+            adjustment_fee_payers,
             cancellation_token,
         )
         .await?;
@@ -954,6 +968,7 @@ pub async fn create_sink_factory_and_relays<P, BiddingServiceFactoryType>(
 ) -> eyre::Result<(
     Box<dyn UnfinishedBlockBuildingSinkFactory>,
     Vec<MevBoostRelaySlotInfoProvider>,
+    ahash::HashMap<MevBoostRelayID, Address>,
     Arc<dyn BiddingServiceWinControl>,
 )>
 where
@@ -964,7 +979,7 @@ where
         Box<dyn Future<Output = eyre::Result<Arc<dyn BiddingService>>> + Send>,
     >,
 {
-    let (sink_sealed_factory, slot_info_provider) =
+    let (sink_sealed_factory, slot_info_provider, adjustment_fee_payers) =
         l1_config.create_relays_sealed_sink_factory(base_config.chain_spec()?, bid_observer)?;
 
     // BlockSealingBidderFactory
@@ -1000,6 +1015,7 @@ where
     Ok((
         sink_factory,
         slot_info_provider,
+        adjustment_fee_payers,
         bidding_service_win_control,
     ))
 }
@@ -1011,6 +1027,7 @@ pub async fn create_builder_from_sink<P>(
     provider: P,
     sink_factory: Box<dyn UnfinishedBlockBuildingSinkFactory>,
     slot_info_provider: Vec<MevBoostRelaySlotInfoProvider>,
+    adjustment_fee_payers: ahash::HashMap<MevBoostRelayID, Address>,
     cancellation_token: CancellationToken,
 ) -> eyre::Result<super::LiveBuilder<P, MevBoostSlotDataGenerator>>
 where
@@ -1024,6 +1041,7 @@ where
         l1_config.beacon_clients()?,
         slot_info_provider,
         l1_config.registration_update_interval(),
+        adjustment_fee_payers,
         blocklist_provider.clone(),
         cancellation_token.clone(),
     );

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -312,6 +312,11 @@ where
                 payload.payload_id,
                 self.evm_caching_enable,
                 self.faster_finalize,
+                payload
+                    .relay_registrations
+                    .iter()
+                    .filter_map(|(_, r)| r.adjustment_fee_payer)
+                    .collect(),
             ) {
                 mark_building_started(block_ctx.timestamp());
                 builder_pool.start_block_building(

--- a/crates/rbuilder/src/live_builder/payload_events/mod.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         SlotSource,
     },
-    mev_boost::ValidatorSlotData,
+    mev_boost::RelaySlotData,
     primitives::mev_boost::{MevBoostRelayID, MevBoostRelaySlotInfoProvider},
     utils::{format_offset_datetime_rfc3339, timestamp_ms_to_offset_datetime},
 };
@@ -49,7 +49,7 @@ pub struct MevBoostSlotData {
     pub payload_attributes_event: PayloadAttributesEvent,
     pub suggested_gas_limit: u64,
     /// Map of relays to the registrations with matching slot data. It may not contain all the relays (eg: errors, forks, validators registering only to some relays)
-    pub relay_registrations: Arc<HashMap<MevBoostRelayID, ValidatorSlotData>>,
+    pub relay_registrations: Arc<HashMap<MevBoostRelayID, RelaySlotData>>,
     pub slot_data: SlotData,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub payload_id: InternalPayloadId,
@@ -100,6 +100,7 @@ pub struct MevBoostSlotDataGenerator {
     cls: Vec<Client>,
     relays: Vec<MevBoostRelaySlotInfoProvider>,
     update_interval: Duration,
+    adjustment_fee_payers: HashMap<MevBoostRelayID, Address>,
     blocklist_provider: Arc<dyn BlockListProvider>,
     global_cancellation: CancellationToken,
 }
@@ -109,6 +110,7 @@ impl MevBoostSlotDataGenerator {
         cls: Vec<Client>,
         relays: Vec<MevBoostRelaySlotInfoProvider>,
         update_interval: Duration,
+        adjustment_fee_payers: HashMap<MevBoostRelayID, Address>,
         blocklist_provider: Arc<dyn BlockListProvider>,
         global_cancellation: CancellationToken,
     ) -> Self {
@@ -116,6 +118,7 @@ impl MevBoostSlotDataGenerator {
             cls,
             relays,
             update_interval,
+            adjustment_fee_payers,
             blocklist_provider,
             global_cancellation,
         }
@@ -133,6 +136,7 @@ impl MevBoostSlotDataGenerator {
         let relays = RelaysForSlotData::spawn_with_interval(
             self.relays.clone(),
             self.update_interval,
+            self.adjustment_fee_payers.clone(),
             self.global_cancellation.clone(),
         );
 

--- a/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
@@ -1,5 +1,5 @@
 use crate::{
-    mev_boost::{RelayError, ValidatorSlotData},
+    mev_boost::{RelayError, RelaySlotData, ValidatorSlotData},
     primitives::mev_boost::{MevBoostRelayID, MevBoostRelaySlotInfoProvider},
     telemetry::{inc_conn_relay_errors, inc_other_relay_errors, inc_too_many_req_relay_errors},
 };
@@ -87,6 +87,8 @@ impl RelayValidatorSlotDataCache {
 pub struct RelaysForSlotData {
     /// Validator registration cache.
     cache: RelayValidatorSlotDataCache,
+    /// Adjustment fee payer addresses by relay.
+    adjustment_fee_payers: HashMap<MevBoostRelayID, Address>,
     /// Redundant with relay but easier to access/pass around.
     can_ignore_gas_limit: HashSet<MevBoostRelayID>,
 }
@@ -95,6 +97,7 @@ impl RelaysForSlotData {
     pub fn spawn_with_interval(
         relays: Vec<MevBoostRelaySlotInfoProvider>,
         interval: Duration,
+        adjustment_fee_payers: HashMap<MevBoostRelayID, Address>,
         cancellation_token: CancellationToken,
     ) -> Self {
         let cache = RelayValidatorSlotDataCache::default();
@@ -122,6 +125,7 @@ impl RelaysForSlotData {
         Self {
             cache,
             can_ignore_gas_limit,
+            adjustment_fee_payers,
         }
     }
 
@@ -131,35 +135,46 @@ impl RelaysForSlotData {
     pub fn slot_data(
         &mut self,
         slot: u64,
-    ) -> Option<(SlotData, Arc<HashMap<MevBoostRelayID, ValidatorSlotData>>)> {
+    ) -> Option<(SlotData, Arc<HashMap<MevBoostRelayID, RelaySlotData>>)> {
         let registrations = self.cache.get_slot_registrations(slot);
-        resolve_relay_slot_data(registrations, &self.can_ignore_gas_limit)
+        let (slot_data, registrations) = resolve_relay_slot_data(
+            registrations,
+            &self.adjustment_fee_payers,
+            &self.can_ignore_gas_limit,
+        )?;
+        Some((slot_data, registrations))
     }
 }
 
 fn resolve_relay_slot_data(
     fetched_data: Vec<(MevBoostRelayID, ValidatorSlotData)>,
+    adjustment_fee_payers: &HashMap<MevBoostRelayID, Address>,
     can_ignore_gas_limit: &HashSet<MevBoostRelayID>,
-) -> Option<(SlotData, Arc<HashMap<MevBoostRelayID, ValidatorSlotData>>)> {
+) -> Option<(SlotData, Arc<HashMap<MevBoostRelayID, RelaySlotData>>)> {
     if fetched_data.is_empty() {
         return None;
     }
 
-    let mut registrations_by_slot_data: HashMap<
-        SlotData,
-        HashMap<MevBoostRelayID, ValidatorSlotData>,
-    > = HashMap::default();
+    let mut registrations_by_slot_data: HashMap<SlotData, HashMap<MevBoostRelayID, RelaySlotData>> =
+        HashMap::default();
 
-    for (relay, raw_data) in fetched_data {
+    for (relay, registration) in fetched_data {
         let slot_data = SlotData {
-            fee_recipient: raw_data.entry.message.fee_recipient,
-            gas_limit: raw_data.entry.message.gas_limit,
-            pubkey: raw_data.entry.message.pubkey,
+            fee_recipient: registration.entry.message.fee_recipient,
+            gas_limit: registration.entry.message.gas_limit,
+            pubkey: registration.entry.message.pubkey,
         };
+        let maybe_fee_payer = adjustment_fee_payers.get(&relay).copied();
         registrations_by_slot_data
             .entry(slot_data)
             .or_default()
-            .insert(relay, raw_data);
+            .insert(
+                relay,
+                RelaySlotData {
+                    registration,
+                    adjustment_fee_payer: maybe_fee_payer,
+                },
+            );
     }
 
     // all relays returned the same data
@@ -173,7 +188,7 @@ fn resolve_relay_slot_data(
         .iter()
         .max_by_key(|(_, v)| {
             v.values()
-                .map(|r| r.entry.message.timestamp)
+                .map(|r| r.registration.entry.message.timestamp)
                 .max()
                 .unwrap_or_default()
         })
@@ -209,20 +224,23 @@ mod test {
     use super::*;
     use alloy_primitives::{address, Bytes};
 
-    fn make_test_data(fee_recipient: Address, timestamp: u64) -> ValidatorSlotData {
-        ValidatorSlotData {
-            entry: ValidatorRegistration {
-                message: ValidatorRegistrationMessage {
-                    fee_recipient,
-                    gas_limit: 30000000,
-                    timestamp,
-                    pubkey: H384::zero(),
+    fn make_test_data(fee_recipient: Address, timestamp: u64) -> RelaySlotData {
+        RelaySlotData {
+            registration: ValidatorSlotData {
+                entry: ValidatorRegistration {
+                    message: ValidatorRegistrationMessage {
+                        fee_recipient,
+                        gas_limit: 30000000,
+                        timestamp,
+                        pubkey: H384::zero(),
+                    },
+                    signature: Bytes::new(),
                 },
-                signature: Bytes::new(),
+                validator_index: 1,
+                slot: 2,
+                regional_endpoints: Vec::new(),
             },
-            validator_index: 1,
-            slot: 2,
-            regional_endpoints: Vec::new(),
+            adjustment_fee_payer: None,
         }
     }
 
@@ -237,11 +255,12 @@ mod test {
         let data = make_test_data(address!("1111111111111111111111111111111111111111"), 100);
 
         let fetched = vec![
-            (relay1.clone(), data.clone()),
-            (relay2.clone(), data.clone()),
+            (relay1.clone(), data.registration.clone()),
+            (relay2.clone(), data.registration.clone()),
         ];
 
-        let result = resolve_relay_slot_data(fetched.clone(), &HashSet::default());
+        let result =
+            resolve_relay_slot_data(fetched.clone(), &Default::default(), &HashSet::default());
         let (slot_data, relays) = result.unwrap();
         assert_eq!(
             SlotData {
@@ -251,16 +270,27 @@ mod test {
             },
             slot_data
         );
-        assert_eq!(relays, Arc::new(HashMap::from_iter(fetched)));
+        assert_eq!(
+            relays,
+            Arc::new(HashMap::from_iter(fetched.into_iter().map(
+                |(relay, registration)| (
+                    relay,
+                    RelaySlotData {
+                        registration,
+                        adjustment_fee_payer: None
+                    }
+                )
+            )))
+        );
 
         // Test when relays return different data (should pick latest timestamp)
         let data2 = make_test_data(address!("2222222222222222222222222222222222222222"), 200);
         let fetched = vec![
-            (relay1.clone(), data.clone()),
-            (relay2.clone(), data2.clone()),
+            (relay1.clone(), data.registration.clone()),
+            (relay2.clone(), data2.registration.clone()),
         ];
 
-        let result = resolve_relay_slot_data(fetched, &HashSet::default());
+        let result = resolve_relay_slot_data(fetched, &Default::default(), &HashSet::default());
         let (slot_data, relays) = result.unwrap();
         assert_eq!(
             SlotData {
@@ -277,17 +307,17 @@ mod test {
 
         // Test when relays return different gas limit but same fee recipient and pubkey
         let mut data3 = data2.clone();
-        data3.entry.message.gas_limit = 40000000;
+        data3.registration.entry.message.gas_limit = 40000000;
         // We want data2 to win.
-        data3.entry.message.timestamp -= 1;
+        data3.registration.entry.message.timestamp -= 1;
         let fetched = vec![
-            (relay1.clone(), data.clone()),
-            (relay2.clone(), data2.clone()),
-            (relay3.clone(), data3.clone()),
+            (relay1.clone(), data.registration.clone()),
+            (relay2.clone(), data2.registration.clone()),
+            (relay3.clone(), data3.registration.clone()),
         ];
 
         // No can_ignore_gas_limit
-        let result = resolve_relay_slot_data(fetched, &HashSet::default());
+        let result = resolve_relay_slot_data(fetched, &Default::default(), &HashSet::default());
         let (slot_data, relays) = result.unwrap();
         assert_eq!(
             SlotData {
@@ -304,12 +334,12 @@ mod test {
 
         // data3 can_ignore_gas_limit
         let fetched = vec![
-            (relay1.clone(), data.clone()),
-            (relay2.clone(), data2.clone()),
-            (relay3.clone(), data3.clone()),
+            (relay1.clone(), data.registration.clone()),
+            (relay2.clone(), data2.registration.clone()),
+            (relay3.clone(), data3.registration.clone()),
         ];
         let can_ignore_gas_limit = HashSet::from_iter([relay3.clone()]);
-        let result = resolve_relay_slot_data(fetched, &can_ignore_gas_limit);
+        let result = resolve_relay_slot_data(fetched, &Default::default(), &can_ignore_gas_limit);
         let (slot_data, relays) = result.unwrap();
         assert_eq!(
             SlotData {

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -303,6 +303,15 @@ pub enum RelayResponse<T> {
     Error(RedactableRelayErrorResponse),
 }
 
+/// Relay validator registration with auxilary data.
+#[derive(PartialEq, Debug, Clone)]
+pub struct RelaySlotData {
+    /// Validator slot registration.
+    pub registration: ValidatorSlotData,
+    /// Fee payer address for bid adjustments.
+    pub adjustment_fee_payer: Option<Address>,
+}
+
 /// Info about a registered validator selected as proposer for a slot.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash)]
@@ -581,6 +590,11 @@ impl RelayClient {
             url.set_path("/relay/v1/builder/blocks");
             url.query_pairs_mut()
                 .append_pair("cancellations", if cancellations { "1" } else { "0" });
+
+            if submission_with_metadata.submission.has_adjustment_data() {
+                url.query_pairs_mut().append_pair("adjustments", "1");
+            }
+
             url
         };
 

--- a/crates/rbuilder/src/mev_boost/sign_payload.rs
+++ b/crates/rbuilder/src/mev_boost/sign_payload.rs
@@ -1,23 +1,8 @@
-use super::submission::{
-    CapellaSubmitBlockRequest, DenebSubmitBlockRequest, ElectraSubmitBlockRequest,
-    FuluSubmitBlockRequest, SubmitBlockRequest,
-};
 use crate::utils::u256decimal_serde_helper;
-use alloy_eips::eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant};
-use alloy_eips::eip7685::Requests;
-use alloy_eips::{eip2718::Encodable2718, eip4844::BlobTransactionSidecar};
-use alloy_primitives::{Address, BlockHash, Bytes, FixedBytes, B256, U256};
-use alloy_rpc_types_beacon::relay::SignedBidSubmissionV5;
-use alloy_rpc_types_beacon::requests::ExecutionRequestsV4;
+use alloy_primitives::{Address, BlockHash, FixedBytes, B256, U256};
 use alloy_rpc_types_beacon::{
-    events::PayloadAttributesData,
-    relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
-    BlsPublicKey,
+    events::PayloadAttributesData, relay::BidTrace, BlsPublicKey, BlsSignature,
 };
-use alloy_rpc_types_engine::{
-    BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
-};
-use alloy_rpc_types_eth::Withdrawal;
 use ethereum_consensus::{
     crypto::SecretKey,
     primitives::{BlsPublicKey as BlsPublicKey2, ExecutionAddress, Hash32},
@@ -25,10 +10,8 @@ use ethereum_consensus::{
     ssz::prelude::*,
 };
 use primitive_types::H384;
-use reth_chainspec::{ChainSpec, EthereumHardforks};
 use reth_primitives::SealedBlock;
 use serde_with::{serde_as, DisplayFromStr};
-use std::sync::Arc;
 
 /// Object to sign blocks to be sent to relays.
 #[derive(Debug, Clone)]
@@ -118,20 +101,13 @@ fn a2e_address(a: &Address) -> ExecutionAddress {
     ExecutionAddress::try_from(a.as_slice()).unwrap()
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn sign_block_for_relay(
     signer: &BLSBlockSigner,
     sealed_block: &SealedBlock,
-    blobs_bundle: &[Arc<BlobTransactionSidecarVariant>],
-    execution_requests: &[Bytes], // The Pectra execution requests for this bid.
-    chain_spec: &ChainSpec,
     attrs: &PayloadAttributesData,
     pubkey: H384,
     value: U256,
-) -> eyre::Result<SubmitBlockRequest> {
-    // TODO: add support for bid adjustments
-    let adjustment_data = None;
-
+) -> eyre::Result<(BidTrace, BlsSignature)> {
     let message = BidTrace {
         slot: attrs.proposal_slot,
         parent_hash: attrs.parent_block_hash,
@@ -143,175 +119,8 @@ pub fn sign_block_for_relay(
         gas_used: sealed_block.gas_used,
         value,
     };
-
     let signature = signer.sign_payload(&message)?;
-    let signature = FixedBytes::from_slice(&signature);
-
-    let capella_payload = ExecutionPayloadV2 {
-        payload_inner: ExecutionPayloadV1 {
-            parent_hash: sealed_block.parent_hash,
-            fee_recipient: sealed_block.beneficiary,
-            state_root: sealed_block.state_root,
-            receipts_root: sealed_block.receipts_root,
-            logs_bloom: sealed_block.logs_bloom,
-            prev_randao: attrs.payload_attributes.prev_randao,
-            block_number: sealed_block.number,
-            gas_limit: sealed_block.gas_limit,
-            gas_used: sealed_block.gas_used,
-            timestamp: sealed_block.timestamp,
-            extra_data: sealed_block.extra_data.clone(),
-            base_fee_per_gas: U256::from(sealed_block.base_fee_per_gas.unwrap_or_default()),
-            block_hash: sealed_block.hash(),
-            transactions: sealed_block
-                .body()
-                .transactions
-                .iter()
-                .map(|tx| {
-                    let mut buf = Vec::new();
-                    tx.encode_2718(&mut buf);
-                    buf.into()
-                })
-                .collect(),
-        },
-        withdrawals: sealed_block
-            .body()
-            .withdrawals
-            .clone()
-            .map(|w| {
-                w.into_iter()
-                    .map(|w| Withdrawal {
-                        index: w.index,
-                        validator_index: w.validator_index,
-                        address: w.address,
-                        amount: w.amount,
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default(),
-    };
-
-    let request = if chain_spec.is_cancun_active_at_timestamp(sealed_block.timestamp) {
-        let execution_payload = ExecutionPayloadV3 {
-            payload_inner: capella_payload,
-            blob_gas_used: sealed_block
-                .blob_gas_used
-                .expect("deneb block does not have blob gas used"),
-            excess_blob_gas: sealed_block
-                .excess_blob_gas
-                .expect("deneb block does not have excess blob gas"),
-        };
-
-        let execution_requests =
-            ExecutionRequestsV4::try_from(Requests::new(execution_requests.to_vec()))?;
-
-        if chain_spec.is_osaka_active_at_timestamp(sealed_block.timestamp) {
-            let blobs_bundle_v2 = marshall_txs_blobs_sidecars_v2(blobs_bundle);
-
-            let submission = SignedBidSubmissionV5 {
-                message,
-                execution_payload,
-                blobs_bundle: blobs_bundle_v2,
-                signature,
-                execution_requests,
-            };
-
-            SubmitBlockRequest::fulu(FuluSubmitBlockRequest::new(submission, adjustment_data))
-        } else if chain_spec.is_prague_active_at_timestamp(sealed_block.timestamp) {
-            let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
-
-            let submission = SignedBidSubmissionV4 {
-                message,
-                execution_payload,
-                blobs_bundle,
-                signature,
-                execution_requests,
-            };
-            SubmitBlockRequest::electra(ElectraSubmitBlockRequest::new(submission, adjustment_data))
-        } else {
-            let blobs_bundle = marshal_txs_blobs_sidecars(blobs_bundle);
-
-            let submission = SignedBidSubmissionV3 {
-                message,
-                execution_payload,
-                blobs_bundle,
-                signature,
-            };
-            SubmitBlockRequest::deneb(DenebSubmitBlockRequest::new(submission, adjustment_data))
-        }
-    } else {
-        let submission = SignedBidSubmissionV2 {
-            message,
-            execution_payload: capella_payload,
-            signature,
-        };
-        SubmitBlockRequest::capella(CapellaSubmitBlockRequest::new(submission, adjustment_data))
-    };
-
-    Ok(request)
-}
-
-fn marshal_txs_blobs_sidecars(
-    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarVariant>],
-) -> BlobsBundleV1 {
-    // Instead of collecting Arc<BlobTransactionSidecar>, just collect references to the inner struct.
-    let eip4844_sidecars: Vec<&BlobTransactionSidecar> = txs_blobs_sidecars
-        .iter()
-        .filter_map(|blob| blob.as_ref().as_eip4844())
-        .collect();
-
-    // Now flatten the fields, only cloning the inner data, not the whole struct or Arc.
-    let commitments = eip4844_sidecars
-        .iter()
-        .flat_map(|t| t.commitments.iter().cloned())
-        .collect();
-
-    let proofs = eip4844_sidecars
-        .iter()
-        .flat_map(|t| t.proofs.iter().cloned())
-        .collect();
-
-    let blobs = eip4844_sidecars
-        .iter()
-        .flat_map(|t| t.blobs.iter().cloned())
-        .collect();
-
-    BlobsBundleV1 {
-        commitments,
-        proofs,
-        blobs,
-    }
-}
-
-fn marshall_txs_blobs_sidecars_v2(
-    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarVariant>],
-) -> BlobsBundleV2 {
-    // Instead of collecting Arc<BlobTransactionSidecarEip7594>, just collect references to the inner struct.
-    let eip7594_sidecars: Vec<&BlobTransactionSidecarEip7594> = txs_blobs_sidecars
-        .iter()
-        .filter_map(|blob| blob.as_ref().as_eip7594())
-        .collect();
-
-    // Now flatten the fields, only cloning the inner data, not the whole struct or Arc.
-    let commitments = eip7594_sidecars
-        .iter()
-        .flat_map(|t| t.commitments.iter().cloned())
-        .collect();
-
-    let proofs = eip7594_sidecars
-        .iter()
-        .flat_map(|t| t.cell_proofs.iter().cloned())
-        .collect();
-
-    let blobs = eip7594_sidecars
-        .iter()
-        .flat_map(|t| t.blobs.iter().cloned())
-        .collect();
-
-    BlobsBundleV2 {
-        commitments,
-        proofs,
-        blobs,
-    }
+    Ok((message, FixedBytes::from_slice(&signature)))
 }
 
 #[cfg(test)]

--- a/crates/rbuilder/src/mev_boost/submission.rs
+++ b/crates/rbuilder/src/mev_boost/submission.rs
@@ -1,7 +1,9 @@
 use alloy_primitives::U256;
-use alloy_rpc_types_beacon::relay::SignedBidSubmissionV5;
 use alloy_rpc_types_beacon::{
-    relay::{BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4},
+    relay::{
+        BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4,
+        SignedBidSubmissionV5,
+    },
     requests::ExecutionRequestsV4,
     BlsSignature,
 };
@@ -53,6 +55,16 @@ impl SubmitBlockRequest {
             SubmitBlockRequest::Deneb(req) => &req.message,
             SubmitBlockRequest::Electra(req) => &req.message,
         }
+    }
+
+    pub fn has_adjustment_data(&self) -> bool {
+        let maybe_adjustment_data = match self {
+            SubmitBlockRequest::Capella(req) => &req.adjustment_data,
+            SubmitBlockRequest::Deneb(req) => &req.adjustment_data,
+            SubmitBlockRequest::Electra(req) => &req.adjustment_data,
+            SubmitBlockRequest::Fulu(req) => &req.adjustment_data,
+        };
+        maybe_adjustment_data.is_some()
     }
 }
 

--- a/crates/rbuilder/src/primitives/built_block.rs
+++ b/crates/rbuilder/src/primitives/built_block.rs
@@ -1,0 +1,234 @@
+use crate::mev_boost::{
+    adjustment::BidAdjustmentData,
+    submission::{
+        CapellaSubmitBlockRequest, DenebSubmitBlockRequest, ElectraSubmitBlockRequest,
+        FuluSubmitBlockRequest, SubmitBlockRequest,
+    },
+};
+use alloy_eips::{
+    eip2718::Encodable2718,
+    eip4844::BlobTransactionSidecar,
+    eip7594::{BlobTransactionSidecarEip7594, BlobTransactionSidecarVariant},
+    eip7685::Requests,
+};
+use alloy_primitives::{Bytes, U256};
+use alloy_rpc_types::Withdrawals;
+use alloy_rpc_types_beacon::{
+    events::PayloadAttributesData,
+    relay::{
+        BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4,
+        SignedBidSubmissionV5,
+    },
+    requests::ExecutionRequestsV4,
+    BlsSignature,
+};
+use alloy_rpc_types_engine::{
+    BlobsBundleV1, BlobsBundleV2, ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2,
+    ExecutionPayloadV3,
+};
+use reth_chainspec::{ChainSpec, EthereumHardforks};
+use reth_primitives::SealedBlock;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct SignedBuiltBlock {
+    pub message: BidTrace,
+    pub signature: BlsSignature,
+    pub execution_payload: ExecutionPayload,
+    pub blob_sidecars: Vec<Arc<BlobTransactionSidecarVariant>>,
+    pub execution_requests: Vec<Bytes>,
+}
+
+impl SignedBuiltBlock {
+    pub fn into_request(
+        self,
+        chain_spec: &ChainSpec,
+        adjustment_data: Option<BidAdjustmentData>,
+    ) -> eyre::Result<SubmitBlockRequest> {
+        match self.execution_payload {
+            ExecutionPayload::V1(_v1) => {
+                eyre::bail!("v1 payloads are not supported");
+            }
+            ExecutionPayload::V2(v2) => {
+                let submission = SignedBidSubmissionV2 {
+                    message: self.message,
+                    execution_payload: v2,
+                    signature: self.signature,
+                };
+                Ok(SubmitBlockRequest::capella(CapellaSubmitBlockRequest::new(
+                    submission,
+                    adjustment_data,
+                )))
+            }
+            ExecutionPayload::V3(v3) => {
+                if chain_spec.is_osaka_active_at_timestamp(v3.timestamp()) {
+                    let execution_requests = ExecutionRequestsV4::try_from(Requests::new(
+                        self.execution_requests.to_vec(),
+                    ))?;
+                    let blobs_bundle_v2 = marshall_txs_blobs_sidecars_v2(&self.blob_sidecars);
+                    let submission = SignedBidSubmissionV5 {
+                        message: self.message,
+                        execution_payload: v3,
+                        blobs_bundle: blobs_bundle_v2,
+                        signature: self.signature,
+                        execution_requests,
+                    };
+                    return Ok(SubmitBlockRequest::fulu(FuluSubmitBlockRequest::new(
+                        submission,
+                        adjustment_data,
+                    )));
+                }
+
+                let blobs_bundle = marshal_txs_blobs_sidecars(&self.blob_sidecars);
+                if chain_spec.is_prague_active_at_timestamp(v3.timestamp()) {
+                    let execution_requests = ExecutionRequestsV4::try_from(Requests::new(
+                        self.execution_requests.to_vec(),
+                    ))?;
+                    let submission = SignedBidSubmissionV4 {
+                        message: self.message,
+                        execution_payload: v3,
+                        blobs_bundle,
+                        signature: self.signature,
+                        execution_requests,
+                    };
+                    return Ok(SubmitBlockRequest::electra(ElectraSubmitBlockRequest::new(
+                        submission,
+                        adjustment_data,
+                    )));
+                }
+
+                let submission = SignedBidSubmissionV3 {
+                    message: self.message,
+                    execution_payload: v3,
+                    blobs_bundle,
+                    signature: self.signature,
+                };
+                Ok(SubmitBlockRequest::deneb(DenebSubmitBlockRequest::new(
+                    submission,
+                    adjustment_data,
+                )))
+            }
+        }
+    }
+}
+
+fn marshal_txs_blobs_sidecars(
+    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarVariant>],
+) -> BlobsBundleV1 {
+    // Instead of collecting Arc<BlobTransactionSidecar>, just collect references to the inner struct.
+    let eip4844_sidecars: Vec<&BlobTransactionSidecar> = txs_blobs_sidecars
+        .iter()
+        .filter_map(|blob| blob.as_ref().as_eip4844())
+        .collect();
+
+    // Now flatten the fields, only cloning the inner data, not the whole struct or Arc.
+    let commitments = eip4844_sidecars
+        .iter()
+        .flat_map(|t| t.commitments.iter().cloned())
+        .collect();
+
+    let proofs = eip4844_sidecars
+        .iter()
+        .flat_map(|t| t.proofs.iter().cloned())
+        .collect();
+
+    let blobs = eip4844_sidecars
+        .iter()
+        .flat_map(|t| t.blobs.iter().cloned())
+        .collect();
+
+    BlobsBundleV1 {
+        commitments,
+        proofs,
+        blobs,
+    }
+}
+
+fn marshall_txs_blobs_sidecars_v2(
+    txs_blobs_sidecars: &[Arc<BlobTransactionSidecarVariant>],
+) -> BlobsBundleV2 {
+    // Instead of collecting Arc<BlobTransactionSidecarEip7594>, just collect references to the inner struct.
+    let eip7594_sidecars: Vec<&BlobTransactionSidecarEip7594> = txs_blobs_sidecars
+        .iter()
+        .filter_map(|blob| blob.as_ref().as_eip7594())
+        .collect();
+
+    // Now flatten the fields, only cloning the inner data, not the whole struct or Arc.
+    let commitments = eip7594_sidecars
+        .iter()
+        .flat_map(|t| t.commitments.iter().cloned())
+        .collect();
+
+    let proofs = eip7594_sidecars
+        .iter()
+        .flat_map(|t| t.cell_proofs.iter().cloned())
+        .collect();
+
+    let blobs = eip7594_sidecars
+        .iter()
+        .flat_map(|t| t.blobs.iter().cloned())
+        .collect();
+
+    BlobsBundleV2 {
+        commitments,
+        proofs,
+        blobs,
+    }
+}
+
+/// Utility function to convert built block to execution payload.
+pub fn block_to_execution_payload(
+    chain_spec: &ChainSpec,
+    attrs: &PayloadAttributesData,
+    sealed_block: &SealedBlock,
+) -> ExecutionPayload {
+    let transactions = sealed_block
+        .body()
+        .transactions
+        .iter()
+        .map(|tx| {
+            let mut buf = Vec::new();
+            tx.encode_2718(&mut buf);
+            buf.into()
+        })
+        .collect();
+    let payload_v1 = ExecutionPayloadV1 {
+        parent_hash: sealed_block.parent_hash,
+        fee_recipient: sealed_block.beneficiary,
+        state_root: sealed_block.state_root,
+        receipts_root: sealed_block.receipts_root,
+        logs_bloom: sealed_block.logs_bloom,
+        prev_randao: attrs.payload_attributes.prev_randao,
+        block_number: sealed_block.number,
+        gas_limit: sealed_block.gas_limit,
+        gas_used: sealed_block.gas_used,
+        timestamp: sealed_block.timestamp,
+        extra_data: sealed_block.extra_data.clone(),
+        base_fee_per_gas: U256::from(sealed_block.base_fee_per_gas.unwrap_or_default()),
+        block_hash: sealed_block.hash(),
+        transactions,
+    };
+    let payload_v2 = ExecutionPayloadV2 {
+        payload_inner: payload_v1,
+        withdrawals: sealed_block
+            .body()
+            .withdrawals
+            .clone()
+            .map(Withdrawals::into_inner)
+            .unwrap_or_default(),
+    };
+
+    if chain_spec.is_cancun_active_at_timestamp(sealed_block.timestamp) {
+        ExecutionPayload::V3(ExecutionPayloadV3 {
+            payload_inner: payload_v2,
+            blob_gas_used: sealed_block
+                .blob_gas_used
+                .expect("deneb block does not have blob gas used"),
+            excess_blob_gas: sealed_block
+                .excess_blob_gas
+                .expect("deneb block does not have excess blob gas"),
+        })
+    } else {
+        ExecutionPayload::V2(payload_v2)
+    }
+}

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -1,5 +1,6 @@
 //! Order types used as elements for block building.
 
+pub mod built_block;
 pub mod fmt;
 pub mod mev_boost;
 pub mod order_builder;

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -36,6 +36,7 @@ use tracing::{trace, trace_span};
 
 use crate::{
     building::ThreadBlockBuildingContext, live_builder::simulation::SimulatedOrderCommand,
+    roothash::RootHashError,
 };
 
 use super::{RootHasher, StateProviderFactory};
@@ -444,13 +445,22 @@ impl RootHasher for StatRootHashCalculator {
         unimplemented!()
     }
 
+    fn account_proofs(
+        &self,
+        _outcome: &reth_provider::ExecutionOutcome,
+        _addresses: &eth_sparse_mpt::utils::HashSet<Address>,
+        _local_ctx: &mut ThreadBlockBuildingContext,
+    ) -> Result<eth_sparse_mpt::utils::HashMap<Address, Vec<Bytes>>, RootHashError> {
+        Err(RootHashError::Other(eyre::eyre!("method not implemented")))
+    }
+
     /// Calculates the state root given changed accounts
     /// IMPORTANT: Assumes IPC provider (node) has RPC call:"rbuilder_calculateStateRoot"
     fn state_root(
         &self,
         outcome: &reth_provider::ExecutionOutcome,
         _local_ctx: &mut ThreadBlockBuildingContext,
-    ) -> Result<B256, crate::roothash::RootHashError> {
+    ) -> Result<B256, RootHashError> {
         let account_diff: HashMap<Address, AccountDiff> = outcome
             .bundle
             .state
@@ -463,7 +473,7 @@ impl RootHasher for StatRootHashCalculator {
             "rbuilder_calculateStateRoot",
             (BlockId::Hash(self.parent_hash.into()), account_diff),
         )
-        .map_err(|err| crate::roothash::RootHashError::Other(err.into()))?;
+        .map_err(|err| RootHashError::Other(err.into()))?;
 
         Ok(hash)
     }

--- a/crates/rbuilder/src/provider/mod.rs
+++ b/crates/rbuilder/src/provider/mod.rs
@@ -1,10 +1,11 @@
-use crate::roothash::RootHashError;
 use crate::{
     building::ThreadBlockBuildingContext, live_builder::simulation::SimulatedOrderCommand,
+    roothash::RootHashError,
 };
 use alloy_consensus::Header;
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{BlockHash, BlockNumber, B256};
+use alloy_primitives::{Address, BlockHash, BlockNumber, Bytes, B256};
+use eth_sparse_mpt::utils::{HashMap, HashSet};
 use reth::providers::ExecutionOutcome;
 use reth_errors::ProviderResult;
 use reth_provider::StateProviderBox;
@@ -57,4 +58,12 @@ pub trait RootHasher: std::fmt::Debug + Send + Sync {
         outcome: &ExecutionOutcome,
         local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<B256, RootHashError>;
+
+    /// Generate the account proof for the target address.
+    fn account_proofs(
+        &self,
+        outcome: &ExecutionOutcome,
+        addresses: &HashSet<Address>,
+        local_ctx: &mut ThreadBlockBuildingContext,
+    ) -> Result<HashMap<Address, Vec<Bytes>>, RootHashError>;
 }

--- a/crates/rbuilder/src/roothash/mod.rs
+++ b/crates/rbuilder/src/roothash/mod.rs
@@ -1,7 +1,6 @@
 mod prefetcher;
-
 use alloy_eips::BlockNumHash;
-use alloy_primitives::B256;
+use alloy_primitives::{Address, Bytes, B256};
 use eth_sparse_mpt::*;
 use reth::providers::{providers::ConsistentDbView, ExecutionOutcome};
 use reth_provider::{BlockReader, DatabaseProviderFactory, HashedPostStateProvider};
@@ -65,6 +64,44 @@ impl RootHashContext {
             thread_pool,
         }
     }
+}
+
+pub fn calculate_account_proofs<P>(
+    provider: P,
+    parent_num_hash: BlockNumHash,
+    outcome: &ExecutionOutcome,
+    addresses: &utils::HashSet<Address>,
+    shared_cache: &SparseTrieSharedCache,
+    local_cache: &mut SparseTrieLocalCache,
+    config: &RootHashContext,
+) -> Result<utils::HashMap<Address, Vec<Bytes>>, RootHashError>
+where
+    P: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync + Clone + 'static,
+{
+    let consistent_db_view = match config.mode {
+        RootHashMode::CorrectRoot => ConsistentDbView::new(
+            provider.clone(),
+            Some((parent_num_hash.hash, parent_num_hash.number)),
+        ),
+        RootHashMode::IgnoreParentHash => ConsistentDbView::new_with_latest_tip(provider.clone())
+            .map_err(|err| RootHashError::Other(err.into()))?,
+    };
+
+    let (result, metrics) = calculate_account_proofs_with_sparse_trie(
+        consistent_db_view,
+        outcome,
+        addresses,
+        shared_cache,
+        local_cache,
+        &config.thread_pool,
+        config.sparse_mpt_version,
+    );
+    inc_root_hash_finalize_count(metrics.fetched_nodes);
+    trace!(?metrics, "Sparse trie metrics");
+    result.map_err(|error| match error {
+        SparseTrieError::WrongDatabaseTrieError => RootHashError::WrongDatabaseTrie,
+        SparseTrieError::Other(other) => RootHashError::Other(other),
+    })
 }
 
 fn calculate_parallel_root_hash<P, HasherType>(

--- a/crates/rbuilder/src/utils/provider_factory_reopen.rs
+++ b/crates/rbuilder/src/utils/provider_factory_reopen.rs
@@ -2,12 +2,15 @@ use crate::{
     building::{builders::mock_block_building_helper::MockRootHasher, ThreadBlockBuildingContext},
     live_builder::simulation::SimulatedOrderCommand,
     provider::{RootHasher, StateProviderFactory},
-    roothash::{calculate_state_root, run_trie_prefetcher, RootHashContext, RootHashError},
+    roothash::{
+        calculate_account_proofs, calculate_state_root, run_trie_prefetcher, RootHashContext,
+        RootHashError,
+    },
     telemetry::{inc_provider_bad_reopen_counter, inc_provider_reopen_counter},
 };
 use alloy_consensus::Header;
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{BlockHash, BlockNumber, B256};
+use alloy_primitives::{Address, BlockHash, BlockNumber, Bytes, B256};
 use eth_sparse_mpt::*;
 use parking_lot::Mutex;
 use reth::providers::{BlockHashReader, ChainSpecProvider, ExecutionOutcome, ProviderFactory};
@@ -303,6 +306,23 @@ where
             simulated_orders,
             cancel,
         );
+    }
+
+    fn account_proofs(
+        &self,
+        outcome: &ExecutionOutcome,
+        addresses: &utils::HashSet<Address>,
+        local_ctx: &mut ThreadBlockBuildingContext,
+    ) -> Result<utils::HashMap<Address, Vec<Bytes>>, RootHashError> {
+        calculate_account_proofs(
+            self.provider.clone(),
+            self.parent_num_hash,
+            outcome,
+            addresses,
+            &self.sparse_trie_shared_cache,
+            &mut local_ctx.root_hash_calculator,
+            &self.config,
+        )
     }
 
     fn state_root(

--- a/crates/rbuilder/src/utils/receipts.rs
+++ b/crates/rbuilder/src/utils/receipts.rs
@@ -181,7 +181,8 @@ fn calculate_tx_root_and_placeholder_proof_with_alloy(
 pub fn ordered_trie_root_and_proof(items: &[Bytes], proof_index: usize) -> (B256, Vec<Bytes>) {
     let items_len = items.len();
 
-    let proof_target_encoded = alloy_rlp::encode_fixed_size(&proof_index);
+    let adjusted_proof_index = adjust_index_for_rlp(proof_index, items_len);
+    let proof_target_encoded = alloy_rlp::encode_fixed_size(&adjusted_proof_index);
     let proof_retainer = ProofRetainer::from_iter([Nibbles::unpack(&proof_target_encoded)]);
 
     let mut hb = HashBuilder::default().with_proof_retainer(proof_retainer);

--- a/crates/rbuilder/src/utils/receipts.rs
+++ b/crates/rbuilder/src/utils/receipts.rs
@@ -1,28 +1,40 @@
 use ahash::HashMap;
 use alloy_consensus::ReceiptWithBloom;
 use alloy_eips::Encodable2718;
-use alloy_primitives::{Bloom, B256};
+use alloy_primitives::{Bloom, Bytes, B256};
+use alloy_trie::{proof::ProofRetainer, root::adjust_index_for_rlp, HashBuilder, Nibbles};
 use eth_sparse_mpt::v2::trie::{proof_store::ProofStore, Trie};
+use itertools::Itertools;
 use reth::primitives::Receipt;
 use reth_primitives::Log;
-use reth_primitives_traits::proofs;
 
 use crate::building::TransactionExecutionInfo;
 
 #[derive(Debug, Clone, Default)]
-pub struct BloomCache {
+pub struct ReceiptsDataCache {
     logs: HashMap<Log, Bloom>,
     trie: Trie,
     buff: Vec<u8>,
     empty_proof_store: ProofStore,
 }
 
+#[derive(Debug, Clone)]
+pub struct ReceiptsData {
+    /// Receipts root for the block.
+    pub receipts_root: B256,
+    /// Logs bloom for the block.
+    pub logs_bloom: Bloom,
+    /// Merkle proof of the last receipt.
+    /// Used for bid adjustments.
+    pub placeholder_receipt_proof: Vec<Bytes>,
+}
+
 /// Speed up bloom filter calculation for block finalization using caching.
-pub fn calculate_receipt_root_and_block_logs_bloom(
-    cache: &mut BloomCache,
+pub fn calculate_receipts_data(
+    cache: &mut ReceiptsDataCache,
     executed_tx_infos: &[TransactionExecutionInfo],
     fast_finalize: bool,
-) -> (B256, Bloom) {
+) -> ReceiptsData {
     let mut block_logs_bloom = Bloom::ZERO;
     let mut receipts_with_blooms = Vec::with_capacity(executed_tx_infos.len());
     for executed_tx_info in executed_tx_infos {
@@ -35,9 +47,7 @@ pub fn calculate_receipt_root_and_block_logs_bloom(
             } else {
                 let mut current_log_bloom = Bloom::ZERO;
                 current_log_bloom.accrue_log(log);
-
                 cache.logs.insert(log.clone(), current_log_bloom);
-
                 current_log_bloom
             };
             current_receipt_bloom.accrue_bloom(&log_bloom);
@@ -51,31 +61,56 @@ pub fn calculate_receipt_root_and_block_logs_bloom(
         });
     }
 
-    let receipts_root = if fast_finalize {
-        faster_calculate_receipt_root(cache, &receipts_with_blooms)
+    let (receipts_root, placeholder_receipt_proof) = if fast_finalize {
+        calculate_receipts_root_and_placeholder_proof_with_cache(cache, &receipts_with_blooms)
     } else {
-        proofs::calculate_receipt_root(&receipts_with_blooms)
+        calculate_receipts_root_and_placeholder_proof_with_alloy(cache, &receipts_with_blooms)
     };
 
-    (receipts_root, block_logs_bloom)
+    ReceiptsData {
+        logs_bloom: block_logs_bloom,
+        receipts_root,
+        placeholder_receipt_proof,
+    }
 }
 
-fn faster_calculate_receipt_root(
-    cache: &mut BloomCache,
+fn calculate_receipts_root_and_placeholder_proof_with_cache(
+    cache: &mut ReceiptsDataCache,
     receipts: &[ReceiptWithBloom<&Receipt>],
-) -> B256 {
+) -> (B256, Vec<Bytes>) {
     let trie = &mut cache.trie;
     trie.clear_empty();
-    let val = &mut cache.buff;
 
     for (idx, receipt) in receipts.iter().enumerate() {
         let index = alloy_rlp::encode_fixed_size(&idx);
-
-        val.clear();
-        receipt.encode_2718(val);
-        trie.insert(&index, val).unwrap();
+        cache.buff.clear();
+        receipt.encode_2718(&mut cache.buff);
+        trie.insert(&index, &cache.buff).unwrap();
     }
-    trie.root_hash(true, &cache.empty_proof_store).unwrap()
+    let root = trie.root_hash(true, &cache.empty_proof_store).unwrap();
+
+    let target_idx = receipts.len().checked_sub(1).unwrap();
+    let adjusted_idx = adjust_index_for_rlp(target_idx, receipts.len());
+    let nibbles = Nibbles::unpack(alloy_rlp::encode_fixed_size(&adjusted_idx));
+    let proof = trie.proof(&nibbles, &cache.empty_proof_store).unwrap();
+
+    (root, proof)
+}
+
+fn calculate_receipts_root_and_placeholder_proof_with_alloy(
+    cache: &mut ReceiptsDataCache,
+    receipts: &[ReceiptWithBloom<&Receipt>],
+) -> (B256, Vec<Bytes>) {
+    let encoded_receipts = receipts
+        .iter()
+        .map(|receipt| {
+            cache.buff.clear();
+            receipt.encode_2718(&mut cache.buff);
+            cache.buff.clone().into()
+        })
+        .collect::<Vec<_>>();
+    let target_idx = receipts.len().checked_sub(1).unwrap();
+    ordered_trie_root_and_proof(&encoded_receipts, target_idx)
 }
 
 #[derive(Debug, Clone, Default)]
@@ -85,31 +120,88 @@ pub struct TransactionRootCache {
     empty_proof_store: ProofStore,
 }
 
-pub fn calculate_transactions_root(
+/// Calculate transactions root and proof for the last transactions
+pub fn calculate_tx_root_and_placeholder_proof(
     cache: &mut TransactionRootCache,
     executed_tx_infos: &[TransactionExecutionInfo],
     faster_finalize: bool,
-) -> B256 {
+) -> (B256, Vec<Bytes>) {
     if faster_finalize {
-        let trie = &mut cache.trie;
-        trie.clear_empty();
-        let val = &mut cache.buff;
-        for (idx, executed_tx_info) in executed_tx_infos.iter().enumerate() {
-            let tx_with_blobs = &executed_tx_info.tx;
-            let index = alloy_rlp::encode_fixed_size(&idx);
-
-            val.clear();
-            tx_with_blobs.encode_2718(val);
-            trie.insert(&index, val).unwrap();
-        }
-        let res = trie.root_hash(true, &cache.empty_proof_store).unwrap();
-        return res;
+        calculate_tx_root_and_placeholder_proof_with_cache(cache, executed_tx_infos)
+    } else {
+        calculate_tx_root_and_placeholder_proof_with_alloy(cache, executed_tx_infos)
     }
-    let txs = executed_tx_infos
+}
+
+/// Calculate transaction root and placeholder proof using cached trie.
+fn calculate_tx_root_and_placeholder_proof_with_cache(
+    cache: &mut TransactionRootCache,
+    executed_tx_infos: &[TransactionExecutionInfo],
+) -> (B256, Vec<Bytes>) {
+    let trie = &mut cache.trie;
+    trie.clear_empty();
+    let val = &mut cache.buff;
+    for (idx, executed_tx_info) in executed_tx_infos.iter().enumerate() {
+        let tx_with_blobs = &executed_tx_info.tx;
+        let index = alloy_rlp::encode_fixed_size(&idx);
+
+        val.clear();
+        tx_with_blobs.encode_2718(val);
+        trie.insert(&index, val).unwrap();
+    }
+    let root = trie.root_hash(true, &cache.empty_proof_store).unwrap();
+
+    let target_idx = executed_tx_infos.len().checked_sub(1).unwrap();
+    let adjusted_idx = adjust_index_for_rlp(target_idx, executed_tx_infos.len());
+    let nibbles = Nibbles::unpack(alloy_rlp::encode_fixed_size(&adjusted_idx));
+    let proof = trie.proof(&nibbles, &cache.empty_proof_store).unwrap();
+
+    (root, proof)
+}
+
+/// Calculate transaction root and placeholder proof using alloy.
+fn calculate_tx_root_and_placeholder_proof_with_alloy(
+    cache: &mut TransactionRootCache,
+    executed_tx_infos: &[TransactionExecutionInfo],
+) -> (B256, Vec<Bytes>) {
+    let encoded_txs = executed_tx_infos
         .iter()
-        .map(|info| info.tx.internal_tx_unsecure())
+        .map(|info| {
+            let tx = info.tx.internal_tx_unsecure();
+            cache.buff.clear();
+            tx.encode_2718(&mut cache.buff);
+            cache.buff.clone().into()
+        })
         .collect::<Vec<_>>();
-    proofs::calculate_transaction_root(&txs)
+    let target_idx = executed_tx_infos.len().checked_sub(1).unwrap();
+    ordered_trie_root_and_proof(&encoded_txs, target_idx)
+}
+
+/// Compute trie root of the collection of items and proof for the target element.
+pub fn ordered_trie_root_and_proof(items: &[Bytes], proof_index: usize) -> (B256, Vec<Bytes>) {
+    let items_len = items.len();
+
+    let proof_target_encoded = alloy_rlp::encode_fixed_size(&proof_index);
+    let proof_retainer = ProofRetainer::from_iter([Nibbles::unpack(&proof_target_encoded)]);
+
+    let mut hb = HashBuilder::default().with_proof_retainer(proof_retainer);
+    for i in 0..items_len {
+        let index = adjust_index_for_rlp(i, items_len);
+        let index_encoded = alloy_rlp::encode_fixed_size(&index);
+        hb.add_leaf(Nibbles::unpack(&index_encoded), &items[index]);
+    }
+
+    let root = hb.root();
+
+    let proof_nodes = hb.take_proof_nodes();
+    let proof = proof_nodes
+        .into_inner()
+        .into_iter()
+        .sorted_unstable_by(|a, b| a.0.cmp(&b.0))
+        .map(|(_, node)| node)
+        .collect();
+
+    (root, proof)
 }
 
 #[cfg(test)]
@@ -191,15 +283,12 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let mut cache = BloomCache::default();
+        let mut cache = ReceiptsDataCache::default();
         for fast_finalize in [false, true, true] {
-            let (got_receipt_root, got_logs_bloom) = calculate_receipt_root_and_block_logs_bloom(
-                &mut cache,
-                &executed_tx_info,
-                fast_finalize,
-            );
-            assert_eq!(expected_receipt_root, got_receipt_root);
-            assert_eq!(expected_logs_bloom, got_logs_bloom);
+            let got_receipts_data =
+                calculate_receipts_data(&mut cache, &executed_tx_info, fast_finalize);
+            assert_eq!(expected_receipt_root, got_receipts_data.receipts_root);
+            assert_eq!(expected_logs_bloom, got_receipts_data.logs_bloom);
         }
     }
 
@@ -216,10 +305,10 @@ mod tests {
         }
 
         let mut cache = TransactionRootCache::default();
-        let expected = calculate_transactions_root(&mut cache, &data, false);
+        let expected = calculate_tx_root_and_placeholder_proof(&mut cache, &data, false);
 
         for _ in 0..2 {
-            let got = calculate_transactions_root(&mut cache, &data, true);
+            let got = calculate_tx_root_and_placeholder_proof(&mut cache, &data, true);
             assert_eq!(expected, got);
         }
     }

--- a/crates/test-relay/src/relay.rs
+++ b/crates/test-relay/src/relay.rs
@@ -333,6 +333,7 @@ fn spawn_mev_boost_slot_data_generator(
         cl_clients,
         vec![relay],
         Duration::from_millis(1_000),
+        Default::default(),
         Arc::new(NullBlockListProvider::default()),
         cancellation_token.clone(),
     );


### PR DESCRIPTION
## 📝 Summary

Add support for generating bid adjustments for relays. If the relay has a configured fee payer address, relevant bid adjustment data will be generated during block finalization. The adjustment data will then be added to the block submission to the specified relay.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
