### PR TITLE
chore: revert block request removal from `BidObserver`

### DIFF
--- a/crates/rbuilder/src/live_builder/block_output/bid_observer.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bid_observer.rs
@@ -25,6 +25,7 @@ impl BidObserver for NullBidObserver {
         &self,
         _slot_data: &MevBoostSlotData,
         _sealed_block: &SealedBlock,
+        _submit_block_request: &SubmitBlockRequest,
         _built_block_trace: &BuiltBlockTrace,
         _builder_name: String,
         _best_bid_value: U256,

--- a/crates/rbuilder/src/live_builder/block_output/bid_observer_multiplexer.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bid_observer_multiplexer.rs
@@ -27,6 +27,7 @@ impl BidObserver for BidObserverMultiplexer {
         &self,
         slot_data: &MevBoostSlotData,
         sealed_block: &SealedBlock,
+        submit_block_request: &SubmitBlockRequest,
         built_block_trace: &BuiltBlockTrace,
         builder_name: String,
         best_bid_value: alloy_primitives::U256,

--- a/crates/rbuilder/src/live_builder/block_output/bidding_service_interface.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding_service_interface.rs
@@ -10,6 +10,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     building::{builders::block_building_helper::BiddableUnfinishedBlock, BuiltBlockTrace},
     live_builder::payload_events::MevBoostSlotData,
+    mev_boost::submission::SubmitBlockRequest,
 };
 
 /// Trait that receives every bid made by us to the relays.
@@ -19,6 +20,7 @@ pub trait BidObserver: std::fmt::Debug {
         &self,
         slot_data: &MevBoostSlotData,
         sealed_block: &SealedBlock,
+        submit_block_request: &SubmitBlockRequest,
         built_block_trace: &BuiltBlockTrace,
         builder_name: String,
         best_bid_value: U256,
@@ -33,6 +35,7 @@ impl BidObserver for NullBidObserver {
         &self,
         _slot_data: &MevBoostSlotData,
         _sealed_block: &SealedBlock,
+        _submit_block_request: &SubmitBlockRequest,
         _built_block_trace: &BuiltBlockTrace,
         _builder_name: String,
         _best_bid_value: U256,

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -298,7 +298,7 @@ async fn run_submit_to_relays_job(
             &cancel,
         );
 
-        if let Some((optimistic_signed_block, _)) = optimistic_signed_block {
+        let signed_block = if let Some((optimistic_signed_block, _)) = optimistic_signed_block {
             submit_block_to_relays(
                 &config.chain_spec,
                 &optimistic_signed_block,
@@ -311,6 +311,7 @@ async fn run_submit_to_relays_job(
                 &submission_span,
                 &cancel,
             );
+            optimistic_signed_block
         } else {
             // non-optimistic submission to optimistic relays
             submit_block_to_relays(
@@ -325,18 +326,27 @@ async fn run_submit_to_relays_job(
                 &submission_span,
                 &cancel,
             );
-        }
+            normal_signed_block
+        };
 
-        submission_span.in_scope(|| {
-            // NOTE: we only notify normal submission here because they have the same contents but different pubkeys
-            config.bid_observer.block_submitted(
-                &slot_data,
-                &block.sealed_block,
-                &block.trace,
-                builder_name,
-                bid_metadata.value.top_competitor_bid.unwrap_or_default(),
-            );
-        })
+        match signed_block.into_request(&config.chain_spec, None) {
+            Ok(request) => {
+                submission_span.in_scope(|| {
+                    // NOTE: we only notify normal submission here because they have the same contents but different pubkeys
+                    config.bid_observer.block_submitted(
+                        &slot_data,
+                        &block.sealed_block,
+                        &request,
+                        &block.trace,
+                        builder_name,
+                        bid_metadata.value.top_competitor_bid.unwrap_or_default(),
+                    );
+                })
+            }
+            Err(err) => {
+                error!(parent: &submission_span, err = ?err, "Error converting request for bid observer");
+            }
+        };
     }
 }
 


### PR DESCRIPTION
## 📝 Summary

Revert block request removal from `BidObserver`. Regression was introduced in https://github.com/flashbots/rbuilder/pull/702

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
