### PR TITLE
support more possible inputs for relay key config

### DIFF
--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -54,6 +54,7 @@ use crate::{
 };
 use alloy_chains::ChainKind;
 use alloy_primitives::{
+    hex,
     utils::{format_ether, parse_ether},
     FixedBytes, B256, U256,
 };
@@ -320,7 +321,8 @@ impl L1Config {
 
         let relay_secret_key = if let Some(secret_key) = &self.relay_secret_key {
             let resolved_key = secret_key.value()?;
-            SecretKey::try_from(resolved_key)?
+            let input = hex::decode(resolved_key)?;
+            SecretKey::from_bytes(&input)?
         } else {
             warn!("No relay secret key provided. A random key will be generated.");
             SecretKey::random(&mut rand::thread_rng())?


### PR DESCRIPTION
the relay secret key configuration option was not compatible with BIP44 input, e.g. the output of a mnemonic seed phrase and a given path in the tree

this PR now supports this feature which was simplest by just exposing a BIP44 compatible API the underlying ethereum-consensus dependency
## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
