### PR TITLE
fix: don't filter out regular txs post fusaka

### DIFF
--- a/crates/rbuilder/src/live_builder/order_input/blob_type_order_filter.rs
+++ b/crates/rbuilder/src/live_builder/order_input/blob_type_order_filter.rs
@@ -35,19 +35,15 @@ pub fn new_pre_fusaka(
 pub fn new_fusaka(
     sink: Box<dyn ReplaceableOrderSink>,
 ) -> BlobTypeOrderFilter<impl Fn(&BlobTransactionSidecarVariant) -> bool + Send + Sync> {
-    BlobTypeOrderFilter::new(sink, |blob| {
-        match blob {
-            BlobTransactionSidecarVariant::Eip4844(sidecar) => {
-                if sidecar.blobs.len() > 0 {
-                    false
-                } else {
-                    true
-                }
-            }
-            BlobTransactionSidecarVariant::Eip7594(_sidecar) => {
+    BlobTypeOrderFilter::new(sink, |blob| match blob {
+        BlobTransactionSidecarVariant::Eip4844(sidecar) => {
+            if sidecar.blobs.len() > 0 {
+                false
+            } else {
                 true
             }
         }
+        BlobTransactionSidecarVariant::Eip7594(_sidecar) => true,
     })
 }
 

--- a/crates/rbuilder/src/live_builder/order_input/blob_type_order_filter.rs
+++ b/crates/rbuilder/src/live_builder/order_input/blob_type_order_filter.rs
@@ -36,7 +36,18 @@ pub fn new_fusaka(
     sink: Box<dyn ReplaceableOrderSink>,
 ) -> BlobTypeOrderFilter<impl Fn(&BlobTransactionSidecarVariant) -> bool + Send + Sync> {
     BlobTypeOrderFilter::new(sink, |blob| {
-        matches!(blob, BlobTransactionSidecarVariant::Eip7594(_))
+        match blob {
+            BlobTransactionSidecarVariant::Eip4844(sidecar) => {
+                if sidecar.blobs.len() > 0 {
+                    false
+                } else {
+                    true
+                }
+            }
+            BlobTransactionSidecarVariant::Eip7594(_sidecar) => {
+                true
+            }
+        }
     })
 }
 

--- a/crates/rbuilder/src/live_builder/order_input/blob_type_order_filter.rs
+++ b/crates/rbuilder/src/live_builder/order_input/blob_type_order_filter.rs
@@ -1,8 +1,11 @@
-use alloy_eips::eip7594::BlobTransactionSidecarVariant;
+use alloy_eips::{eip7594::BlobTransactionSidecarVariant, Typed2718};
 
 use crate::{
     live_builder::order_input::replaceable_order_sink::ReplaceableOrderSink,
-    primitives::{BundleReplacementData, Order, ShareBundleReplacementKey},
+    primitives::{
+        BundleReplacementData, Order, ShareBundleReplacementKey,
+        TransactionSignedEcRecoveredWithBlobs,
+    },
 };
 
 /// Filters out Orders with incorrect blobs (pre/post fusaka).
@@ -25,42 +28,45 @@ impl<FilterFunc> std::fmt::Debug for BlobTypeOrderFilter<FilterFunc> {
 /// Filters out EIP-7594 style blobs, supports only EIP-4844 style.
 pub fn new_pre_fusaka(
     sink: Box<dyn ReplaceableOrderSink>,
-) -> BlobTypeOrderFilter<impl Fn(&BlobTransactionSidecarVariant) -> bool + Send + Sync> {
-    BlobTypeOrderFilter::new(sink, |blob| {
-        matches!(blob, BlobTransactionSidecarVariant::Eip4844(_))
+) -> BlobTypeOrderFilter<impl Fn(&TransactionSignedEcRecoveredWithBlobs) -> bool + Send + Sync> {
+    BlobTypeOrderFilter::new(sink, |tx| {
+        if tx.is_eip4844() {
+            matches!(*tx.blobs_sidecar, BlobTransactionSidecarVariant::Eip4844(_))
+        } else {
+            true
+        }
     })
 }
 
 /// Filters out EIP-4844 style, supports only EIP-7594 style blobs.
 pub fn new_fusaka(
     sink: Box<dyn ReplaceableOrderSink>,
-) -> BlobTypeOrderFilter<impl Fn(&BlobTransactionSidecarVariant) -> bool + Send + Sync> {
-    BlobTypeOrderFilter::new(sink, |blob| match blob {
-        BlobTransactionSidecarVariant::Eip4844(sidecar) => {
-            if sidecar.blobs.len() > 0 {
-                false
-            } else {
-                true
-            }
+) -> BlobTypeOrderFilter<impl Fn(&TransactionSignedEcRecoveredWithBlobs) -> bool + Send + Sync> {
+    BlobTypeOrderFilter::new(sink, |tx| {
+        if tx.is_eip4844() {
+            matches!(*tx.blobs_sidecar, BlobTransactionSidecarVariant::Eip7594(_))
+        } else {
+            true
         }
-        BlobTransactionSidecarVariant::Eip7594(_sidecar) => true,
     })
 }
 
-impl<FilterFunc: Fn(&BlobTransactionSidecarVariant) -> bool> BlobTypeOrderFilter<FilterFunc> {
+impl<FilterFunc: Fn(&TransactionSignedEcRecoveredWithBlobs) -> bool>
+    BlobTypeOrderFilter<FilterFunc>
+{
     fn new(sink: Box<dyn ReplaceableOrderSink>, filter_func: FilterFunc) -> Self {
         Self { sink, filter_func }
     }
 }
 
-impl<FilterFunc: Fn(&BlobTransactionSidecarVariant) -> bool + Send + Sync> ReplaceableOrderSink
-    for BlobTypeOrderFilter<FilterFunc>
+impl<FilterFunc: Fn(&TransactionSignedEcRecoveredWithBlobs) -> bool + Send + Sync>
+    ReplaceableOrderSink for BlobTypeOrderFilter<FilterFunc>
 {
     fn insert_order(&mut self, order: Order) -> bool {
         if order
             .list_txs()
             .iter()
-            .all(|(tx, _)| (self.filter_func)(tx.blobs_sidecar.as_ref()))
+            .all(|(tx, _)| (self.filter_func)(tx))
         {
             self.sink.insert_order(order)
         } else {


### PR DESCRIPTION
## 📝 Summary

The blob filter activated post fusaka was filtering out non-eip4844 txs. This is because it only keeps transactions with `BlobTransactionSidecarVariant::Eip7594(_)`. But non-eip4844 txs have `BlobTransactionSidecarVariant::Eip4844(_)` by default with 0 blobs, commitments and proofs. 

Because of this, post Fusaka only blob txs were being packed in the block since other txs were being rejected by this condiction.

To fix this, we pass the entire tx to the filter function and only check what type of `BlobTransactionSidecarVariant` if the tx is an eip4844 tx.

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
