### PR TITLE
Better bidding 2

### DIFF
--- a/crates/eth-sparse-mpt/Cargo.toml
+++ b/crates/eth-sparse-mpt/Cargo.toml
@@ -17,7 +17,7 @@ rustc-hash = "2.0.0"
 rayon = "1.10.0"
 smallvec = "1.13.2"
 alloy-trie.workspace = true
-nybbles = { version = "0.3.3" }
+nybbles = { version = "0.3.3", features = ["serde"] }
 
 tracing.workspace = true
 

--- a/crates/eth-sparse-mpt/src/lib.rs
+++ b/crates/eth-sparse-mpt/src/lib.rs
@@ -8,9 +8,8 @@
 
 use crate::utils::{HashMap, HashSet};
 use alloy_primitives::{Address, Bytes, B256};
-use reth_provider::{
-    providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, ExecutionOutcome,
-};
+use reth_provider::{providers::ConsistentDbView, BlockReader, DatabaseProviderFactory};
+use revm::database::BundleState;
 use std::sync::Arc;
 
 #[cfg(any(test, feature = "benchmark-utils"))]
@@ -140,7 +139,7 @@ impl SparseTrieError {
 
 pub fn calculate_account_proofs_with_sparse_trie<Provider>(
     consistent_db_view: ConsistentDbView<Provider>,
-    outcome: &ExecutionOutcome,
+    outcome: &BundleState,
     proof_targets: &HashSet<Address>,
     shared_cache: &SparseTrieSharedCache,
     local_cache: &mut SparseTrieLocalCache,
@@ -165,6 +164,7 @@ where
                 consistent_db_view,
                 shared_cache.cache_v2.clone(),
                 outcome,
+		&[],
                 proof_targets,
             );
             match result {
@@ -182,7 +182,8 @@ where
 
 pub fn calculate_root_hash_with_sparse_trie<Provider>(
     consistent_db_view: ConsistentDbView<Provider>,
-    outcome: &ExecutionOutcome,
+    outcome: &BundleState,
+    incremental_change: &[Address],
     shared_cache: &SparseTrieSharedCache,
     local_cache: &mut SparseTrieLocalCache,
     thread_pool: &Option<RootHashThreadPool>,
@@ -196,6 +197,7 @@ where
             calculate_root_hash_with_sparse_trie_internal(
                 consistent_db_view,
                 outcome,
+		incremental_change,
                 shared_cache,
                 local_cache,
                 version,
@@ -205,6 +207,7 @@ where
         calculate_root_hash_with_sparse_trie_internal(
             consistent_db_view,
             outcome,
+	    incremental_change,
             shared_cache,
             local_cache,
             version,
@@ -214,7 +217,8 @@ where
 
 pub fn calculate_root_hash_with_sparse_trie_internal<Provider>(
     consistent_db_view: ConsistentDbView<Provider>,
-    outcome: &ExecutionOutcome,
+    outcome: &BundleState,
+    incremental_change: &[Address],
     shared_cache: &SparseTrieSharedCache,
     local_cache: &mut SparseTrieLocalCache,
     version: ETHSpareMPTVersion,
@@ -239,6 +243,7 @@ where
                 consistent_db_view,
                 shared_cache.cache_v2.clone(),
                 outcome,
+		incremental_change,
                 &Default::default(),
             );
             match result {

--- a/crates/eth-sparse-mpt/src/lib.rs
+++ b/crates/eth-sparse-mpt/src/lib.rs
@@ -164,7 +164,7 @@ where
                 consistent_db_view,
                 shared_cache.cache_v2.clone(),
                 outcome,
-		&[],
+                &[],
                 proof_targets,
             );
             match result {
@@ -197,7 +197,7 @@ where
             calculate_root_hash_with_sparse_trie_internal(
                 consistent_db_view,
                 outcome,
-		incremental_change,
+                incremental_change,
                 shared_cache,
                 local_cache,
                 version,
@@ -207,7 +207,7 @@ where
         calculate_root_hash_with_sparse_trie_internal(
             consistent_db_view,
             outcome,
-	    incremental_change,
+            incremental_change,
             shared_cache,
             local_cache,
             version,
@@ -243,7 +243,7 @@ where
                 consistent_db_view,
                 shared_cache.cache_v2.clone(),
                 outcome,
-		incremental_change,
+                incremental_change,
                 &Default::default(),
             );
             match result {

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/mod.rs
@@ -1,9 +1,7 @@
 use alloy_primitives::B256;
 use change_set::{prepare_change_set, prepare_change_set_for_prefetch};
 use hash::RootHashError;
-use reth_provider::{
-    providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, 
-};
+use reth_provider::{providers::ConsistentDbView, BlockReader, DatabaseProviderFactory};
 use revm::database::BundleState;
 use std::time::{Duration, Instant};
 

--- a/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v1/reth_sparse_trie/mod.rs
@@ -2,8 +2,9 @@ use alloy_primitives::B256;
 use change_set::{prepare_change_set, prepare_change_set_for_prefetch};
 use hash::RootHashError;
 use reth_provider::{
-    providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, ExecutionOutcome,
+    providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, 
 };
+use revm::database::BundleState;
 use std::time::{Duration, Instant};
 
 pub mod change_set;
@@ -105,7 +106,7 @@ where
 /// * It uses rayon for parallelism and the thread pool should be configured from outside.
 pub fn calculate_root_hash_with_sparse_trie<Provider>(
     consistent_db_view: ConsistentDbView<Provider>,
-    outcome: &ExecutionOutcome,
+    outcome: &BundleState,
     shared_cache: SparseTrieSharedCache,
 ) -> (Result<B256, SparseTrieError>, SparseTrieMetrics)
 where
@@ -116,7 +117,7 @@ where
     let fetcher = TrieFetcher::new(consistent_db_view);
 
     let start = Instant::now();
-    let change_set = prepare_change_set(outcome.bundle_accounts_iter());
+    let change_set = prepare_change_set(outcome.state.iter().map(|(a, acc)| (*a, acc)));
     metrics.change_set_time += start.elapsed();
 
     // {

--- a/crates/eth-sparse-mpt/src/v2/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/mod.rs
@@ -4,11 +4,12 @@ use fetch::MissingNodesFetcher;
 use nybbles::Nibbles;
 use parking_lot::{Mutex, RwLock};
 use rayon::prelude::*;
-use reth_provider::{
-    providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, ExecutionOutcome,
-};
+use reth_provider::{providers::ConsistentDbView, BlockReader, DatabaseProviderFactory};
 use reth_trie::TrieAccount;
-use revm::state::AccountInfo;
+use revm::{
+    database::{BundleAccount, BundleState},
+    state::AccountInfo,
+};
 use rustc_hash::FxBuildHasher;
 use std::{ops::Range, sync::Arc, time::Instant};
 use trie::{proof_store::ProofStore, DeletionError, InsertValue, NodeNotFound, Trie};
@@ -69,6 +70,9 @@ pub struct RootHashCalculator {
     account_trie: AccountTrieCalculator,
 
     shared_cache: SharedCacheV2,
+
+    // if set, only changes for these accounts will be incrementally applied
+    incremental_account_change: HashSet<Address>,
 }
 
 impl Clone for RootHashCalculator {
@@ -218,8 +222,6 @@ impl StorageCalculator {
 
         self.missing_nodes.clear();
         self.missing_nodes_requested.clear();
-
-        self.hash = B256::ZERO;
     }
 }
 
@@ -255,6 +257,7 @@ impl RootHashCalculator {
             storage: DashMap::default(),
             changed_account: Default::default(),
             shared_cache,
+            incremental_account_change: Default::default(),
         }
     }
 
@@ -275,87 +278,123 @@ impl RootHashCalculator {
         }
     }
 
+    fn prepare_changes_for_one_storage_trie(
+        &self,
+        address: Address,
+        bundle_account: &BundleAccount,
+    ) {
+        let storage_calc = self.get_account_storage(&address);
+        let mut storage_calc = storage_calc.lock();
+        let storage_calc = &mut *storage_calc;
+
+        storage_calc.clear();
+        storage_calc.account_info = bundle_account.account_info().map(|a| a.without_code());
+
+        if storage_calc.account_info.is_none() {
+            // account processed, no need to compute storage hash
+            storage_calc.hash = B256::ZERO;
+            self.changed_account
+                .write()
+                .push((address, StorageTrieStatus::Hashed));
+            return;
+        }
+
+        for (storage_key, storage_value) in &bundle_account.storage {
+            if !storage_value.is_changed() {
+                continue;
+            }
+
+            let storage_value = storage_value.present_value();
+
+            if let Some(applied_op) = storage_calc
+                .applied_storage_ops_previous_iteration
+                .remove(storage_key)
+            {
+                if applied_op.inserted_value == storage_value {
+                    storage_calc
+                        .applied_storage_ops_current_iteration
+                        .insert(*storage_key, applied_op);
+                    continue;
+                } else {
+                    storage_calc.revert_storage_ops.push(applied_op);
+                    storage_calc.revert_storage_ops_done.push(false);
+                }
+            }
+
+            let hashed_key = Nibbles::unpack(keccak256(B256::from(*storage_key)).as_slice());
+            if !storage_value.is_zero() {
+                let value = alloy_rlp::encode(storage_value);
+                storage_calc.insert_keys.push(hashed_key);
+                storage_calc.insert_values.push(value);
+                storage_calc.insert_storage_key.push(*storage_key);
+                storage_calc.insert_storage_value.push(storage_value);
+                storage_calc.insert_ok.push(false);
+            } else {
+                storage_calc.delete_keys.push(hashed_key);
+                storage_calc.delete_storage_key.push(*storage_key);
+                storage_calc.delete_ok.push(false);
+            }
+        }
+
+        // revert all applied ops from previous iteration
+        let mut applied_storage_ops_previous_iteration =
+            std::mem::take(&mut storage_calc.applied_storage_ops_previous_iteration);
+        for (_, applied_op) in applied_storage_ops_previous_iteration.drain() {
+            storage_calc.revert_storage_ops.push(applied_op);
+            storage_calc.revert_storage_ops_done.push(false);
+        }
+        storage_calc.applied_storage_ops_previous_iteration =
+            applied_storage_ops_previous_iteration;
+
+        if storage_calc.delete_keys.is_empty()
+            && storage_calc.insert_keys.is_empty()
+            && storage_calc.revert_storage_ops.is_empty()
+            && !storage_calc.hash.is_zero()
+            && !storage_calc.trie.is_uninit()
+        {
+            std::mem::swap(
+                &mut storage_calc.applied_storage_ops_previous_iteration,
+                &mut storage_calc.applied_storage_ops_current_iteration,
+            );
+            self.changed_account
+                .write()
+                .push((address, StorageTrieStatus::Hashed));
+        } else {
+            storage_calc.hash = B256::ZERO;
+            self.changed_account
+                .write()
+                .push((address, StorageTrieStatus::InsertsNotProcessed));
+        }
+    }
+
     fn prepare_changes_for_storage_trie(
         &mut self,
-        outcome: &ExecutionOutcome,
+        outcome: &BundleState,
         proof_targets: &HashSet<Address>,
     ) -> eyre::Result<()> {
         self.changed_account.write().clear();
 
-        outcome
-            .bundle_accounts_iter()
-            .par_bridge()
-            .for_each(|(address, bundle_account)| {
-                if bundle_account.status.is_not_modified() && !proof_targets.contains(&address) {
-                    return;
-                }
+	let incremental_change = !self.incremental_account_change.is_empty();
 
-                let storage_calc = self.get_account_storage(&address);
-                let mut storage_calc = storage_calc.lock();
-
-                storage_calc.clear();
-                storage_calc.account_info = bundle_account.account_info().map(|a| a.without_code());
-
-                if storage_calc.account_info.is_none() {
-                    // account processed, no need to compute storage hash
-                    self.changed_account
-                        .write()
-                        .push((address, StorageTrieStatus::Hashed));
-                    return;
-                } else {
-                    self.changed_account
-                        .write()
-                        .push((address, StorageTrieStatus::InsertsNotProcessed));
-                }
-
-                for (storage_key, storage_value) in &bundle_account.storage {
-                    if !storage_value.is_changed() {
-                        continue;
+	if incremental_change {
+	    self.incremental_account_change.iter().for_each(|address| {
+		let bundle_account = outcome.account(address).expect("account with incremental change is not in the BundleState");
+                self.prepare_changes_for_one_storage_trie(*address, bundle_account)
+	    });
+	} else {
+            outcome
+		.state()
+		.iter()
+		.map(|(a, acc)| (*a, acc))
+		.par_bridge()
+		.for_each(|(address, bundle_account)| {
+                    if bundle_account.status.is_not_modified() && !proof_targets.contains(&address) {
+			return;
                     }
+                    self.prepare_changes_for_one_storage_trie(address, bundle_account)
+		});
+	}
 
-                    let storage_value = storage_value.present_value();
-
-                    if let Some(applied_op) = storage_calc
-                        .applied_storage_ops_previous_iteration
-                        .remove(storage_key)
-                    {
-                        if applied_op.inserted_value == storage_value {
-                            storage_calc
-                                .applied_storage_ops_current_iteration
-                                .insert(*storage_key, applied_op);
-                            continue;
-                        } else {
-                            storage_calc.revert_storage_ops.push(applied_op);
-                            storage_calc.revert_storage_ops_done.push(false);
-                        }
-                    }
-
-                    let hashed_key =
-                        Nibbles::unpack(keccak256(B256::from(*storage_key)).as_slice());
-                    if !storage_value.is_zero() {
-                        let value = alloy_rlp::encode(storage_value);
-                        storage_calc.insert_keys.push(hashed_key);
-                        storage_calc.insert_values.push(value);
-                        storage_calc.insert_storage_key.push(*storage_key);
-                        storage_calc.insert_storage_value.push(storage_value);
-                        storage_calc.insert_ok.push(false);
-                    } else {
-                        storage_calc.delete_keys.push(hashed_key);
-                        storage_calc.delete_storage_key.push(*storage_key);
-                        storage_calc.delete_ok.push(false);
-                    }
-                }
-
-                // revert all applied ops from previous iteration
-                let mut applied_storage_ops_previous_iteration =
-                    std::mem::take(&mut storage_calc.applied_storage_ops_previous_iteration);
-                for (_, applied_op) in applied_storage_ops_previous_iteration.drain() {
-                    storage_calc.revert_storage_ops.push(applied_op);
-                    storage_calc.revert_storage_ops_done.push(false);
-                }
-                storage_calc.applied_storage_ops_previous_iteration =
-                    applied_storage_ops_previous_iteration;
-            });
 
         Ok(())
     }
@@ -688,13 +727,21 @@ impl RootHashCalculator {
             }
         }
 
-        for (_, applied_op) in self
+	let incremental_change = !self.incremental_account_change.is_empty();
+
+        for (address, applied_op) in self
             .account_trie
             .applied_account_ops_previous_iteration
             .drain()
         {
-            self.account_trie.revert_account_ops.push(applied_op);
-            self.account_trie.revert_account_ops_done.push(false);
+	    if incremental_change && !self.incremental_account_change.contains(&address) {
+                self.account_trie
+                    .applied_account_ops_current_iteration
+                    .insert(address, applied_op);
+	    } else {
+		self.account_trie.revert_account_ops.push(applied_op);
+		self.account_trie.revert_account_ops_done.push(false);
+	    }
         }
     }
 
@@ -859,12 +906,19 @@ impl RootHashCalculator {
         &mut self,
         consistent_db_view: ConsistentDbView<Provider>,
         shared_cache: SharedCacheV2,
-        outcome: &ExecutionOutcome,
+        outcome: &BundleState,
+        incremental_change: &[Address],
         proof_targets: &HashSet<Address>,
     ) -> Result<(B256, HashMap<Address, Vec<Bytes>>, SparseTrieMetrics), SparseTrieError>
     where
         Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
     {
+	if !incremental_change.is_empty() {
+	    self.incremental_account_change.extend(incremental_change);
+	} else {
+	    self.incremental_account_change.clear();
+	}
+
         let mut stats = Stats::default();
         stats.start_global();
 
@@ -873,7 +927,9 @@ impl RootHashCalculator {
         stats.start();
         self.prepare_changes_for_storage_trie(outcome, proof_targets)?;
         stats.measure_prepare(true);
-        self.do_first_fetch(&consistent_db_view, &mut stats)?;
+	if self.incremental_account_change.is_empty() {
+            self.do_first_fetch(&consistent_db_view, &mut stats)?;
+	}
 
         let mut loop_break = false;
         for _ in 0..10 {

--- a/crates/eth-sparse-mpt/src/v2/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/mod.rs
@@ -374,27 +374,29 @@ impl RootHashCalculator {
     ) -> eyre::Result<()> {
         self.changed_account.write().clear();
 
-	let incremental_change = !self.incremental_account_change.is_empty();
+        let incremental_change = !self.incremental_account_change.is_empty();
 
-	if incremental_change {
-	    self.incremental_account_change.iter().for_each(|address| {
-		let bundle_account = outcome.account(address).expect("account with incremental change is not in the BundleState");
+        if incremental_change {
+            self.incremental_account_change.iter().for_each(|address| {
+                let bundle_account = outcome
+                    .account(address)
+                    .expect("account with incremental change is not in the BundleState");
                 self.prepare_changes_for_one_storage_trie(*address, bundle_account)
-	    });
-	} else {
+            });
+        } else {
             outcome
-		.state()
-		.iter()
-		.map(|(a, acc)| (*a, acc))
-		.par_bridge()
-		.for_each(|(address, bundle_account)| {
-                    if bundle_account.status.is_not_modified() && !proof_targets.contains(&address) {
-			return;
+                .state()
+                .iter()
+                .map(|(a, acc)| (*a, acc))
+                .par_bridge()
+                .for_each(|(address, bundle_account)| {
+                    if bundle_account.status.is_not_modified() && !proof_targets.contains(&address)
+                    {
+                        return;
                     }
                     self.prepare_changes_for_one_storage_trie(address, bundle_account)
-		});
-	}
-
+                });
+        }
 
         Ok(())
     }
@@ -727,21 +729,21 @@ impl RootHashCalculator {
             }
         }
 
-	let incremental_change = !self.incremental_account_change.is_empty();
+        let incremental_change = !self.incremental_account_change.is_empty();
 
         for (address, applied_op) in self
             .account_trie
             .applied_account_ops_previous_iteration
             .drain()
         {
-	    if incremental_change && !self.incremental_account_change.contains(&address) {
+            if incremental_change && !self.incremental_account_change.contains(&address) {
                 self.account_trie
                     .applied_account_ops_current_iteration
                     .insert(address, applied_op);
-	    } else {
-		self.account_trie.revert_account_ops.push(applied_op);
-		self.account_trie.revert_account_ops_done.push(false);
-	    }
+            } else {
+                self.account_trie.revert_account_ops.push(applied_op);
+                self.account_trie.revert_account_ops_done.push(false);
+            }
         }
     }
 
@@ -913,11 +915,11 @@ impl RootHashCalculator {
     where
         Provider: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync,
     {
-	if !incremental_change.is_empty() {
-	    self.incremental_account_change.extend(incremental_change);
-	} else {
-	    self.incremental_account_change.clear();
-	}
+        if !incremental_change.is_empty() {
+            self.incremental_account_change.extend(incremental_change);
+        } else {
+            self.incremental_account_change.clear();
+        }
 
         let mut stats = Stats::default();
         stats.start_global();
@@ -927,9 +929,9 @@ impl RootHashCalculator {
         stats.start();
         self.prepare_changes_for_storage_trie(outcome, proof_targets)?;
         stats.measure_prepare(true);
-	if self.incremental_account_change.is_empty() {
+        if self.incremental_account_change.is_empty() {
             self.do_first_fetch(&consistent_db_view, &mut stats)?;
-	}
+        }
 
         let mut loop_break = false;
         for _ in 0..10 {

--- a/crates/eth-sparse-mpt/src/v2/trie/tests.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/tests.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use super::*;
 use crate::{test_utils::reference_trie_hash_vec, utils::HashSet};
 use proptest::prelude::*;

--- a/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
+++ b/crates/rbuilder/src/backtest/build_block/backtest_build_block.rs
@@ -159,7 +159,7 @@ where
                     println!(
                         "{:>74} gas: {:>8} profit: {}",
                         order_result.order.id().to_string(),
-                        order_result.space_used.gas(),
+                        order_result.space_used.gas,
                         format_ether(order_result.coinbase_profit),
                     );
                     if let Order::Bundle(_) | Order::ShareBundle(_) = order_result.order {

--- a/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/resim_landed_block.rs
@@ -91,7 +91,7 @@ where
             &mut local_ctx.cached_reads,
         )?;
         let coinbase_profit = signed_uint_delta(coinbase_balance_after, coinbase_balance_before);
-        space_state.use_space(result.space_used(), result.blob_gas_used);
+        space_state.use_space(result.space_used());
 
         let mut conflicting_txs: HashMap<B256, Vec<SlotKey>> = HashMap::default();
         for (slot, _) in accumulator_tracer.used_state_trace.read_slot_values {

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -105,7 +105,7 @@ async fn main() -> eyre::Result<()> {
                             format!("Failed to commit tx: {} {:?}", idx, tx.hash())
                         })?
                     };
-                    space_state.use_space(result.space_used(), result.blob_gas_used);
+                    space_state.use_space(result.space_used());
                 }
 
                 let build_time = build_time.elapsed();

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -91,7 +91,7 @@ async fn main() -> eyre::Result<()> {
         let state_provider = state_provider.clone();
         let (build_time, finalize_time) =
             tokio::task::spawn_blocking(move || -> eyre::Result<_> {
-                let partial_block = PartialBlock::new(true);
+                let mut partial_block = PartialBlock::new(true);
                 let mut state = BlockState::new_arc(state_provider);
                 let mut local_ctx = ThreadBlockBuildingContext::default();
 
@@ -111,7 +111,8 @@ async fn main() -> eyre::Result<()> {
                 let build_time = build_time.elapsed();
 
                 let finalize_time = Instant::now();
-                let finalized_block = partial_block.finalize(state, &ctx, &mut local_ctx)?;
+                let finalized_block =
+                    partial_block.finalize(&mut state, &ctx, &mut local_ctx, false)?;
                 let finalize_time = finalize_time.elapsed();
 
                 debug!(

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -7,8 +7,8 @@ use eyre::Context;
 use itertools::Itertools;
 use rbuilder::{
     building::{
-        BlockBuildingContext, BlockBuildingSpaceState, BlockState, PartialBlock, PartialBlockFork,
-        ThreadBlockBuildingContext,
+        BlockBuildingContext, BlockBuildingSpaceState, BlockState, FinalizeRevertState,
+        PartialBlock, PartialBlockFork, ThreadBlockBuildingContext,
     },
     live_builder::{base_config::load_config_toml_and_env, cli::LiveBuilderConfig, config::Config},
     provider::StateProviderFactory,
@@ -95,6 +95,8 @@ async fn main() -> eyre::Result<()> {
                 let mut state = BlockState::new_arc(state_provider);
                 let mut local_ctx = ThreadBlockBuildingContext::default();
 
+                let mut finalize_revert_state = FinalizeRevertState::default();
+
                 let build_time = Instant::now();
 
                 let mut space_state = BlockBuildingSpaceState::ZERO;
@@ -111,8 +113,13 @@ async fn main() -> eyre::Result<()> {
                 let build_time = build_time.elapsed();
 
                 let finalize_time = Instant::now();
-                let finalized_block =
-                    partial_block.finalize(&mut state, &ctx, &mut local_ctx, false)?;
+                let finalized_block = partial_block.finalize(
+                    &mut state,
+                    &ctx,
+                    &mut local_ctx,
+                    false,
+                    &mut finalize_revert_state,
+                )?;
                 let finalize_time = finalize_time.elapsed();
 
                 debug!(

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -61,9 +61,9 @@ pub trait BlockBuildingHelper: Send + Sync {
     /// The main reason to get an error is if profit is so low that we can't pay the payout tx (that would mean negative block value!).
     fn true_block_value(&self) -> Result<U256, BlockBuildingHelperError>;
 
-    /// Eats the BlockBuildingHelper since once it's finished you should not use it anymore.
-    /// payout_tx_value: If Some, added at the end of the block from coinbase to the final fee recipient.
-    ///     This only works if can_add_payout_tx.
+    /// Finalize block for submission.
+    /// if adjust_finalized_block is implemented, finalize_blocks should prepare helper
+    /// for faster adjustments.
     fn finalize_block(
         &mut self,
         local_ctx: &mut ThreadBlockBuildingContext,
@@ -81,6 +81,9 @@ pub trait BlockBuildingHelper: Send + Sync {
     /// BE CAREFUL: Might be ambiguous if several building parts were involved...
     fn builder_name(&self) -> &str;
 
+    /// adjust_finalized_block will be called on block that was previously finalize with
+    /// finalize_block. local_ctx will be set to the one used for finalize_block call.
+    /// This method is supposed to be faster than calling finalize_block from scratch.
     fn adjust_finalized_block(
         &mut self,
         local_ctx: &mut ThreadBlockBuildingContext,

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -65,7 +65,7 @@ pub trait BlockBuildingHelper: Send + Sync {
     /// payout_tx_value: If Some, added at the end of the block from coinbase to the final fee recipient.
     ///     This only works if can_add_payout_tx.
     fn finalize_block(
-        self: Box<Self>,
+        &mut self,
         local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: U256,
         seen_competition_bid: Option<U256>,
@@ -81,12 +81,7 @@ pub trait BlockBuildingHelper: Send + Sync {
     /// BE CAREFUL: Might be ambiguous if several building parts were involved...
     fn builder_name(&self) -> &str;
 
-    fn prefinalize_block(
-        &mut self,
-        local_ctx: &mut ThreadBlockBuildingContext,
-    ) -> Result<(), BlockBuildingHelperError>;
-
-    fn finalize_prefinalized_block(
+    fn adjust_finalized_block(
         &mut self,
         local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: U256,
@@ -152,7 +147,7 @@ pub struct BlockBuildingHelperFromProvider<
 
 #[derive(Debug, Clone)]
 pub struct PrefinalizeState {
-    builder_nonce: u64,
+    last_tx_block_space: BlockSpace,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -171,8 +166,8 @@ pub enum BlockBuildingHelperError {
     FinalizeError(#[from] FinalizeError),
     #[error("Provider historical block hashes error: {0}")]
     HistoricalBlockError(#[from] HistoricalBlockError),
-    #[error("Block is not prefinalized")]
-    BlockIsNotPrefinalized,
+    #[error("Block is not finalized correctly")]
+    BlockFinalizedIncorrectly,
 }
 
 impl BlockBuildingHelperError {
@@ -301,6 +296,7 @@ impl<
             block = building_ctx.block(),
             build_time_mus = built_block_trace.fill_time.as_micros(),
             finalize_time_mus = built_block_trace.finalize_time.as_micros(),
+            finalize_adjust_time_mus = built_block_trace.finalize_adjust_time.as_micros(),
             root_hash_time_mus = built_block_trace.root_hash_time.as_micros(),
             profit = format_ether(built_block_trace.bid_value),
             builder_name = builder_name,
@@ -317,15 +313,17 @@ impl<
         &mut self,
         local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: U256,
-    ) -> Result<(), BlockBuildingHelperError> {
+        adjust_finalized_block: bool,
+    ) -> Result<BlockSpace, BlockBuildingHelperError> {
         self.built_block_trace.coinbase_reward = self.partial_block.coinbase_profit;
 
-        self.partial_block.insert_refunds_and_proposer_payout_tx(
+        let payment_tx_block_space = self.partial_block.insert_refunds_and_proposer_payout_tx(
             self.payout_tx_gas,
             payout_tx_value,
             &self.building_ctx,
             local_ctx,
             &mut self.block_state,
+            adjust_finalized_block,
         )?;
 
         let (bid_value, true_value) = (payout_tx_value, self.true_block_value()?);
@@ -341,7 +339,107 @@ impl<
 
         self.built_block_trace.bid_value = max(bid_value, fee_recipient_balance_diff);
         self.built_block_trace.true_bid_value = true_value;
-        Ok(())
+        Ok(payment_tx_block_space)
+    }
+
+    fn finalize_block_impl(
+        &mut self,
+        local_ctx: &mut ThreadBlockBuildingContext,
+        payout_tx_value: U256,
+        seen_competition_bid: Option<U256>,
+        adjust_finalized_block: bool,
+    ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
+        if adjust_finalized_block != self.prefinalize_state.is_some() {
+            return Err(BlockBuildingHelperError::BlockFinalizedIncorrectly);
+        }
+
+        let start_time = Instant::now();
+        let step_start = Instant::now();
+
+        if adjust_finalized_block {
+            let last_block_tx_space = self
+                .prefinalize_state
+                .as_ref()
+                .map(|s| s.last_tx_block_space)
+                .unwrap();
+            self.partial_block
+                .adjust_finalize_block_revert_to_prefinalized_state(
+                    last_block_tx_space,
+                    &mut self.block_state,
+                )
+        }
+
+        let last_tx_block_space =
+            self.finalize_block_execution(local_ctx, payout_tx_value, adjust_finalized_block)?;
+
+        if !adjust_finalized_block {
+            self.built_block_trace
+                .verify_bundle_consistency(&self.building_ctx.blocklist)?;
+        }
+
+        let finalize_prep_time_ms = elapsed_ms(step_start);
+        let step_start = Instant::now();
+
+        let sim_gas_used = self.partial_block.tracer.used_gas;
+        let block_number = self.building_context().block();
+        let finalized_block = match self.partial_block.finalize(
+            &mut self.block_state,
+            &self.building_ctx,
+            local_ctx,
+            adjust_finalized_block,
+        ) {
+            Ok(finalized_block) => finalized_block,
+            Err(err) => {
+                if err.is_consistent_db_view_err() {
+                    debug!(
+                        block_number,
+                        payload_id = self.building_ctx.payload_id,
+                        "Can't build on this head, cancelling slot"
+                    );
+                    self.cancel_on_fatal_error.cancel();
+                }
+                return Err(BlockBuildingHelperError::FinalizeError(err));
+            }
+        };
+
+        let finalize_block_time_ms = elapsed_ms(step_start);
+        let finalize_time_ms = elapsed_ms(start_time);
+        trace!(
+            finalize_time_ms,
+            finalize_prep_time_ms,
+            finalize_block_time_ms,
+            adjust_finalized_block,
+            "Block building helper finalized block"
+        );
+        self.built_block_trace.update_orders_sealed_at();
+        if adjust_finalized_block {
+            self.built_block_trace.finalize_adjust_time = start_time.elapsed();
+        } else {
+            self.built_block_trace.root_hash_time = finalized_block.root_hash_time;
+            self.built_block_trace.finalize_time = start_time.elapsed();
+        }
+        self.built_block_trace.seen_competition_bid = seen_competition_bid;
+        Self::trace_finalized_block(
+            &finalized_block,
+            &self.builder_name,
+            &self.building_ctx,
+            &self.built_block_trace,
+            sim_gas_used,
+        );
+
+        self.prefinalize_state = Some(PrefinalizeState {
+            last_tx_block_space,
+        });
+
+        let block = Block {
+            builder_name: self.builder_name.clone(),
+            trace: self.built_block_trace.clone(),
+            sealed_block: finalized_block.sealed_block,
+            txs_blobs_sidecars: finalized_block.txs_blob_sidecars,
+            execution_requests: finalized_block.execution_requests,
+            bid_adjustments: finalized_block.bid_adjustments,
+        };
+        Ok(FinalizeBlockResult { block })
     }
 }
 
@@ -402,72 +500,12 @@ impl<
     }
 
     fn finalize_block(
-        mut self: Box<Self>,
+        &mut self,
         local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: U256,
         seen_competition_bid: Option<U256>,
     ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
-        let start_time = Instant::now();
-        let step_start = Instant::now();
-
-        self.finalize_block_execution(local_ctx, payout_tx_value)?;
-        // This could be moved outside of this func (pre finalize) since I don´t think the payout tx can change much.
-        self.built_block_trace
-            .verify_bundle_consistency(&self.building_ctx.blocklist)?;
-
-        let finalize_prep_time_ms = elapsed_ms(step_start);
-        let step_start = Instant::now();
-
-        let sim_gas_used = self.partial_block.tracer.used_gas;
-        let block_number = self.building_context().block();
-        let finalized_block =
-            match self
-                .partial_block
-                .finalize(self.block_state, &self.building_ctx, local_ctx)
-            {
-                Ok(finalized_block) => finalized_block,
-                Err(err) => {
-                    if err.is_consistent_db_view_err() {
-                        debug!(
-                            block_number,
-                            payload_id = self.building_ctx.payload_id,
-                            "Can't build on this head, cancelling slot"
-                        );
-                        self.cancel_on_fatal_error.cancel();
-                    }
-                    return Err(BlockBuildingHelperError::FinalizeError(err));
-                }
-            };
-
-        let finalize_block_time_ms = elapsed_ms(step_start);
-        let finalize_time_ms = elapsed_ms(start_time);
-        trace!(
-            finalize_time_ms,
-            finalize_prep_time_ms,
-            finalize_block_time_ms,
-            "Block building helper finalized block"
-        );
-        self.built_block_trace.update_orders_sealed_at();
-        self.built_block_trace.root_hash_time = finalized_block.root_hash_time;
-        self.built_block_trace.finalize_time = start_time.elapsed();
-        self.built_block_trace.seen_competition_bid = seen_competition_bid;
-        Self::trace_finalized_block(
-            &finalized_block,
-            &self.builder_name,
-            &self.building_ctx,
-            &self.built_block_trace,
-            sim_gas_used,
-        );
-
-        let block = Block {
-            builder_name: self.builder_name.clone(),
-            trace: self.built_block_trace,
-            sealed_block: finalized_block.sealed_block,
-            txs_blobs_sidecars: finalized_block.txs_blob_sidecars,
-            execution_requests: finalized_block.execution_requests,
-            bid_adjustments: finalized_block.bid_adjustments,
-        };
-        Ok(FinalizeBlockResult { block })
+        self.finalize_block_impl(local_ctx, payout_tx_value, seen_competition_bid, false)
     }
 
     fn built_block_trace(&self) -> &BuiltBlockTrace {
@@ -495,108 +533,12 @@ impl<
             .set_filtered_build_statistics(considered_orders_statistics, failed_orders_statistics);
     }
 
-    // prepare block for fast finalization
-    // executes the most expensive part of finalization so that adding a bid transaction is fast
-    fn prefinalize_block(
-        &mut self,
-        local_ctx: &mut ThreadBlockBuildingContext,
-    ) -> Result<(), BlockBuildingHelperError> {
-        self.built_block_trace
-            .verify_bundle_consistency(&self.building_ctx.blocklist)?;
-
-        let builder_nonce = self
-            .partial_block
-            .insert_combined_refunds_two_step_finalize(
-                &self.building_ctx,
-                local_ctx,
-                &mut self.block_state,
-            )?;
-
-        self.prefinalize_state = Some(PrefinalizeState { builder_nonce });
-
-        Ok(())
-    }
-
-    fn finalize_prefinalized_block(
+    fn adjust_finalized_block(
         &mut self,
         local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: U256,
         seen_competition_bid: Option<U256>,
     ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
-        let start_time = Instant::now();
-
-        let prefinalize_state = if let Some(state) = self.prefinalize_state.as_mut() {
-            state
-        } else {
-            return Err(BlockBuildingHelperError::BlockIsNotPrefinalized);
-        };
-
-        let mut partial_block = self.partial_block.clone();
-        let mut block_state = self.block_state.clone();
-
-        let payout_tx_gas = self.payout_tx_gas;
-        partial_block.insert_refund_tx_two_step_finalize(
-            &self.building_ctx,
-            local_ctx,
-            &mut block_state,
-            payout_tx_gas,
-            payout_tx_value,
-            prefinalize_state.builder_nonce,
-        )?;
-
-        let fee_recipient_balance_after = block_state.balance(
-            self.building_ctx.attributes.suggested_fee_recipient,
-            &self.building_ctx.shared_cached_reads,
-            &mut local_ctx.cached_reads,
-        )?;
-        let fee_recipient_balance_diff = fee_recipient_balance_after
-            .checked_sub(self._fee_recipient_balance_start)
-            .unwrap_or_default();
-
-        self.built_block_trace.bid_value = max(payout_tx_value, fee_recipient_balance_diff);
-        self.built_block_trace.true_bid_value =
-            partial_block.get_proposer_payout_tx_value(payout_tx_gas, &self.building_ctx)?;
-
-        let sim_gas_used = partial_block.tracer.used_gas;
-        let block_number = self.building_context().block();
-
-        let finalized_block =
-            match partial_block.finalize(block_state, &self.building_ctx, local_ctx) {
-                Ok(finalized_block) => finalized_block,
-                Err(err) => {
-                    if err.is_consistent_db_view_err() {
-                        debug!(
-                            block_number,
-                            payload_id = self.building_ctx.payload_id,
-                            "Can't build on this head, cancelling slot"
-                        );
-                        self.cancel_on_fatal_error.cancel();
-                    }
-                    return Err(BlockBuildingHelperError::FinalizeError(err));
-                }
-            };
-
-        self.built_block_trace.update_orders_sealed_at();
-        self.built_block_trace.root_hash_time = finalized_block.root_hash_time;
-        self.built_block_trace.finalize_time = start_time.elapsed();
-        self.built_block_trace.seen_competition_bid = seen_competition_bid;
-
-        Self::trace_finalized_block(
-            &finalized_block,
-            &self.builder_name,
-            &self.building_ctx,
-            &self.built_block_trace,
-            sim_gas_used,
-        );
-
-        let block = Block {
-            trace: self.built_block_trace.clone(),
-            sealed_block: finalized_block.sealed_block,
-            txs_blobs_sidecars: finalized_block.txs_blob_sidecars,
-            builder_name: self.builder_name.clone(),
-            execution_requests: finalized_block.execution_requests,
-            bid_adjustments: finalized_block.bid_adjustments,
-        };
-        Ok(FinalizeBlockResult { block })
+        self.finalize_block_impl(local_ctx, payout_tx_value, seen_competition_bid, true)
     }
 }

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -258,7 +258,7 @@ impl<
             BlockSpace::ZERO,
         )?;
         partial_block.reserve_block_space(payout_tx_space);
-        let payout_tx_gas = payout_tx_space.gas();
+        let payout_tx_gas = payout_tx_space.gas;
 
         let mut built_block_trace = BuiltBlockTrace::new();
         built_block_trace.available_orders_statistics = available_orders_statistics;

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -80,6 +80,18 @@ pub trait BlockBuildingHelper: Send + Sync {
     /// Name of the builder that pregenerated this block.
     /// BE CAREFUL: Might be ambiguous if several building parts were involved...
     fn builder_name(&self) -> &str;
+
+    fn prefinalize_block(
+        &mut self,
+        local_ctx: &mut ThreadBlockBuildingContext,
+    ) -> Result<(), BlockBuildingHelperError>;
+
+    fn finalize_prefinalized_block(
+        &mut self,
+        local_ctx: &mut ThreadBlockBuildingContext,
+        payout_tx_value: U256,
+        seen_competition_bid: Option<U256>,
+    ) -> Result<FinalizeBlockResult, BlockBuildingHelperError>;
 }
 
 /// Wraps a BlockBuildingHelper with a valid true_block_value which makes it ready to bid.
@@ -134,6 +146,13 @@ pub struct BlockBuildingHelperFromProvider<
     built_block_trace: BuiltBlockTrace,
     /// Token to cancel in case of fatal error (if we believe that it's impossible to build for this block).
     cancel_on_fatal_error: CancellationToken,
+
+    prefinalize_state: Option<PrefinalizeState>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrefinalizeState {
+    builder_nonce: u64,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -152,6 +171,8 @@ pub enum BlockBuildingHelperError {
     FinalizeError(#[from] FinalizeError),
     #[error("Provider historical block hashes error: {0}")]
     HistoricalBlockError(#[from] HistoricalBlockError),
+    #[error("Block is not prefinalized")]
+    BlockIsNotPrefinalized,
 }
 
 impl BlockBuildingHelperError {
@@ -250,6 +271,7 @@ impl<
             building_ctx,
             built_block_trace,
             cancel_on_fatal_error,
+            prefinalize_state: None,
         })
     }
 
@@ -471,5 +493,110 @@ impl<
     ) {
         self.built_block_trace
             .set_filtered_build_statistics(considered_orders_statistics, failed_orders_statistics);
+    }
+
+    // prepare block for fast finalization
+    // executes the most expensive part of finalization so that adding a bid transaction is fast
+    fn prefinalize_block(
+        &mut self,
+        local_ctx: &mut ThreadBlockBuildingContext,
+    ) -> Result<(), BlockBuildingHelperError> {
+        self.built_block_trace
+            .verify_bundle_consistency(&self.building_ctx.blocklist)?;
+
+        let builder_nonce = self
+            .partial_block
+            .insert_combined_refunds_two_step_finalize(
+                &self.building_ctx,
+                local_ctx,
+                &mut self.block_state,
+            )?;
+
+        self.prefinalize_state = Some(PrefinalizeState { builder_nonce });
+
+        Ok(())
+    }
+
+    fn finalize_prefinalized_block(
+        &mut self,
+        local_ctx: &mut ThreadBlockBuildingContext,
+        payout_tx_value: U256,
+        seen_competition_bid: Option<U256>,
+    ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
+        let start_time = Instant::now();
+
+        let prefinalize_state = if let Some(state) = self.prefinalize_state.as_mut() {
+            state
+        } else {
+            return Err(BlockBuildingHelperError::BlockIsNotPrefinalized);
+        };
+
+        let mut partial_block = self.partial_block.clone();
+        let mut block_state = self.block_state.clone();
+
+        let payout_tx_gas = self.payout_tx_gas;
+        partial_block.insert_refund_tx_two_step_finalize(
+            &self.building_ctx,
+            local_ctx,
+            &mut block_state,
+            payout_tx_gas,
+            payout_tx_value,
+            prefinalize_state.builder_nonce,
+        )?;
+
+        let fee_recipient_balance_after = block_state.balance(
+            self.building_ctx.attributes.suggested_fee_recipient,
+            &self.building_ctx.shared_cached_reads,
+            &mut local_ctx.cached_reads,
+        )?;
+        let fee_recipient_balance_diff = fee_recipient_balance_after
+            .checked_sub(self._fee_recipient_balance_start)
+            .unwrap_or_default();
+
+        self.built_block_trace.bid_value = max(payout_tx_value, fee_recipient_balance_diff);
+        self.built_block_trace.true_bid_value =
+            partial_block.get_proposer_payout_tx_value(payout_tx_gas, &self.building_ctx)?;
+
+        let sim_gas_used = partial_block.tracer.used_gas;
+        let block_number = self.building_context().block();
+
+        let finalized_block =
+            match partial_block.finalize(block_state, &self.building_ctx, local_ctx) {
+                Ok(finalized_block) => finalized_block,
+                Err(err) => {
+                    if err.is_consistent_db_view_err() {
+                        debug!(
+                            block_number,
+                            payload_id = self.building_ctx.payload_id,
+                            "Can't build on this head, cancelling slot"
+                        );
+                        self.cancel_on_fatal_error.cancel();
+                    }
+                    return Err(BlockBuildingHelperError::FinalizeError(err));
+                }
+            };
+
+        self.built_block_trace.update_orders_sealed_at();
+        self.built_block_trace.root_hash_time = finalized_block.root_hash_time;
+        self.built_block_trace.finalize_time = start_time.elapsed();
+        self.built_block_trace.seen_competition_bid = seen_competition_bid;
+
+        Self::trace_finalized_block(
+            &finalized_block,
+            &self.builder_name,
+            &self.building_ctx,
+            &self.built_block_trace,
+            sim_gas_used,
+        );
+
+        let block = Block {
+            trace: self.built_block_trace.clone(),
+            sealed_block: finalized_block.sealed_block,
+            txs_blobs_sidecars: finalized_block.txs_blob_sidecars,
+            builder_name: self.builder_name.clone(),
+            execution_requests: finalized_block.execution_requests,
+            bid_adjustments: finalized_block.bid_adjustments,
+        };
+        Ok(FinalizeBlockResult { block })
     }
 }

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -14,8 +14,8 @@ use crate::{
         estimate_payout_gas_limit, tracers::GasUsedSimulationTracer, BlockBuildingContext,
         BlockSpace, BlockState, BuiltBlockTrace, BuiltBlockTraceError, CriticalCommitOrderError,
         EstimatePayoutGasErr, ExecutionError, ExecutionResult, FinalizeError, FinalizeResult,
-        NullPartialBlockExecutionTracer, PartialBlock, PartialBlockExecutionTracer,
-        ThreadBlockBuildingContext,
+        FinalizeRevertState, NullPartialBlockExecutionTracer, PartialBlock,
+        PartialBlockExecutionTracer, ThreadBlockBuildingContext,
     },
     primitives::{order_statistics::OrderStatistics, SimValue, SimulatedOrder},
     telemetry::{self, add_block_fill_time, add_order_simulation_time},
@@ -145,12 +145,7 @@ pub struct BlockBuildingHelperFromProvider<
     /// Token to cancel in case of fatal error (if we believe that it's impossible to build for this block).
     cancel_on_fatal_error: CancellationToken,
 
-    prefinalize_state: Option<PrefinalizeState>,
-}
-
-#[derive(Debug, Clone)]
-pub struct PrefinalizeState {
-    last_tx_block_space: BlockSpace,
+    finalize_revert_state: Option<FinalizeRevertState>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -269,7 +264,7 @@ impl<
             building_ctx,
             built_block_trace,
             cancel_on_fatal_error,
-            prefinalize_state: None,
+            finalize_revert_state: None,
         })
     }
 
@@ -317,16 +312,18 @@ impl<
         local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: U256,
         adjust_finalized_block: bool,
-    ) -> Result<BlockSpace, BlockBuildingHelperError> {
+        finalize_revert_state: &mut FinalizeRevertState,
+    ) -> Result<(), BlockBuildingHelperError> {
         self.built_block_trace.coinbase_reward = self.partial_block.coinbase_profit;
 
-        let payment_tx_block_space = self.partial_block.insert_refunds_and_proposer_payout_tx(
+        self.partial_block.insert_refunds_and_proposer_payout_tx(
             self.payout_tx_gas,
             payout_tx_value,
             &self.building_ctx,
             local_ctx,
             &mut self.block_state,
             adjust_finalized_block,
+            finalize_revert_state,
         )?;
 
         let (bid_value, true_value) = (payout_tx_value, self.true_block_value()?);
@@ -342,7 +339,7 @@ impl<
 
         self.built_block_trace.bid_value = max(bid_value, fee_recipient_balance_diff);
         self.built_block_trace.true_bid_value = true_value;
-        Ok(payment_tx_block_space)
+        Ok(())
     }
 
     fn finalize_block_impl(
@@ -352,7 +349,7 @@ impl<
         seen_competition_bid: Option<U256>,
         adjust_finalized_block: bool,
     ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
-        if adjust_finalized_block != self.prefinalize_state.is_some() {
+        if adjust_finalized_block != self.finalize_revert_state.is_some() {
             return Err(BlockBuildingHelperError::BlockFinalizedIncorrectly);
         }
 
@@ -360,20 +357,22 @@ impl<
         let step_start = Instant::now();
 
         if adjust_finalized_block {
-            let last_block_tx_space = self
-                .prefinalize_state
-                .as_ref()
-                .map(|s| s.last_tx_block_space)
-                .unwrap();
+            let finalize_revert_state = self.finalize_revert_state.take().unwrap();
             self.partial_block
                 .adjust_finalize_block_revert_to_prefinalized_state(
-                    last_block_tx_space,
+                    finalize_revert_state,
                     &mut self.block_state,
-                )
+                );
         }
 
-        let last_tx_block_space =
-            self.finalize_block_execution(local_ctx, payout_tx_value, adjust_finalized_block)?;
+        let mut finalize_revert_state = FinalizeRevertState::default();
+
+        self.finalize_block_execution(
+            local_ctx,
+            payout_tx_value,
+            adjust_finalized_block,
+            &mut finalize_revert_state,
+        )?;
 
         if !adjust_finalized_block {
             self.built_block_trace
@@ -390,6 +389,7 @@ impl<
             &self.building_ctx,
             local_ctx,
             adjust_finalized_block,
+            &mut finalize_revert_state,
         ) {
             Ok(finalized_block) => finalized_block,
             Err(err) => {
@@ -430,9 +430,7 @@ impl<
             sim_gas_used,
         );
 
-        self.prefinalize_state = Some(PrefinalizeState {
-            last_tx_block_space,
-        });
+        self.finalize_revert_state = Some(finalize_revert_state);
 
         let block = Block {
             builder_name: self.builder_name.clone(),

--- a/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
@@ -7,10 +7,12 @@ use std::{
 use alloy_primitives::{utils::format_ether, U256};
 
 use crate::{
-    building::builders::block_building_helper::BlockBuildingHelper,
+    building::{builders::block_building_helper::BlockBuildingHelper, ThreadBlockBuildingContext},
     live_builder::order_input::mempool_txs_detector::MempoolTxsDetector,
     primitives::{order_statistics::OrderStatistics, OrderId, SimulatedOrder},
 };
+
+use super::block_building_helper::{BlockBuildingHelperError, FinalizeBlockResult};
 
 /// Wraps a BlockBuildingHelper and stores info about every commit_order as lightweight as possible.
 pub struct BlockBuildingHelperStatsLogger<'a> {
@@ -162,7 +164,7 @@ impl BlockBuildingHelper for BlockBuildingHelperStatsLogger<'_> {
 
     fn commit_order(
         &mut self,
-        local_ctx: &mut crate::building::ThreadBlockBuildingContext,
+        local_ctx: &mut ThreadBlockBuildingContext,
         order: &crate::primitives::SimulatedOrder,
         result_filter: &dyn Fn(
             &crate::primitives::SimValue,
@@ -207,10 +209,7 @@ impl BlockBuildingHelper for BlockBuildingHelperStatsLogger<'_> {
         _local_ctx: &mut crate::building::ThreadBlockBuildingContext,
         _payout_tx_value: alloy_primitives::U256,
         _seen_competition_bid: Option<alloy_primitives::U256>,
-    ) -> Result<
-        super::block_building_helper::FinalizeBlockResult,
-        super::block_building_helper::BlockBuildingHelperError,
-    > {
+    ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
         panic!("finalize_block not implemented. This is only for testing.");
     }
 
@@ -233,5 +232,21 @@ impl BlockBuildingHelper for BlockBuildingHelperStatsLogger<'_> {
     ) {
         self.block_building_helper
             .set_filtered_build_statistics(considered_orders_statistics, failed_orders_statistics);
+    }
+
+    fn prefinalize_block(
+        &mut self,
+        _local_ctx: &mut ThreadBlockBuildingContext,
+    ) -> Result<(), BlockBuildingHelperError> {
+        unimplemented!()
+    }
+
+    fn finalize_prefinalized_block(
+        &mut self,
+        _local_ctx: &mut ThreadBlockBuildingContext,
+        _payout_tx_value: U256,
+        _seen_competition_bid: Option<U256>,
+    ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
+        unimplemented!()
     }
 }

--- a/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
@@ -205,7 +205,7 @@ impl BlockBuildingHelper for BlockBuildingHelperStatsLogger<'_> {
     }
 
     fn finalize_block(
-        self: Box<Self>,
+        &mut self,
         _local_ctx: &mut crate::building::ThreadBlockBuildingContext,
         _payout_tx_value: alloy_primitives::U256,
         _seen_competition_bid: Option<alloy_primitives::U256>,
@@ -234,14 +234,7 @@ impl BlockBuildingHelper for BlockBuildingHelperStatsLogger<'_> {
             .set_filtered_build_statistics(considered_orders_statistics, failed_orders_statistics);
     }
 
-    fn prefinalize_block(
-        &mut self,
-        _local_ctx: &mut ThreadBlockBuildingContext,
-    ) -> Result<(), BlockBuildingHelperError> {
-        unimplemented!()
-    }
-
-    fn finalize_prefinalized_block(
+    fn adjust_finalized_block(
         &mut self,
         _local_ctx: &mut ThreadBlockBuildingContext,
         _payout_tx_value: U256,

--- a/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
@@ -60,7 +60,7 @@ impl BlockBuildingHelperCommitLog {
             Some(ExecutionResult {
                 landed_tx_count: exec_ok.tx_infos.len(),
                 coinbase_profit: exec_ok.coinbase_profit,
-                gas_used: exec_ok.space_used.gas(),
+                gas_used: exec_ok.space_used.gas,
             })
         } else {
             None

--- a/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
@@ -10,8 +10,8 @@ use crate::{
 };
 use alloy_primitives::{Address, Bytes, B256, U256};
 use eth_sparse_mpt::utils::{HashMap, HashSet};
-use reth::providers::ExecutionOutcome;
 use reth_primitives::SealedBlock;
+use revm::database::BundleState;
 use time::OffsetDateTime;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -82,7 +82,7 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
     }
 
     fn finalize_block(
-        mut self: Box<Self>,
+        &mut self,
         _local_ctx: &mut ThreadBlockBuildingContext,
         payout_tx_value: U256,
         seen_competition_bid: Option<U256>,
@@ -92,7 +92,7 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
         self.built_block_trace.bid_value = payout_tx_value;
         let block = Block {
             builder_name: "BlockBuildingHelper".to_string(),
-            trace: self.built_block_trace,
+            trace: self.built_block_trace.clone(),
             sealed_block: SealedBlock::default(),
             txs_blobs_sidecars: Vec::new(),
             execution_requests: Default::default(),
@@ -123,14 +123,7 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
             .set_filtered_build_statistics(considered_orders_statistics, failed_orders_statistics);
     }
 
-    fn prefinalize_block(
-        &mut self,
-        _local_ctx: &mut ThreadBlockBuildingContext,
-    ) -> Result<(), BlockBuildingHelperError> {
-        unimplemented!()
-    }
-
-    fn finalize_prefinalized_block(
+    fn adjust_finalized_block(
         &mut self,
         _local_ctx: &mut ThreadBlockBuildingContext,
         _payout_tx_value: U256,
@@ -153,7 +146,7 @@ impl RootHasher for MockRootHasher {
 
     fn account_proofs(
         &self,
-        _outcome: &ExecutionOutcome,
+        _outcome: &BundleState,
         _addresses: &HashSet<Address>,
         _local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<HashMap<Address, Vec<Bytes>>, RootHashError> {
@@ -162,7 +155,8 @@ impl RootHasher for MockRootHasher {
 
     fn state_root(
         &self,
-        _outcome: &ExecutionOutcome,
+        _outcome: &BundleState,
+        _incremental_change: &[Address],
         _local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<B256, RootHashError> {
         Ok(B256::default())

--- a/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
@@ -122,6 +122,22 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
         self.built_block_trace
             .set_filtered_build_statistics(considered_orders_statistics, failed_orders_statistics);
     }
+
+    fn prefinalize_block(
+        &mut self,
+        _local_ctx: &mut ThreadBlockBuildingContext,
+    ) -> Result<(), BlockBuildingHelperError> {
+        unimplemented!()
+    }
+
+    fn finalize_prefinalized_block(
+        &mut self,
+        _local_ctx: &mut ThreadBlockBuildingContext,
+        _payout_tx_value: U256,
+        _seen_competition_bid: Option<U256>,
+    ) -> Result<FinalizeBlockResult, BlockBuildingHelperError> {
+        unimplemented!()
+    }
 }
 
 #[derive(Debug)]

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -387,7 +387,7 @@ impl OrderingBuilderContext {
             let success = commit_result.is_ok();
             match commit_result {
                 Ok(res) => {
-                    gas_used = res.space_used.gas();
+                    gas_used = res.space_used.gas;
                     // This intermediate step is needed until we replace all (Address, u64) for AccountNonce
                     let nonces_updated: Vec<_> = res
                         .nonces_updated

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -182,7 +182,7 @@ where
         ordering_config,
         Arc::new(BuiltBlockCache::new()),
     );
-    let block_builder = builder.build_block_with_execution_tracer(
+    let mut block_builder = builder.build_block_with_execution_tracer(
         block_orders,
         CancellationToken::new(),
         partial_block_execution_tracer,

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -224,7 +224,7 @@ impl BlockBuildingResultAssembler {
                 let success = commit_result.is_ok();
                 match commit_result {
                     Ok(res) => {
-                        gas_used = res.space_used.gas();
+                        gas_used = res.space_used.gas;
                     }
                     Err(err) => execution_error = Some(err),
                 }
@@ -285,7 +285,7 @@ impl BlockBuildingResultAssembler {
                         tracing::trace!(
                             order_id = ?sim_order.id(),
                             success = true,
-                            gas_used = res.space_used.gas(),
+                            gas_used = res.space_used.gas,
                             "Executed order in backtest"
                         );
                     }

--- a/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/mod.rs
@@ -366,7 +366,7 @@ where
 
     // Block building
     let building_start = Instant::now();
-    let block_building_helper = block_building_result_assembler
+    let mut block_building_helper = block_building_result_assembler
         .build_backtest_block(best_results, OffsetDateTime::now_utc())?;
 
     let payout_tx_value = block_building_helper.true_block_value()?;

--- a/crates/rbuilder/src/building/built_block_trace.rs
+++ b/crates/rbuilder/src/building/built_block_trace.rs
@@ -25,6 +25,7 @@ pub struct BuiltBlockTrace {
     pub orders_sealed_at: OffsetDateTime,
     pub fill_time: Duration,
     pub finalize_time: Duration,
+    pub finalize_adjust_time: Duration,
     pub root_hash_time: Duration,
     /// Value we saw in the competition when we decided to make this bid.
     pub seen_competition_bid: Option<U256>,
@@ -70,6 +71,7 @@ impl BuiltBlockTrace {
             orders_sealed_at: OffsetDateTime::now_utc(),
             fill_time: Duration::from_secs(0),
             finalize_time: Duration::from_secs(0),
+            finalize_adjust_time: Duration::from_secs(0),
             root_hash_time: Duration::from_secs(0),
             seen_competition_bid: None,
             considered_orders_statistics: Default::default(),

--- a/crates/rbuilder/src/building/conflict.rs
+++ b/crates/rbuilder/src/building/conflict.rs
@@ -88,7 +88,7 @@ pub fn find_conflict_slow(
         let mut space_state = BlockBuildingSpaceState::ZERO;
         match fork.commit_order(order1, space_state, true, &combined_refunds)? {
             Ok(res) => {
-                space_state.use_space(res.space_used, res.blob_gas_used);
+                space_state.use_space(res.space_used);
             }
             Err(_) => {
                 results.insert(pair, Conflict::Fatal);

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -469,38 +469,36 @@ impl PartialBlockForkExecutionTracer for NullPartialBlockExecutionTracer {
 }
 
 /// Models consumed/reserved space on a block to be able to insert payout tx when finished filling the block.
-/// @Pending: Add blob gas?
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct BlockSpace {
     pub gas: u64,
     /// EIP-7934 limits the size of the final rlp block.
     /// Estimation of the sum of the rlp txs sizes.
     pub rlp_length: usize,
+    pub blob_gas: u64,
 }
 
 impl BlockSpace {
-    pub fn new(gas: u64, rlp_length: usize) -> Self {
-        Self { gas, rlp_length }
+    pub fn new(gas: u64, rlp_length: usize, blob_gas: u64) -> Self {
+        Self {
+            gas,
+            rlp_length,
+            blob_gas,
+        }
     }
 
     pub const ZERO: Self = Self {
         gas: 0,
         rlp_length: 0,
+        blob_gas: 0,
     };
-
-    pub fn gas(&self) -> u64 {
-        self.gas
-    }
-
-    pub fn rlp_length(&self) -> usize {
-        self.rlp_length
-    }
 }
 
 impl AddAssign for BlockSpace {
     fn add_assign(&mut self, other: Self) {
         self.gas += other.gas;
         self.rlp_length += other.rlp_length;
+        self.blob_gas += other.blob_gas;
     }
 }
 
@@ -511,6 +509,7 @@ impl Add for BlockSpace {
         Self {
             gas: self.gas + other.gas,
             rlp_length: self.rlp_length + other.rlp_length,
+            blob_gas: self.blob_gas + other.blob_gas,
         }
     }
 }
@@ -521,26 +520,19 @@ pub struct BlockBuildingSpaceState {
     space_used: BlockSpace,
     /// Reserved gas/size for later use (usually final payout tx). When simulating we subtract this from the block gas limit.
     reserved_block_space: BlockSpace,
-    blob_gas_used: u64,
 }
 
 impl BlockBuildingSpaceState {
-    pub fn new(
-        space_used: BlockSpace,
-        reserved_block_space: BlockSpace,
-        blob_gas_used: u64,
-    ) -> Self {
+    pub fn new(space_used: BlockSpace, reserved_block_space: BlockSpace) -> Self {
         Self {
             space_used,
             reserved_block_space,
-            blob_gas_used,
         }
     }
 
     pub const ZERO: Self = Self {
         space_used: BlockSpace::ZERO,
         reserved_block_space: BlockSpace::ZERO,
-        blob_gas_used: 0,
     };
 
     pub fn free_reserved_block_space(&mut self) {
@@ -557,11 +549,11 @@ impl BlockBuildingSpaceState {
     }
 
     pub fn gas_used(&self) -> u64 {
-        self.space_used.gas()
+        self.space_used.gas
     }
 
     pub fn blob_gas_used(&self) -> u64 {
-        self.blob_gas_used
+        self.space_used.blob_gas
     }
 
     pub fn space_used(&self) -> BlockSpace {
@@ -572,9 +564,8 @@ impl BlockBuildingSpaceState {
         self.reserved_block_space += space;
     }
 
-    pub fn use_space(&mut self, space: BlockSpace, blob_gas_used: u64) {
+    pub fn use_space(&mut self, space: BlockSpace) {
         self.space_used += space;
-        self.blob_gas_used += blob_gas_used;
     }
 }
 
@@ -788,8 +779,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             }
         }
 
-        self.space_state
-            .use_space(ok_result.space_used, ok_result.blob_gas_used);
+        self.space_state.use_space(ok_result.space_used);
         self.coinbase_profit += ok_result.coinbase_profit;
         self.executed_tx_infos.extend(ok_result.tx_infos.clone());
 
@@ -879,8 +869,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
                 return Err(InsertPayoutTxErr::CombinedRefundTxReverted);
             }
 
-            self.space_state
-                .use_space(refund_result.space_used(), refund_result.blob_gas_used);
+            self.space_state.use_space(refund_result.space_used());
             self.executed_tx_infos.push(refund_result.tx_info);
 
             nonce += 1;
@@ -903,8 +892,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             return Err(InsertPayoutTxErr::PayoutTxReverted);
         }
 
-        self.space_state
-            .use_space(ok_result.space_used(), ok_result.blob_gas_used);
+        self.space_state.use_space(ok_result.space_used());
         self.executed_tx_infos.push(ok_result.tx_info);
 
         Ok(())
@@ -957,8 +945,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
                 return Err(InsertPayoutTxErr::CombinedRefundTxReverted);
             }
 
-            self.space_state
-                .use_space(refund_result.space_used(), refund_result.blob_gas_used);
+            self.space_state.use_space(refund_result.space_used());
             self.executed_tx_infos.push(refund_result.tx_info);
 
             nonce += 1;
@@ -997,8 +984,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             return Err(InsertPayoutTxErr::PayoutTxReverted);
         }
 
-        self.space_state
-            .use_space(ok_result.space_used(), ok_result.blob_gas_used);
+        self.space_state.use_space(ok_result.space_used());
         self.executed_tx_infos.push(ok_result.tx_info);
 
         Ok(())
@@ -1353,13 +1339,11 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         state: &mut BlockState,
     ) -> eyre::Result<()> {
         // We "pre-use" the RLP overhead for the withdrawals and the block header.
-        self.space_state.use_space(
-            BlockSpace::new(
-                0,
-                ctx.attributes.withdrawals.length() + BLOCK_HEADER_RLP_OVERHEAD,
-            ),
+        self.space_state.use_space(BlockSpace::new(
             0,
-        );
+            ctx.attributes.withdrawals.length() + BLOCK_HEADER_RLP_OVERHEAD,
+            0,
+        ));
 
         let mut db = state.new_db_ref(&ctx.shared_cached_reads, &mut local_ctx.cached_reads);
         let mut system_caller = SystemCaller::new(ctx.chain_spec.clone());
@@ -1448,7 +1432,6 @@ pub fn create_sim_value(
         order_ok.coinbase_profit,
         non_mempool_coinbase_profit,
         order_ok.space_used,
-        order_ok.blob_gas_used,
         order_ok.paid_kickbacks.clone(),
     )
 }
@@ -1480,19 +1463,17 @@ mod test {
             coinbase_profit: Default::default(),
             space_used: Default::default(),
             cumulative_space_used: Default::default(),
-            blob_gas_used: Default::default(),
-            cumulative_blob_gas_used: Default::default(),
             tx_infos: vec![
                 TransactionExecutionInfo {
                     tx: tx1,
                     receipt: Default::default(),
-                    gas_used: Default::default(),
+                    space_used: Default::default(),
                     coinbase_profit: profit_1,
                 },
                 TransactionExecutionInfo {
                     tx: tx2,
                     receipt: Default::default(),
-                    gas_used: Default::default(),
+                    space_used: Default::default(),
                     coinbase_profit: profit_2,
                 },
             ],
@@ -1531,12 +1512,10 @@ mod test {
             coinbase_profit: profit.unsigned_abs(),
             space_used: Default::default(),
             cumulative_space_used: Default::default(),
-            blob_gas_used: Default::default(),
-            cumulative_blob_gas_used: Default::default(),
             tx_infos: vec![TransactionExecutionInfo {
                 tx,
                 receipt: Default::default(),
-                gas_used: Default::default(),
+                space_used: Default::default(),
                 coinbase_profit: profit,
             }],
             delayed_kickback: None,

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -39,7 +39,6 @@ use jsonrpsee::core::Serialize;
 use reth::{
     payload::PayloadId,
     primitives::{Block, SealedBlock},
-    providers::ExecutionOutcome,
     revm::database::StateProviderDatabase,
 };
 use reth_chainspec::{ChainSpec, EthChainSpec, EthereumHardforks};
@@ -50,7 +49,6 @@ use reth_node_api::{EngineApiMessageVersion, PayloadBuilderAttributes};
 use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_primitives::BlockBody;
 use reth_primitives_traits::{proofs, Block as _};
-use reth_provider::StateProvider;
 use revm::{
     context::BlockEnv,
     context_interface::{block::BlobExcessGasAndPrice, result::InvalidTransaction},
@@ -62,7 +60,7 @@ use serde::Deserialize;
 use std::{
     collections::{hash_map, HashMap, HashSet},
     hash::Hash,
-    ops::{Add, AddAssign},
+    ops::{Add, AddAssign, SubAssign},
     str::FromStr,
     sync::Arc,
     time::{Duration, Instant},
@@ -514,6 +512,14 @@ impl Add for BlockSpace {
     }
 }
 
+impl SubAssign for BlockSpace {
+    fn sub_assign(&mut self, other: Self) {
+        self.gas -= other.gas;
+        self.rlp_length -= other.rlp_length;
+        self.blob_gas -= other.blob_gas;
+    }
+}
+
 /// Models the current state of the block building space.
 #[derive(Debug, Clone, Copy)]
 pub struct BlockBuildingSpaceState {
@@ -566,6 +572,10 @@ impl BlockBuildingSpaceState {
 
     pub fn use_space(&mut self, space: BlockSpace) {
         self.space_used += space;
+    }
+
+    pub fn free_used_state(&mut self, space: BlockSpace) {
+        self.space_used -= space;
     }
 }
 
@@ -827,7 +837,8 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         ctx: &BlockBuildingContext,
         local_ctx: &mut ThreadBlockBuildingContext,
         state: &mut BlockState,
-    ) -> Result<(), InsertPayoutTxErr> {
+        adjust_finalized_block: bool,
+    ) -> Result<BlockSpace, InsertPayoutTxErr> {
         let builder_signer = &ctx.builder_signer;
         self.free_reserved_block_space();
         let mut nonce = state
@@ -840,39 +851,42 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
 
         let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
 
-        for (refund_recipient, refund_amount) in &self.combined_refunds {
-            let refund_recipient_code_hash = fork
-                .state
-                .code_hash(
-                    *refund_recipient,
-                    &ctx.shared_cached_reads,
-                    &mut fork.local_ctx.cached_reads,
-                )
-                .map_err(CriticalCommitOrderError::Reth)?;
-            if refund_recipient_code_hash != KECCAK_EMPTY {
-                error!(%refund_recipient_code_hash, %refund_recipient, %refund_amount, "Refund recipient has code, skipping refund");
-                continue;
+        if !adjust_finalized_block {
+            for (refund_recipient, refund_amount) in &self.combined_refunds {
+                let refund_recipient_code_hash = fork
+                    .state
+                    .code_hash(
+                        *refund_recipient,
+                        &ctx.shared_cached_reads,
+                        &mut fork.local_ctx.cached_reads,
+                    )
+                    .map_err(CriticalCommitOrderError::Reth)?;
+                if refund_recipient_code_hash != KECCAK_EMPTY {
+                    error!(%refund_recipient_code_hash, %refund_recipient, %refund_amount, "Refund recipient has code, skipping refund");
+                    continue;
+                }
+
+                let refund_tx =
+                    TransactionSignedEcRecoveredWithBlobs::new_no_blobs(create_payout_tx(
+                        ctx.chain_spec.as_ref(),
+                        ctx.evm_env.block_env.basefee,
+                        builder_signer,
+                        nonce,
+                        *refund_recipient,
+                        BASE_TX_GAS,
+                        *refund_amount,
+                    )?)
+                    .unwrap();
+                let refund_result = fork.commit_tx(&refund_tx, self.space_state)??;
+                if !refund_result.tx_info.receipt.success {
+                    return Err(InsertPayoutTxErr::CombinedRefundTxReverted);
+                }
+
+                self.space_state.use_space(refund_result.space_used());
+                self.executed_tx_infos.push(refund_result.tx_info);
+
+                nonce += 1;
             }
-
-            let refund_tx = TransactionSignedEcRecoveredWithBlobs::new_no_blobs(create_payout_tx(
-                ctx.chain_spec.as_ref(),
-                ctx.evm_env.block_env.basefee,
-                builder_signer,
-                nonce,
-                *refund_recipient,
-                BASE_TX_GAS,
-                *refund_amount,
-            )?)
-            .unwrap();
-            let refund_result = fork.commit_tx(&refund_tx, self.space_state)??;
-            if !refund_result.tx_info.receipt.success {
-                return Err(InsertPayoutTxErr::CombinedRefundTxReverted);
-            }
-
-            self.space_state.use_space(refund_result.space_used());
-            self.executed_tx_infos.push(refund_result.tx_info);
-
-            nonce += 1;
         }
 
         let tx = create_payout_tx(
@@ -892,102 +906,28 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             return Err(InsertPayoutTxErr::PayoutTxReverted);
         }
 
-        self.space_state.use_space(ok_result.space_used());
+        let payment_tx_block_space = ok_result.space_used();
+        self.space_state.use_space(payment_tx_block_space);
         self.executed_tx_infos.push(ok_result.tx_info);
 
-        Ok(())
+        Ok(payment_tx_block_space)
     }
 
-    pub fn insert_combined_refunds_two_step_finalize(
+    // when adjusting prefinalized block we revert two state changes:
+    // 1. Payment transaction
+    // 2. Requests processing (e.g. withdrawals)
+    const ADJUST_PREFINALIZE_REVERT_SIZE: usize = 2;
+
+    pub fn adjust_finalize_block_revert_to_prefinalized_state(
         &mut self,
-        ctx: &BlockBuildingContext,
-        local_ctx: &mut ThreadBlockBuildingContext,
-        state: &mut BlockState,
-    ) -> Result<u64, InsertPayoutTxErr> {
-        let builder_signer = &ctx.builder_signer;
-        self.free_reserved_block_space();
-        let mut nonce = state
-            .nonce(
-                builder_signer.address,
-                &ctx.shared_cached_reads,
-                &mut local_ctx.cached_reads,
-            )
-            .map_err(CriticalCommitOrderError::Reth)?;
-
-        let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
-
-        for (refund_recipient, refund_amount) in &self.combined_refunds {
-            let refund_recipient_code_hash = fork
-                .state
-                .code_hash(
-                    *refund_recipient,
-                    &ctx.shared_cached_reads,
-                    &mut fork.local_ctx.cached_reads,
-                )
-                .map_err(CriticalCommitOrderError::Reth)?;
-            if refund_recipient_code_hash != KECCAK_EMPTY {
-                error!(%refund_recipient_code_hash, %refund_recipient, %refund_amount, "Refund recipient has code, skipping refund");
-                continue;
-            }
-
-            let refund_tx = TransactionSignedEcRecoveredWithBlobs::new_no_blobs(create_payout_tx(
-                ctx.chain_spec.as_ref(),
-                ctx.evm_env.block_env.basefee,
-                builder_signer,
-                nonce,
-                *refund_recipient,
-                BASE_TX_GAS,
-                *refund_amount,
-            )?)
-            .unwrap();
-            let refund_result = fork.commit_tx(&refund_tx, self.space_state)??;
-            if !refund_result.tx_info.receipt.success {
-                return Err(InsertPayoutTxErr::CombinedRefundTxReverted);
-            }
-
-            self.space_state.use_space(refund_result.space_used());
-            self.executed_tx_infos.push(refund_result.tx_info);
-
-            nonce += 1;
-        }
-
-        Ok(nonce)
-    }
-
-    pub fn insert_refund_tx_two_step_finalize(
-        &mut self,
-        ctx: &BlockBuildingContext,
-        local_ctx: &mut ThreadBlockBuildingContext,
-        state: &mut BlockState,
-        gas_limit: u64,
-        value: U256,
-        nonce: u64,
-    ) -> Result<(), InsertPayoutTxErr> {
-        let builder_signer = &ctx.builder_signer;
-
-        let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
-
-        let tx = create_payout_tx(
-            ctx.chain_spec.as_ref(),
-            ctx.evm_env.block_env.basefee,
-            builder_signer,
-            nonce,
-            ctx.attributes.suggested_fee_recipient,
-            gas_limit,
-            value,
-        )?;
-        // payout tx has no blobs so it's safe to unwrap
-        let tx = TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx).unwrap();
-        let exec_result = fork.commit_tx(&tx, self.space_state)?;
-        let ok_result = exec_result?;
-        if !ok_result.tx_info.receipt.success {
-            return Err(InsertPayoutTxErr::PayoutTxReverted);
-        }
-
-        self.space_state.use_space(ok_result.space_used());
-        self.executed_tx_infos.push(ok_result.tx_info);
-
-        Ok(())
+        last_tx_block_space: BlockSpace,
+        block_state: &mut BlockState,
+    ) {
+        self.space_state.free_used_state(last_tx_block_space);
+        self.executed_tx_infos.pop();
+        block_state
+            .bundle_state_mut()
+            .revert(Self::ADJUST_PREFINALIZE_REVERT_SIZE);
     }
 
     /// returns (requests, withdrawals_root)
@@ -1056,15 +996,16 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
 
     /// Mostly based on reth's (v1.2) default_ethereum_payload_builder.
     pub fn finalize(
-        self,
-        mut state: BlockState,
+        &mut self,
+        state: &mut BlockState,
         ctx: &BlockBuildingContext,
         local_ctx: &mut ThreadBlockBuildingContext,
+        adjust_finalize_block: bool,
     ) -> Result<FinalizeResult, FinalizeError> {
         let start = Instant::now();
 
         let step_start = Instant::now();
-        let (requests, withdrawals_root) = self.process_requests(&mut state, ctx, local_ctx)?;
+        let (requests, withdrawals_root) = self.process_requests(state, ctx, local_ctx)?;
         let block_number = ctx.block();
 
         let request_processsing_time_ms = elapsed_ms(step_start);
@@ -1083,46 +1024,46 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             &mut local_ctx.bloom_cache,
             &self.executed_tx_infos,
             ctx.faster_finalize,
+            adjust_finalize_block,
         );
 
         let bloom_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
-        // calculate the state root
-        let (bundle, state_provider) = state.into_parts();
-        // we use execution outcome here only for interface compatibility, its just a wrapper around bundle
-        let mut execution_outcome =
-            ExecutionOutcome::new(bundle, Vec::new(), block_number, Vec::new());
-        let state_root = ctx.root_hasher.state_root(&execution_outcome, local_ctx)?;
+        let incremental_change = if adjust_finalize_block {
+            let mut result = Vec::new();
+            state
+                .bundle_state()
+                .reverts
+                .iter()
+                .rev()
+                .take(Self::ADJUST_PREFINALIZE_REVERT_SIZE)
+                .for_each(|r| r.iter().for_each(|c| result.push(c.0)));
+            result
+        } else {
+            Vec::new()
+        };
+
+        // // calculate the state root
+        let state_root =
+            ctx.root_hasher
+                .state_root(state.bundle_state(), &incremental_change, local_ctx)?;
         let root_hash_time = step_start.elapsed();
 
         let root_hash_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
 
-        // create the block header
+        // // create the block header
         let (transactions_root, placeholder_transaction_proof) =
             calculate_tx_root_and_placeholder_proof(
                 &mut local_ctx.tx_root_cache,
                 &self.executed_tx_infos,
                 ctx.faster_finalize,
+                adjust_finalize_block,
             );
 
         let transactions_root_time_ms = elapsed_ms(step_start);
         let step_start = Instant::now();
-
-        // double check blocked txs
-        for tx_with_blob in self.executed_tx_infos.iter().map(|info| &info.tx) {
-            if ctx.blocklist.contains(&tx_with_blob.signer()) {
-                return Err(FinalizeError::Other(eyre::eyre!(
-                    "To from blocked address."
-                )));
-            }
-            if let Some(to) = tx_with_blob.to() {
-                if ctx.blocklist.contains(&to) {
-                    return Err(FinalizeError::Other(eyre::eyre!("Tx to blocked address")));
-                }
-            }
-        }
 
         let mut txs_blob_sidecars: Vec<Arc<BlobTransactionSidecarVariant>> = Vec::new();
         let (excess_blob_gas, blob_gas_used) = if ctx
@@ -1190,6 +1131,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             body: BlockBody {
                 transactions: self
                     .executed_tx_infos
+                    .clone()
                     .into_iter()
                     .map(|t| t.tx.into_internal_tx_unsecure().into_inner())
                     .collect(),
@@ -1200,8 +1142,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
 
         let bid_adjustments = Self::generate_bid_adjustments(
             &block.header,
-            &state_provider,
-            &mut execution_outcome,
+            state,
             ctx,
             local_ctx,
             placeholder_transaction_proof,
@@ -1243,8 +1184,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
 
     fn generate_bid_adjustments(
         header: &Header,
-        state_provider: &impl StateProvider,
-        outcome: &mut ExecutionOutcome,
+        block_state: &mut BlockState,
         ctx: &BlockBuildingContext,
         local_ctx: &mut ThreadBlockBuildingContext,
         placeholder_transaction_proof: Vec<Bytes>,
@@ -1267,12 +1207,14 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         // Pre-load all proof targets that are missing from the bundle state.
         // This is a requirement for accounts to become a part of the trie and be able to generate proofs for them.
         let mut cachedb = CachedDB::new(
-            StateProviderDatabase::new(state_provider),
+            StateProviderDatabase::new(block_state.state_provider()),
             &mut local_ctx.cached_reads,
             &ctx.shared_cached_reads,
         );
         for fee_payer in &ctx.adjustment_fee_payers {
-            if let hash_map::Entry::Vacant(entry) = outcome.bundle.state.entry(*fee_payer) {
+            if let hash_map::Entry::Vacant(entry) =
+                block_state.bundle_state_mut().state.entry(*fee_payer)
+            {
                 let account_info = cachedb
                     .basic(*fee_payer)
                     .map_err(|error| FinalizeError::Other(error.into()))?;
@@ -1285,9 +1227,11 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             }
         }
 
-        let mut account_proofs =
-            ctx.root_hasher
-                .account_proofs(outcome, &proof_targets, local_ctx)?;
+        let mut account_proofs = ctx.root_hasher.account_proofs(
+            block_state.bundle_state(),
+            &proof_targets,
+            local_ctx,
+        )?;
 
         let Some(builder_proof) = account_proofs.remove(&builder_address) else {
             return Err(FinalizeError::Other(eyre::eyre!(

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -703,6 +703,14 @@ impl FinalizeError {
     }
 }
 
+/// FinalizeRevertState accumulates data needed to revert state changes
+/// to run finalize on the same PartialBlock / BlockState again
+#[derive(Debug, Clone, Default)]
+pub struct FinalizeRevertState {
+    pub last_tx_block_space: BlockSpace,
+    pub state_reverts: usize,
+}
+
 impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExecutionTracer>
     PartialBlock<Tracer, PartialBlockExecutionTracerType>
 {
@@ -830,6 +838,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
 
     /// Inserts payout tx to ctx.attributes.suggested_fee_recipient (should be called at the end of the block)
     /// Returns the paid value (block profit after subtracting the burned basefee of the payout tx)
+    #[allow(clippy::too_many_arguments)]
     pub fn insert_refunds_and_proposer_payout_tx(
         &mut self,
         gas_limit: u64,
@@ -838,7 +847,8 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         local_ctx: &mut ThreadBlockBuildingContext,
         state: &mut BlockState,
         adjust_finalized_block: bool,
-    ) -> Result<BlockSpace, InsertPayoutTxErr> {
+        finalize_revert_state: &mut FinalizeRevertState,
+    ) -> Result<(), InsertPayoutTxErr> {
         let builder_signer = &ctx.builder_signer;
         self.free_reserved_block_space();
         let mut nonce = state
@@ -905,29 +915,26 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         if !ok_result.tx_info.receipt.success {
             return Err(InsertPayoutTxErr::PayoutTxReverted);
         }
-
-        let payment_tx_block_space = ok_result.space_used();
-        self.space_state.use_space(payment_tx_block_space);
+        finalize_revert_state.last_tx_block_space = ok_result.space_used();
+        // add revert for commit_tx for the last payment transaction
+        finalize_revert_state.state_reverts += 1;
+        self.space_state.use_space(ok_result.space_used());
         self.executed_tx_infos.push(ok_result.tx_info);
 
-        Ok(payment_tx_block_space)
+        Ok(())
     }
-
-    // when adjusting prefinalized block we revert two state changes:
-    // 1. Payment transaction
-    // 2. Requests processing (e.g. withdrawals)
-    const ADJUST_PREFINALIZE_REVERT_SIZE: usize = 2;
 
     pub fn adjust_finalize_block_revert_to_prefinalized_state(
         &mut self,
-        last_tx_block_space: BlockSpace,
+        finalize_revert_state: FinalizeRevertState,
         block_state: &mut BlockState,
     ) {
-        self.space_state.free_used_state(last_tx_block_space);
+        self.space_state
+            .free_used_state(finalize_revert_state.last_tx_block_space);
         self.executed_tx_infos.pop();
         block_state
             .bundle_state_mut()
-            .revert(Self::ADJUST_PREFINALIZE_REVERT_SIZE);
+            .revert(finalize_revert_state.state_reverts);
     }
 
     /// returns (requests, withdrawals_root)
@@ -936,6 +943,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         state: &mut BlockState,
         ctx: &BlockBuildingContext,
         local_ctx: &mut ThreadBlockBuildingContext,
+        finalize_revert_state: &mut FinalizeRevertState,
     ) -> Result<(Option<Requests>, Option<B256>), FinalizeError> {
         let mut db = state.new_db_ref(&ctx.shared_cached_reads, &mut local_ctx.cached_reads);
 
@@ -990,6 +998,8 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         };
 
         db.db().merge_transitions(BundleRetention::Reverts);
+        // add one revert for processed requests
+        finalize_revert_state.state_reverts += 1;
 
         Ok((requests, withdrawals_root))
     }
@@ -1001,11 +1011,13 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         ctx: &BlockBuildingContext,
         local_ctx: &mut ThreadBlockBuildingContext,
         adjust_finalize_block: bool,
+        finalize_revert_state: &mut FinalizeRevertState,
     ) -> Result<FinalizeResult, FinalizeError> {
         let start = Instant::now();
 
         let step_start = Instant::now();
-        let (requests, withdrawals_root) = self.process_requests(state, ctx, local_ctx)?;
+        let (requests, withdrawals_root) =
+            self.process_requests(state, ctx, local_ctx, finalize_revert_state)?;
         let block_number = ctx.block();
 
         let request_processsing_time_ms = elapsed_ms(step_start);
@@ -1031,13 +1043,14 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         let step_start = Instant::now();
 
         let incremental_change = if adjust_finalize_block {
+            // get list of account that changed after finalize was called
             let mut result = Vec::new();
             state
                 .bundle_state()
                 .reverts
                 .iter()
                 .rev()
-                .take(Self::ADJUST_PREFINALIZE_REVERT_SIZE)
+                .take(finalize_revert_state.state_reverts)
                 .for_each(|r| r.iter().for_each(|c| result.push(c.0)));
             result
         } else {

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -514,9 +514,9 @@ impl Add for BlockSpace {
 
 impl SubAssign for BlockSpace {
     fn sub_assign(&mut self, other: Self) {
-        self.gas -= other.gas;
-        self.rlp_length -= other.rlp_length;
-        self.blob_gas -= other.blob_gas;
+        self.gas = self.gas.checked_sub(other.gas).unwrap();
+        self.rlp_length = self.rlp_length.checked_sub(other.rlp_length).unwrap();
+        self.blob_gas = self.blob_gas.checked_sub(other.blob_gas).unwrap();
     }
 }
 

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -910,6 +910,100 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         Ok(())
     }
 
+    pub fn insert_combined_refunds_two_step_finalize(
+        &mut self,
+        ctx: &BlockBuildingContext,
+        local_ctx: &mut ThreadBlockBuildingContext,
+        state: &mut BlockState,
+    ) -> Result<u64, InsertPayoutTxErr> {
+        let builder_signer = &ctx.builder_signer;
+        self.free_reserved_block_space();
+        let mut nonce = state
+            .nonce(
+                builder_signer.address,
+                &ctx.shared_cached_reads,
+                &mut local_ctx.cached_reads,
+            )
+            .map_err(CriticalCommitOrderError::Reth)?;
+
+        let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
+
+        for (refund_recipient, refund_amount) in &self.combined_refunds {
+            let refund_recipient_code_hash = fork
+                .state
+                .code_hash(
+                    *refund_recipient,
+                    &ctx.shared_cached_reads,
+                    &mut fork.local_ctx.cached_reads,
+                )
+                .map_err(CriticalCommitOrderError::Reth)?;
+            if refund_recipient_code_hash != KECCAK_EMPTY {
+                error!(%refund_recipient_code_hash, %refund_recipient, %refund_amount, "Refund recipient has code, skipping refund");
+                continue;
+            }
+
+            let refund_tx = TransactionSignedEcRecoveredWithBlobs::new_no_blobs(create_payout_tx(
+                ctx.chain_spec.as_ref(),
+                ctx.evm_env.block_env.basefee,
+                builder_signer,
+                nonce,
+                *refund_recipient,
+                BASE_TX_GAS,
+                *refund_amount,
+            )?)
+            .unwrap();
+            let refund_result = fork.commit_tx(&refund_tx, self.space_state)??;
+            if !refund_result.tx_info.receipt.success {
+                return Err(InsertPayoutTxErr::CombinedRefundTxReverted);
+            }
+
+            self.space_state
+                .use_space(refund_result.space_used(), refund_result.blob_gas_used);
+            self.executed_tx_infos.push(refund_result.tx_info);
+
+            nonce += 1;
+        }
+
+        Ok(nonce)
+    }
+
+    pub fn insert_refund_tx_two_step_finalize(
+        &mut self,
+        ctx: &BlockBuildingContext,
+        local_ctx: &mut ThreadBlockBuildingContext,
+        state: &mut BlockState,
+        gas_limit: u64,
+        value: U256,
+        nonce: u64,
+    ) -> Result<(), InsertPayoutTxErr> {
+        let builder_signer = &ctx.builder_signer;
+
+        let mut fork = PartialBlockFork::new(state, ctx, local_ctx).with_tracer(&mut self.tracer);
+
+        let tx = create_payout_tx(
+            ctx.chain_spec.as_ref(),
+            ctx.evm_env.block_env.basefee,
+            builder_signer,
+            nonce,
+            ctx.attributes.suggested_fee_recipient,
+            gas_limit,
+            value,
+        )?;
+        // payout tx has no blobs so it's safe to unwrap
+        let tx = TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx).unwrap();
+        let exec_result = fork.commit_tx(&tx, self.space_state)?;
+        let ok_result = exec_result?;
+        if !ok_result.tx_info.receipt.success {
+            return Err(InsertPayoutTxErr::PayoutTxReverted);
+        }
+
+        self.space_state
+            .use_space(ok_result.space_used(), ok_result.blob_gas_used);
+        self.executed_tx_infos.push(ok_result.tx_info);
+
+        Ok(())
+    }
+
     /// returns (requests, withdrawals_root)
     pub fn process_requests(
         &self,

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -71,6 +71,18 @@ impl BlockState {
         (self.bundle_state.unwrap(), self.provider)
     }
 
+    pub fn bundle_state(&self) -> &BundleState {
+        self.bundle_state.as_ref().unwrap()
+    }
+
+    pub fn bundle_state_mut(&mut self) -> &mut BundleState {
+        self.bundle_state.as_mut().unwrap()
+    }
+
+    pub fn state_provider(&self) -> Arc<dyn StateProvider> {
+        self.provider.clone()
+    }
+
     pub fn clone_bundle(&self) -> BundleState {
         self.bundle_state.clone().unwrap()
     }

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -190,7 +190,7 @@ where
 pub struct TransactionExecutionInfo {
     pub tx: TransactionSignedEcRecoveredWithBlobs,
     pub receipt: Receipt,
-    pub gas_used: u64,
+    pub space_used: BlockSpace,
     /// coinbase balance after tx - before.
     pub coinbase_profit: I256,
 }
@@ -198,8 +198,6 @@ pub struct TransactionExecutionInfo {
 pub struct TransactionOk {
     pub exec_result: ExecutionResult,
     pub cumulative_space_used: BlockSpace,
-    pub blob_gas_used: u64,
-    pub cumulative_blob_gas_used: u64,
     pub tx_info: TransactionExecutionInfo,
     /// nonces_updates is nonce after tx was applied.
     /// account nonce was 0, tx was included, nonce is 1. => nonce_updated.1 == 1
@@ -208,7 +206,7 @@ pub struct TransactionOk {
 
 impl TransactionOk {
     pub fn space_used(&self) -> BlockSpace {
-        BlockSpace::new(self.tx_info.gas_used, self.tx_info.tx.length_eip7934())
+        self.tx_info.space_used
     }
 }
 
@@ -238,8 +236,6 @@ pub struct DelayedKickback {
 pub struct BundleOk {
     pub space_used: BlockSpace,
     pub cumulative_space_used: BlockSpace,
-    pub blob_gas_used: u64,
-    pub cumulative_blob_gas_used: u64,
     pub tx_infos: Vec<TransactionExecutionInfo>,
     /// nonces_updates has a set of deduplicated final nonces of the txs in the order
     pub nonces_updated: Vec<(Address, u64)>,
@@ -255,11 +251,7 @@ pub struct BundleOk {
 impl BundleOk {
     /// Creates the current space state by adding the reserved block space to the cumulative space used.
     pub fn space_state(&self, reserved_block_space: BlockSpace) -> BlockBuildingSpaceState {
-        BlockBuildingSpaceState::new(
-            self.cumulative_space_used,
-            reserved_block_space,
-            self.cumulative_blob_gas_used,
-        )
+        BlockBuildingSpaceState::new(self.cumulative_space_used, reserved_block_space)
     }
 }
 
@@ -312,8 +304,6 @@ pub struct OrderOk {
     pub coinbase_profit: U256,
     pub space_used: BlockSpace,
     pub cumulative_space_used: BlockSpace,
-    pub blob_gas_used: u64,
-    pub cumulative_blob_gas_used: u64,
     pub tx_infos: Vec<TransactionExecutionInfo>,
     /// Patch to get the executed OrderIds for merged sbundles (see: [`BundleOk::original_order_ids`],[`ShareBundleMerger`] )
     pub original_order_ids: Vec<OrderId>,
@@ -542,11 +532,11 @@ impl<
         space_state: BlockBuildingSpaceState,
     ) -> Result<(), TransactionErr> {
         let total_consumed_space = space_state.total_consumed_space();
-        if space_needed.rlp_length() + total_consumed_space.rlp_length() > MAX_RLP_BLOCK_SIZE {
+        if space_needed.rlp_length + total_consumed_space.rlp_length > MAX_RLP_BLOCK_SIZE {
             return Err(TransactionErr::BlockSpaceLeft);
         }
 
-        if space_needed.gas() + total_consumed_space.gas() > self.ctx.evm_env.block_env.gas_limit {
+        if space_needed.gas + total_consumed_space.gas > self.ctx.evm_env.block_env.gas_limit {
             return Err(TransactionErr::GasLeft);
         }
 
@@ -667,9 +657,10 @@ impl<
         let space_used = BlockSpace::new(
             res.result.gas_used(),
             tx_with_blobs.internal_tx_unsecure().length(),
+            blob_gas_used,
         );
 
-        space_state.use_space(space_used, blob_gas_used);
+        space_state.use_space(space_used);
 
         let success = res.result.is_success();
         let receipt = Receipt {
@@ -681,13 +672,11 @@ impl<
         let coinbase_balance_after = I256::try_from(self.coinbase_balance()?)?;
         Ok(Ok(TransactionOk {
             exec_result: res.result,
-            blob_gas_used,
-            cumulative_blob_gas_used: space_state.blob_gas_used(),
             cumulative_space_used: space_state.space_used(),
             tx_info: TransactionExecutionInfo {
                 tx: tx_with_blobs.clone(),
                 receipt,
-                gas_used: space_used.gas(),
+                space_used,
                 coinbase_profit: coinbase_balance_after - coinbase_balance_before,
             },
             nonce_updated: (tx.signer(), tx.nonce() + 1),
@@ -735,8 +724,6 @@ impl<
     fn accumulate_tx_execution(transaction_ok: TransactionOk, bundle_ok: &mut BundleOk) {
         bundle_ok.space_used += transaction_ok.space_used();
         bundle_ok.cumulative_space_used = transaction_ok.cumulative_space_used;
-        bundle_ok.blob_gas_used += transaction_ok.blob_gas_used;
-        bundle_ok.cumulative_blob_gas_used = transaction_ok.cumulative_blob_gas_used;
         bundle_ok.tx_infos.push(transaction_ok.tx_info);
         update_nonce_list(&mut bundle_ok.nonces_updated, transaction_ok.nonce_updated);
     }
@@ -754,8 +741,7 @@ impl<
                     return Err(BundleErr::EstimatePayoutGas(err));
                 }
             };
-        let base_fee =
-            U256::from(self.ctx.evm_env.block_env.basefee) * U256::from(space_limit.gas());
+        let base_fee = U256::from(self.ctx.evm_env.block_env.basefee) * U256::from(space_limit.gas);
         if base_fee > refundable_value {
             return Err(BundleErr::NotEnoughRefundForGas {
                 to,
@@ -794,7 +780,7 @@ impl<
             builder_signer,
             nonce,
             to,
-            payout.space_limit.gas(),
+            payout.space_limit.gas,
             payout.tx_value,
         ) {
             // payout tx has no blobs so it's safe to unwrap
@@ -809,7 +795,7 @@ impl<
                 if !res.tx_info.receipt.success {
                     return Ok(Err(BundleErr::FailedToCommitPayoutTx {
                         to,
-                        gas_limit: payout.space_limit.gas(),
+                        gas_limit: payout.space_limit.gas,
                         value: payout.tx_value,
                         err: None,
                     }));
@@ -820,7 +806,7 @@ impl<
             Err(err) => {
                 return Ok(Err(BundleErr::FailedToCommitPayoutTx {
                     to,
-                    gas_limit: payout.space_limit.gas(),
+                    gas_limit: payout.space_limit.gas,
                     value: payout.tx_value,
                     err: Some(err),
                 }));
@@ -840,8 +826,6 @@ impl<
         let mut insert = BundleOk {
             space_used: BlockSpace::ZERO,
             cumulative_space_used: space_state.space_used(),
-            blob_gas_used: 0,
-            cumulative_blob_gas_used: space_state.blob_gas_used(),
             tx_infos: Vec::new(),
             nonces_updated: Vec::new(),
             paid_kickbacks: Vec::new(),
@@ -885,7 +869,7 @@ impl<
                 }
             }
         }
-        if insert.space_used.gas() == 0 {
+        if insert.space_used.gas == 0 {
             return Ok(Err(BundleErr::EmptyBundle));
         }
 
@@ -921,7 +905,7 @@ impl<
             };
 
             let space_state = insert.space_state(space_state.reserved_block_space());
-            if payout.space_limit.gas() == BASE_TX_GAS
+            if payout.space_limit.gas == BASE_TX_GAS
                 && self.can_fit_tx(payout.space_limit, 0, space_state).is_ok()
             {
                 // This refund recipient is eligible for a combined refund at the end of the block.
@@ -1020,8 +1004,6 @@ impl<
         let mut insert = BundleOk {
             space_used: BlockSpace::ZERO,
             cumulative_space_used: space_state.space_used(),
-            blob_gas_used: 0,
-            cumulative_blob_gas_used: space_state.blob_gas_used(),
             tx_infos: Vec::new(),
             nonces_updated: Vec::new(),
             paid_kickbacks: Vec::new(),
@@ -1099,9 +1081,6 @@ impl<
                                 .extend(res.bundle_ok.original_order_ids);
                             insert.space_used += res.bundle_ok.space_used;
                             insert.cumulative_space_used = res.bundle_ok.cumulative_space_used;
-                            insert.blob_gas_used += res.bundle_ok.blob_gas_used;
-                            insert.cumulative_blob_gas_used =
-                                res.bundle_ok.cumulative_blob_gas_used;
                             insert.tx_infos.extend(res.bundle_ok.tx_infos);
                             update_nonce_list_with_updates(
                                 &mut insert.nonces_updated,
@@ -1221,8 +1200,6 @@ impl<
                             coinbase_profit,
                             space_used: ok.space_used(),
                             cumulative_space_used: ok.cumulative_space_used,
-                            blob_gas_used: ok.blob_gas_used,
-                            cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
                             tx_infos: vec![ok.tx_info],
                             nonces_updated: vec![ok.nonce_updated],
                             paid_kickbacks: Vec::new(),
@@ -1274,8 +1251,6 @@ impl<
                     coinbase_profit,
                     space_used: ok.space_used,
                     cumulative_space_used: ok.cumulative_space_used,
-                    blob_gas_used: ok.blob_gas_used,
-                    cumulative_blob_gas_used: ok.cumulative_blob_gas_used,
                     tx_infos: ok.tx_infos,
                     nonces_updated: ok.nonces_updated,
                     paid_kickbacks: ok.paid_kickbacks,

--- a/crates/rbuilder/src/building/payout_tx.rs
+++ b/crates/rbuilder/src/building/payout_tx.rs
@@ -139,6 +139,7 @@ fn estimate_payout_tx_space(ctx: &BlockBuildingContext) -> Result<BlockSpace, se
     Ok(BlockSpace::new(
         BASE_TX_GAS,
         tx.inner().length() + 32 * 4, /* To account for any possible length encoding on ZERO fields */
+        0,
     ))
 }
 
@@ -162,7 +163,7 @@ pub fn estimate_payout_gas_limit(
         .evm_env
         .block_env
         .gas_limit
-        .checked_sub(space_used.gas())
+        .checked_sub(space_used.gas)
         .unwrap_or_default();
     let estimation = insert_test_payout_tx(to, ctx, local_ctx, state, gas_left)?
         .ok_or(EstimatePayoutGasErr::FailedToEstimate)?;
@@ -170,7 +171,8 @@ pub fn estimate_payout_gas_limit(
     if insert_test_payout_tx(to, ctx, local_ctx, state, estimation)?.is_some() {
         return Ok(BlockSpace::new(
             estimation,
-            default_payout_tx_space.rlp_length(),
+            default_payout_tx_space.rlp_length,
+            0,
         ));
     }
 
@@ -181,7 +183,11 @@ pub fn estimate_payout_gas_limit(
     loop {
         let mid = (left + right) / 2;
         if mid == left || mid == right {
-            return Ok(BlockSpace::new(right, default_payout_tx_space.rlp_length()));
+            return Ok(BlockSpace::new(
+                right,
+                default_payout_tx_space.rlp_length,
+                0,
+            ));
         }
 
         if insert_test_payout_tx(to, ctx, local_ctx, state, mid)?.is_some() {
@@ -254,6 +260,6 @@ mod tests {
         let estimate_result =
             estimate_payout_gas_limit(proposer, &ctx, &mut local_ctx, &mut state, BlockSpace::ZERO);
         assert_matches!(estimate_result, Ok(_));
-        assert_eq!(estimate_result.unwrap().gas(), 21_000);
+        assert_eq!(estimate_result.unwrap().gas, 21_000);
     }
 }

--- a/crates/rbuilder/src/building/sim.rs
+++ b/crates/rbuilder/src/building/sim.rs
@@ -449,7 +449,7 @@ pub fn simulate_order_using_fork<Tracer: SimulationTracer>(
         let result = fork.commit_order(&parent, space_state, true, &combined_refunds)?;
         match result {
             Ok(res) => {
-                space_state.use_space(res.space_used, res.blob_gas_used);
+                space_state.use_space(res.space_used);
             }
             Err(err) => {
                 tracing::trace!(parent_order = ?parent.id(), ?err, "failed to simulate parent order");

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -755,7 +755,7 @@ fn bundle_revert_modes_tests(share_bundle: bool) -> eyre::Result<()> {
     // Bundles behave different to sbundles on empty execution
     if share_bundle {
         let res = test_setup.commit_order_ok();
-        assert_eq!(res.space_used.gas(), 0);
+        assert_eq!(res.space_used.gas, 0);
     } else {
         test_setup.commit_order_err_check(|err| {
             assert!(matches!(err, OrderErr::Bundle(BundleErr::EmptyBundle)));
@@ -766,27 +766,27 @@ fn bundle_revert_modes_tests(share_bundle: bool) -> eyre::Result<()> {
     begin_bundle(&mut test_setup);
     test_setup.add_revert(tx_sender0, TxRevertBehavior::AllowedIncluded)?;
     let res = test_setup.commit_order_ok();
-    let reverting_gas = res.space_used.gas();
+    let reverting_gas = res.space_used.gas;
 
     // Measure reverting tx
     begin_bundle(&mut test_setup);
     test_setup.add_send_to_coinbase_tx(tx_sender0, 0)?;
     let res = test_setup.commit_order_ok();
-    let send_gas = res.space_used.gas();
+    let send_gas = res.space_used.gas;
 
     // send + rev on AllowedIncluded pay both gases
     begin_bundle(&mut test_setup);
     test_setup.add_send_to_coinbase_tx(tx_sender1, 0)?;
     test_setup.add_revert(tx_sender0, TxRevertBehavior::AllowedIncluded)?;
     let res = test_setup.commit_order_ok();
-    assert_eq!(res.space_used.gas(), send_gas + reverting_gas);
+    assert_eq!(res.space_used.gas, send_gas + reverting_gas);
 
     // send + rev on AllowedExcluded pay send
     begin_bundle(&mut test_setup);
     test_setup.add_send_to_coinbase_tx(tx_sender0, 0)?;
     test_setup.add_revert(tx_sender1, TxRevertBehavior::AllowedExcluded)?;
     let res = test_setup.commit_order_ok();
-    assert_eq!(res.space_used.gas(), send_gas);
+    assert_eq!(res.space_used.gas, send_gas);
 
     Ok(())
 }

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -129,6 +129,10 @@ pub struct BaseConfig {
     /// if 0 global rayon pool is used
     root_hash_threads: usize,
 
+    /// use pipelined finalization where blocks are "prefinalized" first
+    /// and payment tx is inserted later for faster bidding response time
+    pub adjust_finalized_blocks: bool,
+
     pub watchdog_timeout_sec: Option<u64>,
 
     /// List of `builders` to be used for live building
@@ -573,6 +577,7 @@ impl Default for BaseConfig {
             root_hash_sparse_trie_version: "v1".to_string(),
             root_hash_compare_sparse_trie: false,
             root_hash_threads: 0,
+            adjust_finalized_blocks: false,
             watchdog_timeout_sec: None,
             backtest_fetch_mempool_data_dir: "/mnt/data/mempool".into(),
             backtest_fetch_eth_rpc_url: "http://127.0.0.1:8545".to_string(),

--- a/crates/rbuilder/src/live_builder/block_output/best_block_from_algorithms.rs
+++ b/crates/rbuilder/src/live_builder/block_output/best_block_from_algorithms.rs
@@ -1,0 +1,184 @@
+use ahash::HashMap;
+use derivative::Derivative;
+
+use crate::building::builders::block_building_helper::BiddableUnfinishedBlock;
+
+/// BestBlockFromAlgorithms maintains last block by each algorithm
+/// When new block is created we choose best (by profit) block from last blocks produced by each algorithm.
+#[derive(Derivative, Default)]
+#[derivative(Debug)]
+pub struct BestBlockFromAlgorithms {
+    #[derivative(Debug = "ignore")]
+    last_block_by_algorithm: HashMap<String, BiddableUnfinishedBlock>,
+    last_best_block_hash: u64,
+}
+
+impl BestBlockFromAlgorithms {
+    pub fn update_with_new_block(
+        &mut self,
+        unfinished_block: BiddableUnfinishedBlock,
+    ) -> Option<BiddableUnfinishedBlock> {
+        self.last_block_by_algorithm.insert(
+            unfinished_block.block.builder_name().to_string(),
+            unfinished_block,
+        );
+        let last_best_block = self
+            .last_block_by_algorithm
+            .values()
+            .max_by_key(|bb| bb.true_block_value)
+            .unwrap();
+        let best_block_hash = last_best_block
+            .block
+            .built_block_trace()
+            .transactions_hash();
+        if self.last_best_block_hash == best_block_hash {
+            None
+        } else {
+            self.last_best_block_hash = best_block_hash;
+            Some(last_best_block.clone())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{I256, U256};
+
+    use crate::{
+        building::{
+            builders::mock_block_building_helper::MockBlockBuildingHelper, BlockSpace,
+            ExecutionResult, TransactionExecutionInfo,
+        },
+        primitives::{AccountNonce, Order},
+    };
+
+    use super::*;
+
+    struct TestDataGenerator {
+        base: crate::primitives::TestDataGenerator,
+    }
+    impl TestDataGenerator {
+        fn new() -> Self {
+            Self {
+                base: Default::default(),
+            }
+        }
+
+        /// Creates a unique block with true_block_value / builder_name
+        fn create_block(
+            &mut self,
+            true_block_value: U256,
+            builder_name: &str,
+        ) -> BiddableUnfinishedBlock {
+            let mut block = MockBlockBuildingHelper::new(true_block_value)
+                .with_builder_name(builder_name.to_string());
+            let order = self.base.create_mempool_tx(AccountNonce::default());
+            let tx = order.tx_with_blobs.clone();
+            // Give unique identity
+            block
+                .built_block_trace_mut_ref()
+                .included_orders
+                .push(ExecutionResult {
+                    coinbase_profit: Default::default(),
+                    inplace_sim: Default::default(),
+                    space_used: Default::default(),
+                    order: Order::Tx(order),
+                    tx_infos: vec![TransactionExecutionInfo {
+                        tx,
+                        receipt: Default::default(),
+                        space_used: BlockSpace::default(),
+                        coinbase_profit: I256::ZERO,
+                    }],
+                    original_order_ids: Default::default(),
+                    nonces_updated: Default::default(),
+                    paid_kickbacks: Default::default(),
+                });
+            BiddableUnfinishedBlock::new(Box::new(block)).unwrap()
+        }
+    }
+
+    const NAME_1: &str = "NAME1";
+    const NAME_2: &str = "NAME2";
+    const LOW_VAL: u64 = 10;
+    const HIGH_VAL: u64 = 100;
+
+    #[test]
+    fn first_block() {
+        let mut data_gen = TestDataGenerator::new();
+        let mut state = BestBlockFromAlgorithms::default();
+        let block = data_gen.create_block(U256::from(LOW_VAL), NAME_1);
+        let best_block = state.update_with_new_block(block.clone());
+        assert_eq!(block.true_block_value, best_block.unwrap().true_block_value);
+    }
+
+    ///Send block and then send a better one from other builder, the new one should win.
+    #[test]
+    fn better_block_not_same_as_winning_builder() {
+        let mut data_gen = TestDataGenerator::new();
+        let mut state = BestBlockFromAlgorithms::default();
+        let block_low = data_gen.create_block(U256::from(LOW_VAL), NAME_1);
+        let block_high = data_gen.create_block(U256::from(HIGH_VAL), NAME_2);
+        let _ = state.update_with_new_block(block_low);
+        let best_block = state.update_with_new_block(block_high.clone());
+        assert_eq!(
+            block_high.true_block_value,
+            best_block.unwrap().true_block_value
+        );
+    }
+
+    ///Send block and then send a better one from the same builder, the new one should win.
+    #[test]
+    fn better_block_same_winning_builder() {
+        let mut data_gen = TestDataGenerator::new();
+        let mut state = BestBlockFromAlgorithms::default();
+        let block_low = data_gen.create_block(U256::from(LOW_VAL), NAME_1);
+        let block_high = data_gen.create_block(U256::from(HIGH_VAL), NAME_1);
+        let _ = state.update_with_new_block(block_low);
+        let best_block = state.update_with_new_block(block_high.clone());
+        assert_eq!(
+            block_high.true_block_value,
+            best_block.unwrap().true_block_value
+        );
+    }
+
+    /// Send block and then send a worse one from the same builder, should lower the bid
+    #[test]
+    fn worse_block_same_winning_builder() {
+        let mut data_gen = TestDataGenerator::new();
+        let mut state = BestBlockFromAlgorithms::default();
+        let block_high = data_gen.create_block(U256::from(HIGH_VAL), NAME_1);
+        let block_low = data_gen.create_block(U256::from(LOW_VAL), NAME_1);
+
+        let _ = state.update_with_new_block(block_high);
+        let best_block = state.update_with_new_block(block_low.clone());
+        assert_eq!(
+            block_low.true_block_value,
+            best_block.unwrap().true_block_value
+        );
+    }
+
+    /// Send block and then send a worse one from other builder, should not bid
+    #[test]
+    fn worse_block_not_same_as_winning_builder() {
+        let mut data_gen = TestDataGenerator::new();
+        let mut state = BestBlockFromAlgorithms::default();
+        let block_high = data_gen.create_block(U256::from(HIGH_VAL), NAME_1);
+        let block_low = data_gen.create_block(U256::from(LOW_VAL), NAME_2);
+
+        let _ = state.update_with_new_block(block_high);
+        let best_block = state.update_with_new_block(block_low.clone());
+        assert!(best_block.is_none());
+    }
+
+    /// Send the same winning block twice, second should be ignored
+    #[test]
+    fn exact_same_block_winning_builder() {
+        let mut data_gen = TestDataGenerator::new();
+        let mut state = BestBlockFromAlgorithms::default();
+        let block = data_gen.create_block(U256::from(LOW_VAL), NAME_1);
+
+        let _ = state.update_with_new_block(block.clone());
+        let best_block = state.update_with_new_block(block);
+        assert!(best_block.is_none());
+    }
+}

--- a/crates/rbuilder/src/live_builder/block_output/mod.rs
+++ b/crates/rbuilder/src/live_builder/block_output/mod.rs
@@ -1,3 +1,4 @@
+pub mod best_block_from_algorithms;
 pub mod bidding_service_interface;
 pub mod relay_submit;
 pub mod true_value_bidding_service;

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -215,6 +215,7 @@ async fn run_submit_to_relays_job(
             builder_name = block.builder_name,
             fill_time_ms = duration_ms(block.trace.fill_time),
             finalize_time_ms = duration_ms(block.trace.finalize_time),
+            finalize_adjust_time_ms = duration_ms(block.trace.finalize_adjust_time),
         );
         info!(
             parent: &submission_span,

--- a/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
+++ b/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
@@ -325,12 +325,16 @@ impl UnfinishedBuiltBlocksInput {
             let mut local_ctx = self.local_ctx();
             let mut block_building_helper = next_block.into_building_helper();
             if self.adjust_finalized_blocks {
-		let value = if block_building_helper.true_block_value().unwrap_or_default().is_zero() {
-		    U256::ZERO
-		} else {
-		    // set value to 1 so that some contracts do not revert
-		    U256::ONE
-		}; 
+                let value = if block_building_helper
+                    .true_block_value()
+                    .unwrap_or_default()
+                    .is_zero()
+                {
+                    U256::ZERO
+                } else {
+                    // set value to 1 so that some contracts do not revert
+                    U256::ONE
+                };
                 match block_building_helper.finalize_block(&mut local_ctx, value, None) {
                     Ok(_) => {}
                     Err(err) => {

--- a/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
+++ b/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
@@ -50,6 +50,7 @@ pub struct UnfinishedBuiltBlocksInputFactory<P> {
     /// Factory for the final destination for blocks.
     block_sink_factory: RelaySubmitSinkFactory,
     wallet_balance_watcher: WalletBalanceWatcher<P>,
+    adjust_finalized_blocks: bool,
 }
 
 impl<P: StateProviderFactory> UnfinishedBuiltBlocksInputFactory<P> {
@@ -57,11 +58,13 @@ impl<P: StateProviderFactory> UnfinishedBuiltBlocksInputFactory<P> {
         bidding_service: Arc<dyn BiddingService>,
         block_sink_factory: RelaySubmitSinkFactory,
         wallet_balance_watcher: WalletBalanceWatcher<P>,
+        adjust_finalized_blocks: bool,
     ) -> Self {
         Self {
             bidding_service,
             block_sink_factory,
             wallet_balance_watcher,
+            adjust_finalized_blocks,
         }
     }
 
@@ -89,8 +92,12 @@ impl<P: StateProviderFactory> UnfinishedBuiltBlocksInputFactory<P> {
             .block_sink_factory
             .create_builder_sink(slot_data.clone(), cancel.clone());
 
-        let input =
-            UnfinishedBuiltBlocksInput::new(built_block_cache, finished_block_sink, cancel.clone());
+        let input = UnfinishedBuiltBlocksInput::new(
+            built_block_cache,
+            finished_block_sink,
+            self.adjust_finalized_blocks,
+            cancel.clone(),
+        );
 
         let slot_bidder = self.bidding_service.create_slot_bidder(
             SlotBlockId::new(
@@ -132,11 +139,18 @@ impl PrefinalizedBlockInner {
         &mut self,
         value: U256,
         seen_competition_bid: Option<U256>,
+        adjust_finalized_blocks: bool,
     ) -> Result<Option<FinalizeBlockResult>, BlockBuildingHelperError> {
         if let Some(local_ctx) = self.local_ctx.as_mut() {
-            self.block_building_helper
-                .finalize_prefinalized_block(local_ctx, value, seen_competition_bid)
-                .map(Some)
+            if adjust_finalized_blocks {
+                self.block_building_helper
+                    .adjust_finalized_block(local_ctx, value, seen_competition_bid)
+                    .map(Some)
+            } else {
+                self.block_building_helper
+                    .finalize_block(local_ctx, value, seen_competition_bid)
+                    .map(Some)
+            }
         } else {
             Ok(None)
         }
@@ -226,12 +240,14 @@ pub struct UnfinishedBuiltBlocksInput {
     cancellation_token: CancellationToken,
     #[derivative(Debug = "ignore")]
     block_building_sink: Arc<Mutex<Box<dyn BlockBuildingSink>>>,
+    adjust_finalized_blocks: bool,
 }
 
 impl UnfinishedBuiltBlocksInput {
     fn new(
         built_block_cache: Arc<BuiltBlockCache>,
         block_building_sink: Box<dyn BlockBuildingSink>,
+        adjust_finalized_blocks: bool,
         cancellation_token: CancellationToken,
     ) -> Self {
         Self {
@@ -244,6 +260,7 @@ impl UnfinishedBuiltBlocksInput {
             last_finalize_command: Arc::new((Mutex::new(None), Condvar::new())),
             cancellation_token,
             block_building_sink: Arc::new(Mutex::new(block_building_sink)),
+            adjust_finalized_blocks,
         }
     }
 
@@ -307,13 +324,15 @@ impl UnfinishedBuiltBlocksInput {
 
             let mut local_ctx = self.local_ctx();
             let mut block_building_helper = next_block.into_building_helper();
-            match block_building_helper.prefinalize_block(&mut local_ctx) {
-                Ok(()) => {}
-                Err(err) => {
-                    error!(?err, "Failed to prefinalize block");
-                    continue;
-                }
-            };
+            if self.adjust_finalized_blocks {
+                match block_building_helper.finalize_block(&mut local_ctx, U256::ZERO, None) {
+                    Ok(_) => {}
+                    Err(err) => {
+                        error!(?err, "Failed to prefinalize block");
+                        continue;
+                    }
+                };
+            }
             let prefinalized_result =
                 PrefinalizedBlock::new(block_id, block_building_helper, local_ctx);
             self.finalized_blocks.lock().push(prefinalized_result);
@@ -382,6 +401,7 @@ impl UnfinishedBuiltBlocksInput {
             let result = match command.finalize_prefinalized_block(
                 finalize_command.value,
                 finalize_command.seen_competition_bid,
+                self.adjust_finalized_blocks,
             ) {
                 Ok(Some(result)) => result,
                 Ok(None) => {

--- a/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
+++ b/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
@@ -113,7 +113,7 @@ impl<P: StateProviderFactory> UnfinishedBuiltBlocksInputFactory<P> {
         let input_clone = input.clone();
         std::thread::Builder::new()
             .name("prefinalize_worker".into())
-            .spawn(move || input_clone.run_prefinilze_thread(slot_bidder))
+            .spawn(move || input_clone.run_prefinalize_thread(slot_bidder))
             .unwrap();
 
         let input_clone = input.clone();
@@ -308,7 +308,7 @@ impl UnfinishedBuiltBlocksInput {
         }
     }
 
-    fn run_prefinilze_thread(self, slot_bidder: Arc<dyn SlotBidder>) {
+    fn run_prefinalize_thread(self, slot_bidder: Arc<dyn SlotBidder>) {
         loop {
             if self.cancellation_token.is_cancelled() {
                 break;

--- a/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
+++ b/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
@@ -325,7 +325,13 @@ impl UnfinishedBuiltBlocksInput {
             let mut local_ctx = self.local_ctx();
             let mut block_building_helper = next_block.into_building_helper();
             if self.adjust_finalized_blocks {
-                match block_building_helper.finalize_block(&mut local_ctx, U256::ZERO, None) {
+		let value = if block_building_helper.true_block_value().unwrap_or_default().is_zero() {
+		    U256::ZERO
+		} else {
+		    // set value to 1 so that some contracts do not revert
+		    U256::ONE
+		}; 
+                match block_building_helper.finalize_block(&mut local_ctx, value, None) {
                     Ok(_) => {}
                     Err(err) => {
                         error!(?err, "Failed to prefinalize block");

--- a/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
+++ b/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
@@ -1,19 +1,21 @@
-use std::{collections::VecDeque, time::Duration};
+use std::time::Duration;
 
-use alloy_primitives::{utils::format_ether, U256};
+use alloy_primitives::U256;
 use derivative::Derivative;
-use flume::RecvTimeoutError;
 use parking_lot::{Condvar, Mutex};
 use std::sync::Arc;
 
-use tracing::{error, info_span, trace, warn};
+use tracing::{error, warn};
 
 use ahash::HashMap;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
     building::{
-        builders::block_building_helper::{BiddableUnfinishedBlock, BlockBuildingHelper},
+        builders::block_building_helper::{
+            BiddableUnfinishedBlock, BlockBuildingHelper, BlockBuildingHelperError,
+            FinalizeBlockResult,
+        },
         ThreadBlockBuildingContext,
     },
     live_builder::{
@@ -34,295 +36,6 @@ use super::relay_submit::BlockBuildingSink;
 use crate::live_builder::building::built_block_cache::BuiltBlockCache;
 
 const THREAD_BLOCKING_DURATION: Duration = Duration::from_millis(100);
-
-#[derive(Debug, Clone)]
-struct FinalizeWorkerInput {
-    finalize_task: Arc<(Mutex<Option<FinalizeTask>>, Condvar)>,
-}
-
-impl FinalizeWorkerInput {
-    fn new() -> Self {
-        Self {
-            finalize_task: Arc::new((Mutex::new(None), Condvar::new())),
-        }
-    }
-
-    fn new_finalize_task(&self, finalize_task: FinalizeTask) {
-        let (lock, cvar) = &*self.finalize_task;
-        let mut guard = lock.lock();
-        *guard = Some(finalize_task);
-        cvar.notify_one();
-    }
-
-    fn wait_for_task(&self) -> Option<FinalizeTask> {
-        let (lock, cvar) = &*self.finalize_task;
-        let mut guard = lock.lock();
-        while guard.is_none() {
-            let timeout_result = cvar.wait_for(&mut guard, THREAD_BLOCKING_DURATION);
-            if timeout_result.timed_out() {
-                return None;
-            }
-        }
-        guard.take()
-    }
-}
-
-pub struct FinalizeWorker {
-    slot_data: MevBoostSlotData,
-    finalize_task: FinalizeWorkerInput,
-    finalized_blocks: Box<dyn BlockBuildingSink>,
-    cancellation_token: CancellationToken,
-}
-
-impl FinalizeWorker {
-    pub fn run(self) {
-        let slot_span = info_span!(
-            "slot_data",
-            payload_id = self.slot_data.payload_id,
-            block = self.slot_data.block(),
-            slot = self.slot_data.slot()
-        );
-        let _span_guard = slot_span.enter();
-
-        let mut local_ctx = ThreadBlockBuildingContext::default();
-        loop {
-            if self.cancellation_token.is_cancelled() {
-                break;
-            }
-
-            let finalize_task = if let Some(task) = self.finalize_task.wait_for_task() {
-                task
-            } else {
-                continue;
-            };
-            let FinalizeTask {
-                block,
-                payout_tx_val,
-                seen_competition_bid,
-            } = finalize_task;
-            trace!(payout_tx_val = ?format_ether(payout_tx_val),
-		   seen_competition_bid = ?seen_competition_bid.map(format_ether),
-		   "Started block finalization");
-            match block.finalize_block(&mut local_ctx, payout_tx_val, seen_competition_bid) {
-                Ok(result) => {
-                    self.finalized_blocks.new_block(result.block);
-                }
-                Err(err) => {
-                    error!(?err, "Error finalizing block");
-                }
-            }
-        }
-        trace!("Shutting down finalize worker");
-    }
-}
-
-enum BlockSealSlotWorkerCommands {
-    NewBuiltBlock(BiddableUnfinishedBlock),
-    SealBid(SlotBidderSealBidCommand),
-}
-
-#[derive(Clone, Debug)]
-pub struct UnfinishedBuiltBlocksInput {
-    command_queue: flume::Sender<BlockSealSlotWorkerCommands>,
-}
-
-pub struct BlockSealSlotWorkerOutput {
-    command_queue: flume::Receiver<BlockSealSlotWorkerCommands>,
-}
-
-impl BlockSealInterfaceForSlotBidder for UnfinishedBuiltBlocksInput {
-    fn seal_bid(&self, bid: SlotBidderSealBidCommand) {
-        self.command_queue
-            .send(BlockSealSlotWorkerCommands::SealBid(bid))
-            .map_err(|err| warn!(?err, "Failed to send bid command"))
-            .unwrap_or_default();
-    }
-}
-
-impl UnfinishedBuiltBlocksInput {
-    pub fn new_block(&self, block: BiddableUnfinishedBlock) {
-        self.command_queue
-            .send(BlockSealSlotWorkerCommands::NewBuiltBlock(block))
-            .map_err(|err| warn!(?err, "Failed to send new block command"))
-            .unwrap_or_default();
-    }
-}
-
-fn create_slot_seal_worker() -> (UnfinishedBuiltBlocksInput, BlockSealSlotWorkerOutput) {
-    let (sender, receiver) = flume::unbounded();
-    (
-        UnfinishedBuiltBlocksInput {
-            command_queue: sender,
-        },
-        BlockSealSlotWorkerOutput {
-            command_queue: receiver,
-        },
-    )
-}
-
-fn start_slot_seal_worker(
-    slot_data: MevBoostSlotData,
-    slot_bidder: Arc<dyn SlotBidder>,
-    finalized_blocks: Box<dyn BlockBuildingSink>,
-    output: BlockSealSlotWorkerOutput,
-    built_block_cache: Arc<BuiltBlockCache>,
-    cancellation_token: CancellationToken,
-) {
-    let finalize_task = FinalizeWorkerInput::new();
-    let finalize_worker = FinalizeWorker {
-        finalize_task: finalize_task.clone(),
-        finalized_blocks,
-        cancellation_token: cancellation_token.clone(),
-        slot_data: slot_data.clone(),
-    };
-
-    let worker = UnfinishedBlocksSlotWorker {
-        slot_data,
-        cancellation_token,
-        command_queue: output.command_queue,
-        built_block_cache,
-        last_block_by_algorithm: HashMap::default(),
-        last_best_block_hash: 0,
-        slot_bidder,
-        pending_blocks_last_id: 0,
-        pending_blocks: VecDeque::new(),
-        finalize_worker: finalize_task.clone(),
-    };
-    std::thread::Builder::new()
-        .name("unfinished_built_blocks_worker".into())
-        .spawn(move || {
-            if let Err(err) = worker.run() {
-                error!(?err, "unfinished_built_blocks_worker exited with error");
-            }
-        })
-        .expect("spawn block_seal_slot_worker");
-    std::thread::Builder::new()
-        .name("finalize_worker".into())
-        .spawn(move || {
-            finalize_worker.run();
-        })
-        .expect("spawn finalize_worker");
-}
-
-pub struct UnfinishedBlocksSlotWorker {
-    slot_data: MevBoostSlotData,
-    cancellation_token: CancellationToken,
-
-    command_queue: flume::Receiver<BlockSealSlotWorkerCommands>,
-
-    built_block_cache: Arc<BuiltBlockCache>,
-
-    last_block_by_algorithm: HashMap<String, BiddableUnfinishedBlock>,
-    last_best_block_hash: u64,
-
-    slot_bidder: Arc<dyn SlotBidder>,
-
-    // bidding service was notified about these blocks
-    pending_blocks_last_id: u64,
-    pending_blocks: VecDeque<(BlockId, Box<dyn BlockBuildingHelper>)>,
-
-    finalize_worker: FinalizeWorkerInput,
-}
-
-#[derive(Derivative)]
-#[derivative(Debug)]
-struct FinalizeTask {
-    #[derivative(Debug = "ignore")]
-    block: Box<dyn BlockBuildingHelper>,
-    payout_tx_val: U256,
-    seen_competition_bid: Option<U256>,
-}
-
-impl UnfinishedBlocksSlotWorker {
-    fn run(mut self) -> eyre::Result<()> {
-        let slot_span = info_span!(
-            "slot_data",
-            payload_id = self.slot_data.payload_id,
-            block = self.slot_data.block(),
-            slot = self.slot_data.slot()
-        );
-        let _span_guard = slot_span.enter();
-
-        loop {
-            if self.cancellation_token.is_cancelled() {
-                break;
-            }
-            let command = match self.command_queue.recv_timeout(THREAD_BLOCKING_DURATION) {
-                Ok(command) => command,
-                Err(RecvTimeoutError::Timeout) => {
-                    continue;
-                }
-                Err(RecvTimeoutError::Disconnected) => {
-                    break;
-                }
-            };
-            match command {
-                BlockSealSlotWorkerCommands::NewBuiltBlock(unfinished_block) => {
-                    trace!(
-                        builder_name = unfinished_block.block().builder_name(),
-                        true_block_value = format_ether(unfinished_block.true_block_value),
-                        "New unfinished block"
-                    );
-
-                    self.built_block_cache
-                        .update_from_new_unfinished_block(unfinished_block.block());
-
-                    self.last_block_by_algorithm.insert(
-                        unfinished_block.block.builder_name().to_string(),
-                        unfinished_block,
-                    );
-                    let last_best_block = self
-                        .last_block_by_algorithm
-                        .values()
-                        .max_by_key(|bb| bb.true_block_value)
-                        .unwrap();
-                    let best_block_hash = last_best_block
-                        .block
-                        .built_block_trace()
-                        .transactions_hash();
-                    if self.last_best_block_hash == best_block_hash {
-                        continue;
-                    }
-                    self.last_best_block_hash = best_block_hash;
-                    let new_block_id = BlockId(self.pending_blocks_last_id);
-                    self.pending_blocks_last_id += 1;
-                    self.pending_blocks
-                        .push_back((new_block_id, last_best_block.block.box_clone()));
-                    let block_descriptor =
-                        BuiltBlockDescriptorForSlotBidder::new(new_block_id, last_best_block);
-                    self.slot_bidder.notify_new_built_block(block_descriptor);
-                }
-                BlockSealSlotWorkerCommands::SealBid(slot_bidder_seal_bid_command) => {
-                    trace!(?slot_bidder_seal_bid_command, "New seal bid command");
-                    // prune blocks that are no longer useful
-                    self.pending_blocks
-                        .retain(|(id, _)| id.0 >= slot_bidder_seal_bid_command.block_id.0);
-                    let block_to_seal = self.pending_blocks.iter().find_map(|(id, block)| {
-                        if id == &slot_bidder_seal_bid_command.block_id {
-                            Some(block)
-                        } else {
-                            None
-                        }
-                    });
-                    let block = if let Some(block) = block_to_seal {
-                        block.box_clone()
-                    } else {
-                        continue;
-                    };
-                    let finalize_task = FinalizeTask {
-                        block,
-                        payout_tx_val: slot_bidder_seal_bid_command.payout_tx_value,
-                        seen_competition_bid: slot_bidder_seal_bid_command.seen_competition_bid,
-                    };
-                    self.finalize_worker.new_finalize_task(finalize_task);
-                }
-            }
-        }
-        trace!("Finished UnfinishedBuiltBlocksSlotWorker");
-
-        Ok(())
-    }
-}
 
 /// UnfinishedBlockBuildingSinkFactory to bid blocks against the competition.
 /// Blocks are given to a slot bidder (UnfinishedBlockBuildingSink created per block by the BiddingService).
@@ -375,7 +88,9 @@ impl<P: StateProviderFactory> UnfinishedBuiltBlocksInputFactory<P> {
         let finished_block_sink = self
             .block_sink_factory
             .create_builder_sink(slot_data.clone(), cancel.clone());
-        let (input, output) = create_slot_seal_worker();
+
+        let input =
+            UnfinishedBuiltBlocksInput::new(built_block_cache, finished_block_sink, cancel.clone());
 
         let slot_bidder = self.bidding_service.create_slot_bidder(
             SlotBlockId::new(
@@ -388,15 +103,303 @@ impl<P: StateProviderFactory> UnfinishedBuiltBlocksInputFactory<P> {
             cancel.clone(),
         );
 
-        start_slot_seal_worker(
-            slot_data,
-            slot_bidder,
-            finished_block_sink,
-            output,
-            built_block_cache,
-            cancel,
-        );
+        let input_clone = input.clone();
+        std::thread::Builder::new()
+            .name("prefinalize_worker".into())
+            .spawn(move || input_clone.run_prefinilze_thread(slot_bidder))
+            .unwrap();
+
+        let input_clone = input.clone();
+        std::thread::Builder::new()
+            .name("finalize_worker".into())
+            .spawn(move || input_clone.run_finalize_thread())
+            .unwrap();
 
         input
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+struct PrefinalizedBlockInner {
+    #[derivative(Debug = "ignore")]
+    block_building_helper: Box<dyn BlockBuildingHelper>,
+    local_ctx: Option<ThreadBlockBuildingContext>,
+}
+
+impl PrefinalizedBlockInner {
+    fn finalize_prefinalized_block(
+        &mut self,
+        value: U256,
+        seen_competition_bid: Option<U256>,
+    ) -> Result<Option<FinalizeBlockResult>, BlockBuildingHelperError> {
+        if let Some(local_ctx) = self.local_ctx.as_mut() {
+            self.block_building_helper
+                .finalize_prefinalized_block(local_ctx, value, seen_competition_bid)
+                .map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PrefinalizedBlock {
+    block_id: BlockId,
+    inner: Arc<Mutex<PrefinalizedBlockInner>>,
+}
+
+impl PrefinalizedBlock {
+    fn new(
+        block_id: BlockId,
+        block_building_helper: Box<dyn BlockBuildingHelper>,
+        local_ctx: ThreadBlockBuildingContext,
+    ) -> Self {
+        Self {
+            block_id,
+            inner: Arc::new(Mutex::new(PrefinalizedBlockInner {
+                block_building_helper,
+                local_ctx: Some(local_ctx),
+            })),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FinalizeCommand {
+    prefinalized_block: PrefinalizedBlock,
+    value: U256,
+    seen_competition_bid: Option<U256>,
+}
+
+#[derive(Derivative, Default)]
+#[derivative(Debug)]
+struct BestBlockFromAlgorithms {
+    #[derivative(Debug = "ignore")]
+    last_block_by_algorithm: HashMap<String, BiddableUnfinishedBlock>,
+    last_best_block_hash: u64,
+}
+
+impl BestBlockFromAlgorithms {
+    fn new_block(
+        &mut self,
+        unfinished_block: BiddableUnfinishedBlock,
+    ) -> Option<BiddableUnfinishedBlock> {
+        self.last_block_by_algorithm.insert(
+            unfinished_block.block.builder_name().to_string(),
+            unfinished_block,
+        );
+        let last_best_block = self
+            .last_block_by_algorithm
+            .values()
+            .max_by_key(|bb| bb.true_block_value)
+            .unwrap();
+        let best_block_hash = last_best_block
+            .block
+            .built_block_trace()
+            .transactions_hash();
+        if self.last_best_block_hash == best_block_hash {
+            None
+        } else {
+            self.last_best_block_hash = best_block_hash;
+            Some(last_best_block.clone())
+        }
+    }
+}
+
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
+pub struct UnfinishedBuiltBlocksInput {
+    built_block_cache: Arc<BuiltBlockCache>,
+
+    best_block_from_algorithms: Arc<Mutex<BestBlockFromAlgorithms>>,
+
+    #[derivative(Debug = "ignore")]
+    last_unfinalized_block: Arc<(Mutex<Option<BiddableUnfinishedBlock>>, Condvar)>,
+
+    unused_prefinalized_blocks: Arc<Mutex<Vec<PrefinalizedBlock>>>,
+    last_block_id: Arc<Mutex<u64>>,
+    finalized_blocks: Arc<Mutex<Vec<PrefinalizedBlock>>>,
+
+    last_finalize_command: Arc<(Mutex<Option<FinalizeCommand>>, Condvar)>,
+
+    cancellation_token: CancellationToken,
+    #[derivative(Debug = "ignore")]
+    block_building_sink: Arc<Mutex<Box<dyn BlockBuildingSink>>>,
+}
+
+impl UnfinishedBuiltBlocksInput {
+    fn new(
+        built_block_cache: Arc<BuiltBlockCache>,
+        block_building_sink: Box<dyn BlockBuildingSink>,
+        cancellation_token: CancellationToken,
+    ) -> Self {
+        Self {
+            built_block_cache,
+            best_block_from_algorithms: Arc::new(Mutex::new(BestBlockFromAlgorithms::default())),
+            last_unfinalized_block: Arc::new((Mutex::new(None), Condvar::new())),
+            unused_prefinalized_blocks: Arc::new(Mutex::new(Vec::new())),
+            last_block_id: Arc::new(Mutex::new(0)),
+            finalized_blocks: Arc::new(Mutex::new(Vec::new())),
+            last_finalize_command: Arc::new((Mutex::new(None), Condvar::new())),
+            cancellation_token,
+            block_building_sink: Arc::new(Mutex::new(block_building_sink)),
+        }
+    }
+
+    pub fn new_block(&self, block: BiddableUnfinishedBlock) {
+        self.built_block_cache
+            .update_from_new_unfinished_block(block.block());
+
+        let block = if let Some(block) = self.best_block_from_algorithms.lock().new_block(block) {
+            block
+        } else {
+            return;
+        };
+
+        let (lock, cvar) = &*self.last_unfinalized_block;
+        let mut guard = lock.lock();
+        *guard = Some(block);
+        cvar.notify_one();
+    }
+
+    fn get_next_block(&self) -> Option<BiddableUnfinishedBlock> {
+        let (lock, cvar) = &*self.last_unfinalized_block;
+        let mut guard = lock.lock();
+        while guard.is_none() {
+            let timeout_result = cvar.wait_for(&mut guard, THREAD_BLOCKING_DURATION);
+            if timeout_result.timed_out() {
+                return None;
+            }
+        }
+        guard.take()
+    }
+
+    fn next_block_id(&self) -> BlockId {
+        let mut last_id = self.last_block_id.lock();
+        let id = BlockId(*last_id);
+        *last_id += 1;
+        id
+    }
+
+    fn local_ctx(&self) -> ThreadBlockBuildingContext {
+        if let Some(last_prefin_block) = self.unused_prefinalized_blocks.lock().pop() {
+            let mut inner = last_prefin_block.inner.lock();
+            inner.local_ctx.take().unwrap_or_default()
+        } else {
+            ThreadBlockBuildingContext::default()
+        }
+    }
+
+    fn run_prefinilze_thread(self, slot_bidder: Arc<dyn SlotBidder>) {
+        loop {
+            if self.cancellation_token.is_cancelled() {
+                break;
+            }
+            let next_block = if let Some(block) = self.get_next_block() {
+                block
+            } else {
+                continue;
+            };
+
+            let block_id = self.next_block_id();
+            let block_descriptor = BuiltBlockDescriptorForSlotBidder::new(block_id, &next_block);
+
+            let mut local_ctx = self.local_ctx();
+            let mut block_building_helper = next_block.into_building_helper();
+            match block_building_helper.prefinalize_block(&mut local_ctx) {
+                Ok(()) => {}
+                Err(err) => {
+                    error!(?err, "Failed to prefinalize block");
+                    continue;
+                }
+            };
+            let prefinalized_result =
+                PrefinalizedBlock::new(block_id, block_building_helper, local_ctx);
+            self.finalized_blocks.lock().push(prefinalized_result);
+            slot_bidder.notify_new_built_block(block_descriptor);
+        }
+    }
+
+    fn get_next_finalize_command(&self) -> Option<FinalizeCommand> {
+        let (lock, cvar) = &*self.last_finalize_command;
+        let mut guard = lock.lock();
+        while guard.is_none() {
+            let timeout_result = cvar.wait_for(&mut guard, THREAD_BLOCKING_DURATION);
+            if timeout_result.timed_out() {
+                return None;
+            }
+        }
+        guard.take()
+    }
+
+    fn seal_command(&self, bid: SlotBidderSealBidCommand) {
+        let mut unused_blocks = Vec::new();
+        let mut found_block: Option<PrefinalizedBlock> = None;
+        {
+            let mut finalized_blocks = self.finalized_blocks.lock();
+            let mut i = 0;
+            while i < finalized_blocks.len() {
+                if finalized_blocks[i].block_id.0 < bid.block_id.0 {
+                    unused_blocks.push(finalized_blocks.remove(i));
+                    continue;
+                }
+                if finalized_blocks[i].block_id == bid.block_id {
+                    found_block = Some(finalized_blocks[i].clone());
+                    break;
+                }
+                i += 1;
+            }
+        }
+        self.unused_prefinalized_blocks
+            .lock()
+            .append(&mut unused_blocks);
+        if let Some(prefinalized_block) = found_block {
+            let finalize_command = FinalizeCommand {
+                prefinalized_block,
+                value: bid.payout_tx_value,
+                seen_competition_bid: bid.seen_competition_bid,
+            };
+            let (lock, cvar) = &*self.last_finalize_command;
+            let mut guard = lock.lock();
+            *guard = Some(finalize_command);
+            cvar.notify_one();
+        }
+    }
+
+    fn run_finalize_thread(self) {
+        loop {
+            if self.cancellation_token.is_cancelled() {
+                break;
+            }
+            let finalize_command = if let Some(command) = self.get_next_finalize_command() {
+                command
+            } else {
+                continue;
+            };
+
+            let mut command = finalize_command.prefinalized_block.inner.lock();
+            let result = match command.finalize_prefinalized_block(
+                finalize_command.value,
+                finalize_command.seen_competition_bid,
+            ) {
+                Ok(Some(result)) => result,
+                Ok(None) => {
+                    warn!("Prefinalized block was discarded");
+                    continue;
+                }
+                Err(err) => {
+                    error!(?err, "Failed to finalize prefinalized block");
+                    continue;
+                }
+            };
+            self.block_building_sink.lock().new_block(result.block);
+        }
+    }
+}
+
+impl BlockSealInterfaceForSlotBidder for UnfinishedBuiltBlocksInput {
+    fn seal_bid(&self, bid: SlotBidderSealBidCommand) {
+        self.seal_command(bid)
     }
 }

--- a/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
+++ b/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
@@ -1,11 +1,24 @@
+/// Unfinsihed block processing handles blocks that are produced by block building algorithms.
+///
+/// 1. Block building algorithm produces unfinished blocks `BiddableUnfinishedBlock` and submits it to the `UnfinishedBuiltBlocksInput`
+/// 2. Block cache is updated from the last unfinished block. Its used to share data about built blocks between different algorithms.
+/// 3. Then we select next block to use for submission from the blocks built by different algorithms (`BestBlockFromAlgorithms`)
+/// 4. Then this block is finalized (`prefinalize_worker` thread)
+/// 5. We notify bidding service about new block.
+/// 6. Bidding service asks to finalize that block with concrete proposer value  
+/// 7. Finalized block is adjusted to pay chosen amount to the proposer (`finalize_worker` thread)
+/// 8. Resulting block is submitted to `BlockBuildingSink` (in running builder its used by a thread that submits block to relays).
+///
+/// Alternatively if configured (adjust_finalized_blocks = true) to run using old flow `prefinalize_worker` would not do anything with the block
+/// and `finalize_worker` would do full finalization instead of adjustment of the finalize block.
 use std::time::Duration;
 
-use alloy_primitives::U256;
+use alloy_primitives::{utils::format_ether, U256};
 use derivative::Derivative;
 use parking_lot::{Condvar, Mutex};
 use std::sync::Arc;
 
-use tracing::{error, warn};
+use tracing::{error, trace, warn};
 
 use ahash::HashMap;
 use tokio_util::sync::CancellationToken;
@@ -37,10 +50,12 @@ use crate::live_builder::building::built_block_cache::BuiltBlockCache;
 
 const THREAD_BLOCKING_DURATION: Duration = Duration::from_millis(100);
 
-/// UnfinishedBlockBuildingSinkFactory to bid blocks against the competition.
-/// Blocks are given to a slot bidder (UnfinishedBlockBuildingSink created per block by the BiddingService).
-/// Slot bidder bids using a SequentialSealerBidMaker (created per block).
-/// SequentialSealerBidMaker sends the bids to a BlockBuildingSink (created per block).
+/// UnfinishedBlockBuildingSinkFactory creates UnfinishedBuiltBlocksInput
+/// and related workers for each slot
+/// For each slot it creates:
+/// 1. UnfinishedBuiltBlocksInput and starts `prefinalize_worker` and `finalize_worker` threads.
+/// 2. SlotBidder from BiddingService to manage bidding values for the sealed blocks
+/// 3. BlockBuildingSink to send finished blocks for relay submission
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct UnfinishedBuiltBlocksInputFactory<P> {
@@ -50,6 +65,8 @@ pub struct UnfinishedBuiltBlocksInputFactory<P> {
     /// Factory for the final destination for blocks.
     block_sink_factory: RelaySubmitSinkFactory,
     wallet_balance_watcher: WalletBalanceWatcher<P>,
+    /// If set to true blocks will be finalized before notifying BiddingService
+    /// This reduces latency for creating block with concrete proposer payout value.
     adjust_finalized_blocks: bool,
 }
 
@@ -126,6 +143,8 @@ impl<P: StateProviderFactory> UnfinishedBuiltBlocksInputFactory<P> {
     }
 }
 
+/// Prefinalized blocks must carry ThreadBlockBuildingContext with them because
+/// it contains cached state that would be used in adjust_finalized_block
 #[derive(Derivative)]
 #[derivative(Debug)]
 struct PrefinalizedBlockInner {
@@ -135,7 +154,7 @@ struct PrefinalizedBlockInner {
 }
 
 impl PrefinalizedBlockInner {
-    fn finalize_prefinalized_block(
+    fn finalize_block(
         &mut self,
         value: U256,
         seen_competition_bid: Option<U256>,
@@ -186,6 +205,8 @@ struct FinalizeCommand {
     seen_competition_bid: Option<U256>,
 }
 
+/// BestBlockFromAlgorithms maintains last block by each algorithm
+/// When new block is created we choose best (by profit) block from last blocks produced by each algorithm.
 #[derive(Derivative, Default)]
 #[derivative(Debug)]
 struct BestBlockFromAlgorithms {
@@ -274,95 +295,24 @@ impl UnfinishedBuiltBlocksInput {
             return;
         };
 
+        let log_span = create_logging_span(block.block());
+        let _guard = log_span.enter();
+
+        trace!("New unfinalized block");
+
+        // update last_unfinalized_block
         let (lock, cvar) = &*self.last_unfinalized_block;
         let mut guard = lock.lock();
         *guard = Some(block);
         cvar.notify_one();
     }
 
-    fn get_next_block(&self) -> Option<BiddableUnfinishedBlock> {
-        let (lock, cvar) = &*self.last_unfinalized_block;
-        let mut guard = lock.lock();
-        while guard.is_none() {
-            let timeout_result = cvar.wait_for(&mut guard, THREAD_BLOCKING_DURATION);
-            if timeout_result.timed_out() {
-                return None;
-            }
-        }
-        guard.take()
-    }
-
-    fn next_block_id(&self) -> BlockId {
-        let mut last_id = self.last_block_id.lock();
-        let id = BlockId(*last_id);
-        *last_id += 1;
-        id
-    }
-
-    fn local_ctx(&self) -> ThreadBlockBuildingContext {
-        if let Some(last_prefin_block) = self.unused_prefinalized_blocks.lock().pop() {
-            let mut inner = last_prefin_block.inner.lock();
-            inner.local_ctx.take().unwrap_or_default()
-        } else {
-            ThreadBlockBuildingContext::default()
-        }
-    }
-
-    fn run_prefinalize_thread(self, slot_bidder: Arc<dyn SlotBidder>) {
-        loop {
-            if self.cancellation_token.is_cancelled() {
-                break;
-            }
-            let next_block = if let Some(block) = self.get_next_block() {
-                block
-            } else {
-                continue;
-            };
-
-            let block_id = self.next_block_id();
-            let block_descriptor = BuiltBlockDescriptorForSlotBidder::new(block_id, &next_block);
-
-            let mut local_ctx = self.local_ctx();
-            let mut block_building_helper = next_block.into_building_helper();
-            if self.adjust_finalized_blocks {
-                let value = if block_building_helper
-                    .true_block_value()
-                    .unwrap_or_default()
-                    .is_zero()
-                {
-                    U256::ZERO
-                } else {
-                    // set value to 1 so that some contracts do not revert
-                    U256::ONE
-                };
-                match block_building_helper.finalize_block(&mut local_ctx, value, None) {
-                    Ok(_) => {}
-                    Err(err) => {
-                        error!(?err, "Failed to prefinalize block");
-                        continue;
-                    }
-                };
-            }
-            let prefinalized_result =
-                PrefinalizedBlock::new(block_id, block_building_helper, local_ctx);
-            self.finalized_blocks.lock().push(prefinalized_result);
-            slot_bidder.notify_new_built_block(block_descriptor);
-        }
-    }
-
-    fn get_next_finalize_command(&self) -> Option<FinalizeCommand> {
-        let (lock, cvar) = &*self.last_finalize_command;
-        let mut guard = lock.lock();
-        while guard.is_none() {
-            let timeout_result = cvar.wait_for(&mut guard, THREAD_BLOCKING_DURATION);
-            if timeout_result.timed_out() {
-                return None;
-            }
-        }
-        guard.take()
-    }
-
     fn seal_command(&self, bid: SlotBidderSealBidCommand) {
+        let id_span = tracing::info_span!("block_id", block_id = bid.block_id.0);
+        let _guard_id_span = id_span.enter();
+
+        trace!(?bid, "Received seal command");
+
         let mut unused_blocks = Vec::new();
         let mut found_block: Option<PrefinalizedBlock> = None;
         {
@@ -393,7 +343,107 @@ impl UnfinishedBuiltBlocksInput {
             let mut guard = lock.lock();
             *guard = Some(finalize_command);
             cvar.notify_one();
+        } else {
+            warn!("Seal command discarded, prefinalized block was not found");
         }
+    }
+}
+
+// prefinalize_worker
+impl UnfinishedBuiltBlocksInput {
+    fn take_last_unfinalized_block(&self) -> Option<BiddableUnfinishedBlock> {
+        let (lock, cvar) = &*self.last_unfinalized_block;
+        let mut guard = lock.lock();
+        while guard.is_none() {
+            let timeout_result = cvar.wait_for(&mut guard, THREAD_BLOCKING_DURATION);
+            if timeout_result.timed_out() {
+                return None;
+            }
+        }
+        guard.take()
+    }
+
+    fn create_new_block_id(&self) -> BlockId {
+        let mut last_id = self.last_block_id.lock();
+        let id = BlockId(*last_id);
+        *last_id += 1;
+        id
+    }
+
+    fn local_ctx(&self) -> ThreadBlockBuildingContext {
+        // we try to reuse ThreadBlockBuildingContext from previously built blocks (as they contain useful caches)
+        if let Some(last_prefin_block) = self.unused_prefinalized_blocks.lock().pop() {
+            let mut inner = last_prefin_block.inner.lock();
+            inner.local_ctx.take().unwrap_or_default()
+        } else {
+            ThreadBlockBuildingContext::default()
+        }
+    }
+
+    fn run_prefinalize_thread(self, slot_bidder: Arc<dyn SlotBidder>) {
+        loop {
+            if self.cancellation_token.is_cancelled() {
+                break;
+            }
+            let next_block = if let Some(block) = self.take_last_unfinalized_block() {
+                block
+            } else {
+                continue;
+            };
+
+            let log_span = create_logging_span(next_block.block());
+            let _guard = log_span.enter();
+
+            let block_id = self.create_new_block_id();
+            let id_span = tracing::info_span!("block_id", block_id = block_id.0);
+            let _guard_id_span = id_span.enter();
+            let block_descriptor = BuiltBlockDescriptorForSlotBidder::new(block_id, &next_block);
+
+            let mut local_ctx = self.local_ctx();
+            let mut block_building_helper = next_block.into_building_helper();
+            if self.adjust_finalized_blocks {
+                let value = if block_building_helper
+                    .true_block_value()
+                    .unwrap_or_default()
+                    .is_zero()
+                {
+                    U256::ZERO
+                } else {
+                    // set value to 1 so that some contracts do not revert
+                    U256::ONE
+                };
+                match block_building_helper.finalize_block(&mut local_ctx, value, None) {
+                    Ok(_) => {
+                        trace!("Prefinalized block");
+                    }
+                    Err(err) => {
+                        error!(?err, "Failed to prefinalize block");
+                        continue;
+                    }
+                };
+            }
+            let prefinalized_result =
+                PrefinalizedBlock::new(block_id, block_building_helper, local_ctx);
+            self.finalized_blocks.lock().push(prefinalized_result);
+            slot_bidder.notify_new_built_block(block_descriptor);
+            trace!("Notified bidding service");
+        }
+        trace!("Finished prefinalize_worker");
+    }
+}
+
+// finalize_worker
+impl UnfinishedBuiltBlocksInput {
+    fn take_next_finalize_command(&self) -> Option<FinalizeCommand> {
+        let (lock, cvar) = &*self.last_finalize_command;
+        let mut guard = lock.lock();
+        while guard.is_none() {
+            let timeout_result = cvar.wait_for(&mut guard, THREAD_BLOCKING_DURATION);
+            if timeout_result.timed_out() {
+                return None;
+            }
+        }
+        guard.take()
     }
 
     fn run_finalize_thread(self) {
@@ -401,19 +451,32 @@ impl UnfinishedBuiltBlocksInput {
             if self.cancellation_token.is_cancelled() {
                 break;
             }
-            let finalize_command = if let Some(command) = self.get_next_finalize_command() {
+            let finalize_command = if let Some(command) = self.take_next_finalize_command() {
                 command
             } else {
                 continue;
             };
 
             let mut command = finalize_command.prefinalized_block.inner.lock();
-            let result = match command.finalize_prefinalized_block(
+
+            let id_span = tracing::info_span!(
+                "block_id",
+                block_id = finalize_command.prefinalized_block.block_id.0
+            );
+            let _guard_id_span = id_span.enter();
+
+            let log_span = create_logging_span(command.block_building_helper.as_ref());
+            let _guard = log_span.enter();
+
+            let result = match command.finalize_block(
                 finalize_command.value,
                 finalize_command.seen_competition_bid,
                 self.adjust_finalized_blocks,
             ) {
-                Ok(Some(result)) => result,
+                Ok(Some(result)) => {
+                    trace!("Finalized block");
+                    result
+                }
                 Ok(None) => {
                     warn!("Prefinalized block was discarded");
                     continue;
@@ -432,4 +495,20 @@ impl BlockSealInterfaceForSlotBidder for UnfinishedBuiltBlocksInput {
     fn seal_bid(&self, bid: SlotBidderSealBidCommand) {
         self.seal_command(bid)
     }
+}
+
+fn create_logging_span(block_helper: &dyn BlockBuildingHelper) -> tracing::Span {
+    let ctx = block_helper.building_context();
+    let block = ctx.block();
+    let payload_id = ctx.payload_id;
+    let builder_name = block_helper.builder_name();
+    let true_block_value = format_ether(block_helper.true_block_value().unwrap_or_default());
+
+    tracing::info_span!(
+        "unfinished_block",
+        block,
+        payload_id,
+        builder_name,
+        true_block_value
+    )
 }

--- a/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
+++ b/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
@@ -1,4 +1,4 @@
-/// Unfinsihed block processing handles blocks that are produced by block building algorithms.
+/// Unfinished block processing handles blocks that are produced by block building algorithms.
 ///
 /// 1. Block building algorithm produces unfinished blocks `BiddableUnfinishedBlock` and submits it to the `UnfinishedBuiltBlocksInput`
 /// 2. Block cache is updated from the last unfinished block. Its used to share data about built blocks between different algorithms.

--- a/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
+++ b/crates/rbuilder/src/live_builder/block_output/unfinished_block_processing.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 
 use tracing::{error, trace, warn};
 
-use ahash::HashMap;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -38,6 +37,7 @@ use crate::{
 };
 
 use super::{
+    best_block_from_algorithms::BestBlockFromAlgorithms,
     bidding_service_interface::{
         BiddingService, BlockId, BlockSealInterfaceForSlotBidder,
         BuiltBlockDescriptorForSlotBidder, SlotBidder, SlotBidderSealBidCommand, SlotBlockId,
@@ -205,43 +205,6 @@ struct FinalizeCommand {
     seen_competition_bid: Option<U256>,
 }
 
-/// BestBlockFromAlgorithms maintains last block by each algorithm
-/// When new block is created we choose best (by profit) block from last blocks produced by each algorithm.
-#[derive(Derivative, Default)]
-#[derivative(Debug)]
-struct BestBlockFromAlgorithms {
-    #[derivative(Debug = "ignore")]
-    last_block_by_algorithm: HashMap<String, BiddableUnfinishedBlock>,
-    last_best_block_hash: u64,
-}
-
-impl BestBlockFromAlgorithms {
-    fn new_block(
-        &mut self,
-        unfinished_block: BiddableUnfinishedBlock,
-    ) -> Option<BiddableUnfinishedBlock> {
-        self.last_block_by_algorithm.insert(
-            unfinished_block.block.builder_name().to_string(),
-            unfinished_block,
-        );
-        let last_best_block = self
-            .last_block_by_algorithm
-            .values()
-            .max_by_key(|bb| bb.true_block_value)
-            .unwrap();
-        let best_block_hash = last_best_block
-            .block
-            .built_block_trace()
-            .transactions_hash();
-        if self.last_best_block_hash == best_block_hash {
-            None
-        } else {
-            self.last_best_block_hash = best_block_hash;
-            Some(last_best_block.clone())
-        }
-    }
-}
-
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub struct UnfinishedBuiltBlocksInput {
@@ -289,7 +252,11 @@ impl UnfinishedBuiltBlocksInput {
         self.built_block_cache
             .update_from_new_unfinished_block(block.block());
 
-        let block = if let Some(block) = self.best_block_from_algorithms.lock().new_block(block) {
+        let block = if let Some(block) = self
+            .best_block_from_algorithms
+            .lock()
+            .update_with_new_block(block)
+        {
             block
         } else {
             return;

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -967,6 +967,7 @@ where
         bidding_service,
         sink_sealed_factory,
         wallet_balance_watcher,
+        base_config.adjust_finalized_blocks,
     );
 
     Ok((sink_factory, slot_info_provider, adjustment_fee_payers))

--- a/crates/rbuilder/src/primitives/mod.rs
+++ b/crates/rbuilder/src/primitives/mod.rs
@@ -741,7 +741,11 @@ impl TransactionSignedEcRecoveredWithBlobs {
     }
 
     pub fn space_needed(&self) -> BlockSpace {
-        BlockSpace::new(self.tx.gas_limit(), self.length_eip7934())
+        BlockSpace::new(
+            self.tx.gas_limit(),
+            self.length_eip7934(),
+            self.blobs_gas_used(),
+        )
     }
 
     pub fn blobs_len(&self) -> usize {
@@ -1152,7 +1156,6 @@ pub struct SimValue {
     /// For mempool orders it should match ProfitInfo
     non_mempool_profit_info: ProfitInfo,
     space_used: BlockSpace,
-    blob_gas_used: u64,
     /// Kickbacks paid during simulation as (receiver, amount)
     paid_kickbacks: Vec<(Address, U256)>,
 }
@@ -1164,14 +1167,12 @@ impl SimValue {
         // for s/bundles profit from non-mempool txs.
         non_mempool_coinbase_profit: U256,
         space_used: BlockSpace,
-        blob_gas_used: u64,
         paid_kickbacks: Vec<(Address, U256)>,
     ) -> Self {
         Self {
-            full_profit_info: ProfitInfo::new(full_coinbase_profit, space_used.gas()),
-            non_mempool_profit_info: ProfitInfo::new(non_mempool_coinbase_profit, space_used.gas()),
+            full_profit_info: ProfitInfo::new(full_coinbase_profit, space_used.gas),
+            non_mempool_profit_info: ProfitInfo::new(non_mempool_coinbase_profit, space_used.gas),
             space_used,
-            blob_gas_used,
             paid_kickbacks,
         }
     }
@@ -1190,7 +1191,7 @@ impl SimValue {
         Self {
             full_profit_info: ProfitInfo::new(full_coinbase_profit, gas_used),
             non_mempool_profit_info: ProfitInfo::new(non_mempool_profit, gas_used),
-            space_used: BlockSpace::new(gas_used, 0),
+            space_used: BlockSpace::new(gas_used, 0, 0),
             ..Default::default()
         }
     }
@@ -1204,11 +1205,11 @@ impl SimValue {
     }
 
     pub fn gas_used(&self) -> u64 {
-        self.space_used.gas()
+        self.space_used.gas
     }
 
     pub fn blob_gas_used(&self) -> u64 {
-        self.blob_gas_used
+        self.space_used.blob_gas
     }
 
     pub fn paid_kickbacks(&self) -> &Vec<(Address, U256)> {

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -447,7 +447,7 @@ impl RootHasher for StatRootHashCalculator {
 
     fn account_proofs(
         &self,
-        _outcome: &reth_provider::ExecutionOutcome,
+        _outcome: &BundleState,
         _addresses: &eth_sparse_mpt::utils::HashSet<Address>,
         _local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<eth_sparse_mpt::utils::HashMap<Address, Vec<Bytes>>, RootHashError> {
@@ -458,11 +458,11 @@ impl RootHasher for StatRootHashCalculator {
     /// IMPORTANT: Assumes IPC provider (node) has RPC call:"rbuilder_calculateStateRoot"
     fn state_root(
         &self,
-        outcome: &reth_provider::ExecutionOutcome,
+        outcome: &BundleState,
+        _incremental_change: &[Address],
         _local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<B256, RootHashError> {
         let account_diff: HashMap<Address, AccountDiff> = outcome
-            .bundle
             .state
             .iter()
             .map(|(address, diff)| (*address, diff.clone().into()))

--- a/crates/rbuilder/src/provider/mod.rs
+++ b/crates/rbuilder/src/provider/mod.rs
@@ -6,9 +6,9 @@ use alloy_consensus::Header;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{Address, BlockHash, BlockNumber, Bytes, B256};
 use eth_sparse_mpt::utils::{HashMap, HashSet};
-use reth::providers::ExecutionOutcome;
 use reth_errors::ProviderResult;
 use reth_provider::StateProviderBox;
+use revm::database::BundleState;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
@@ -53,9 +53,11 @@ pub trait RootHasher: std::fmt::Debug + Send + Sync {
     );
 
     /// State root for changes outcome on top of parent block.
+    /// Incermental change is a list of accounts that are changed for the block since the last call to state_root
     fn state_root(
         &self,
-        outcome: &ExecutionOutcome,
+        outcome: &BundleState,
+        incremental_change: &[Address],
         local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<B256, RootHashError>;
 
@@ -64,7 +66,7 @@ pub trait RootHasher: std::fmt::Debug + Send + Sync {
     /// If the accounts are missing from the bundle state, the method will return "KeyNotFound" error.
     fn account_proofs(
         &self,
-        outcome: &ExecutionOutcome,
+        outcome: &BundleState,
         addresses: &HashSet<Address>,
         local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<HashMap<Address, Vec<Bytes>>, RootHashError>;

--- a/crates/rbuilder/src/roothash/mod.rs
+++ b/crates/rbuilder/src/roothash/mod.rs
@@ -2,10 +2,11 @@ mod prefetcher;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{Address, Bytes, B256};
 use eth_sparse_mpt::*;
-use reth::providers::{providers::ConsistentDbView, ExecutionOutcome};
+use reth::providers::providers::ConsistentDbView;
 use reth_provider::{BlockReader, DatabaseProviderFactory, HashedPostStateProvider};
 use reth_trie::TrieInput;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
+use revm::database::BundleState;
 use tracing::trace;
 
 pub use prefetcher::run_trie_prefetcher;
@@ -69,7 +70,7 @@ impl RootHashContext {
 pub fn calculate_account_proofs<P>(
     provider: P,
     parent_num_hash: BlockNumHash,
-    outcome: &ExecutionOutcome,
+    outcome: &BundleState,
     addresses: &utils::HashSet<Address>,
     shared_cache: &SparseTrieSharedCache,
     local_cache: &mut SparseTrieLocalCache,
@@ -106,14 +107,14 @@ where
 
 fn calculate_parallel_root_hash<P, HasherType>(
     hasher: &HasherType,
-    outcome: &ExecutionOutcome,
+    outcome: &BundleState,
     consistent_db_view: ConsistentDbView<P>,
 ) -> Result<B256, ParallelStateRootError>
 where
     HasherType: HashedPostStateProvider,
     P: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync + Clone + 'static,
 {
-    let hashed_post_state = hasher.hashed_post_state(outcome.state());
+    let hashed_post_state = hasher.hashed_post_state(outcome);
     let parallel_root_calculator = ParallelStateRoot::new(
         consistent_db_view.clone(),
         TrieInput::from_state(hashed_post_state),
@@ -126,7 +127,8 @@ pub fn calculate_state_root<P, HasherType>(
     provider: P,
     hasher: &HasherType,
     parent_num_hash: BlockNumHash,
-    outcome: &ExecutionOutcome,
+    outcome: &BundleState,
+    incremental_change: &[Address],
     shared_cache: &SparseTrieSharedCache,
     local_cache: &mut SparseTrieLocalCache,
     config: &RootHashContext,
@@ -165,6 +167,7 @@ where
         let (root, metrics) = calculate_root_hash_with_sparse_trie(
             consistent_db_view,
             outcome,
+            incremental_change,
             shared_cache,
             local_cache,
             &config.thread_pool,

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -305,6 +305,12 @@ register_metrics! {
         &[]
     )
     .unwrap();
+    pub static BLOCK_FINALIZE_ADJUST_TIME: HistogramVec = HistogramVec::new(
+        HistogramOpts::new("block_finalize_adjust_time", "Block Finalize Adjust Times (ms)")
+            .buckets(exponential_buckets_range(0.01, 300.0, 200)),
+        &[]
+    )
+    .unwrap();
     pub static BLOCK_ROOT_HASH_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_root_hash_time", "Block Root Hash Time (ms)")
             .buckets(exponential_buckets_range(0.01, 2000.0, 200)),
@@ -490,6 +496,9 @@ pub fn add_finalized_block_metrics(
     BLOCK_FINALIZE_TIME
         .with_label_values(&[])
         .observe(duration_ms(built_block_trace.finalize_time));
+    BLOCK_FINALIZE_ADJUST_TIME
+        .with_label_values(&[])
+        .observe(duration_ms(built_block_trace.finalize_adjust_time));
     BLOCK_ROOT_HASH_TIME
         .with_label_values(&[])
         .observe(duration_ms(built_block_trace.root_hash_time));

--- a/crates/rbuilder/src/utils/provider_factory_reopen.rs
+++ b/crates/rbuilder/src/utils/provider_factory_reopen.rs
@@ -13,7 +13,7 @@ use alloy_eips::BlockNumHash;
 use alloy_primitives::{Address, BlockHash, BlockNumber, Bytes, B256};
 use eth_sparse_mpt::*;
 use parking_lot::Mutex;
-use reth::providers::{BlockHashReader, ChainSpecProvider, ExecutionOutcome, ProviderFactory};
+use reth::providers::{BlockHashReader, ChainSpecProvider, ProviderFactory};
 use reth_db::DatabaseError;
 use reth_errors::{ProviderError, ProviderResult, RethResult};
 use reth_node_api::{NodePrimitives, NodeTypesWithDB};
@@ -22,6 +22,7 @@ use reth_provider::{
     BlockNumReader, BlockReader, DatabaseProviderFactory, HashedPostStateProvider, HeaderProvider,
     StateProviderBox, StaticFileProviderFactory,
 };
+use revm::database::BundleState;
 use std::{ops::DerefMut, path::PathBuf, sync::Arc};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -310,7 +311,7 @@ where
 
     fn account_proofs(
         &self,
-        outcome: &ExecutionOutcome,
+        outcome: &BundleState,
         addresses: &utils::HashSet<Address>,
         local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<utils::HashMap<Address, Vec<Bytes>>, RootHashError> {
@@ -327,7 +328,8 @@ where
 
     fn state_root(
         &self,
-        outcome: &ExecutionOutcome,
+        outcome: &BundleState,
+        incremental_change: &[Address],
         local_ctx: &mut ThreadBlockBuildingContext,
     ) -> Result<B256, RootHashError> {
         calculate_state_root(
@@ -335,6 +337,7 @@ where
             &self.hasher,
             self.parent_num_hash,
             outcome,
+            incremental_change,
             &self.sparse_trie_shared_cache,
             &mut local_ctx.root_hash_calculator,
             &self.config,

--- a/crates/rbuilder/src/utils/receipts.rs
+++ b/crates/rbuilder/src/utils/receipts.rs
@@ -16,6 +16,8 @@ pub struct ReceiptsDataCache {
     trie: Trie,
     buff: Vec<u8>,
     empty_proof_store: ProofStore,
+    block_logs_bloom_without_last_tx: Bloom,
+    receipts_bloom_without_last_tx: Vec<Bloom>,
 }
 
 #[derive(Debug, Clone)]
@@ -34,10 +36,39 @@ pub fn calculate_receipts_data(
     cache: &mut ReceiptsDataCache,
     executed_tx_infos: &[TransactionExecutionInfo],
     fast_finalize: bool,
+    adjust_finalized_blocks: bool,
 ) -> ReceiptsData {
     let mut block_logs_bloom = Bloom::ZERO;
-    let mut receipts_with_blooms = Vec::with_capacity(executed_tx_infos.len());
-    for executed_tx_info in executed_tx_infos {
+    let mut receipts_blooms = Vec::with_capacity(executed_tx_infos.len());
+    if adjust_finalized_blocks {
+        block_logs_bloom = cache.block_logs_bloom_without_last_tx;
+        receipts_blooms.extend_from_slice(&cache.receipts_bloom_without_last_tx);
+    } else {
+        for executed_tx_info in executed_tx_infos.iter().take(executed_tx_infos.len() - 1) {
+            let receipt = &executed_tx_info.receipt;
+            let mut current_receipt_bloom = Bloom::ZERO;
+
+            for log in &receipt.logs {
+                let log_bloom = if let Some(log_bloom) = cache.logs.get(log) {
+                    *log_bloom
+                } else {
+                    let mut current_log_bloom = Bloom::ZERO;
+                    current_log_bloom.accrue_log(log);
+                    cache.logs.insert(log.clone(), current_log_bloom);
+                    current_log_bloom
+                };
+                current_receipt_bloom.accrue_bloom(&log_bloom);
+            }
+            receipts_blooms.push(current_receipt_bloom);
+
+            block_logs_bloom.accrue_bloom(&current_receipt_bloom);
+        }
+        cache.block_logs_bloom_without_last_tx = block_logs_bloom;
+        cache.receipts_bloom_without_last_tx = receipts_blooms.clone();
+    }
+
+    {
+        let executed_tx_info = executed_tx_infos.last().unwrap();
         let receipt = &executed_tx_info.receipt;
         let mut current_receipt_bloom = Bloom::ZERO;
 
@@ -52,17 +83,24 @@ pub fn calculate_receipts_data(
             };
             current_receipt_bloom.accrue_bloom(&log_bloom);
         }
-
+        receipts_blooms.push(current_receipt_bloom);
         block_logs_bloom.accrue_bloom(&current_receipt_bloom);
+    }
 
+    let mut receipts_with_blooms = Vec::with_capacity(executed_tx_infos.len());
+    for (info, logs_bloom) in executed_tx_infos.iter().zip(receipts_blooms.into_iter()) {
         receipts_with_blooms.push(ReceiptWithBloom {
-            receipt,
-            logs_bloom: current_receipt_bloom,
+            receipt: &info.receipt,
+            logs_bloom,
         });
     }
 
     let (receipts_root, placeholder_receipt_proof) = if fast_finalize {
-        calculate_receipts_root_and_placeholder_proof_with_cache(cache, &receipts_with_blooms)
+        calculate_receipts_root_and_placeholder_proof_with_cache(
+            cache,
+            &receipts_with_blooms,
+            adjust_finalized_blocks,
+        )
     } else {
         calculate_receipts_root_and_placeholder_proof_with_alloy(cache, &receipts_with_blooms)
     };
@@ -77,17 +115,26 @@ pub fn calculate_receipts_data(
 fn calculate_receipts_root_and_placeholder_proof_with_cache(
     cache: &mut ReceiptsDataCache,
     receipts: &[ReceiptWithBloom<&Receipt>],
+    adjust_finalized_block: bool,
 ) -> (B256, Vec<Bytes>) {
     let trie = &mut cache.trie;
-    trie.clear_empty();
-
-    for (idx, receipt) in receipts.iter().enumerate() {
+    let root = if !adjust_finalized_block {
+        trie.clear_empty();
+        for (idx, receipt) in receipts.iter().enumerate() {
+            let index = alloy_rlp::encode_fixed_size(&idx);
+            cache.buff.clear();
+            receipt.encode_2718(&mut cache.buff);
+            trie.insert(&index, &cache.buff).unwrap();
+        }
+        trie.root_hash(true, &cache.empty_proof_store).unwrap()
+    } else {
+        let idx = receipts.len() - 1;
         let index = alloy_rlp::encode_fixed_size(&idx);
         cache.buff.clear();
-        receipt.encode_2718(&mut cache.buff);
+        receipts[idx].encode_2718(&mut cache.buff);
         trie.insert(&index, &cache.buff).unwrap();
-    }
-    let root = trie.root_hash(true, &cache.empty_proof_store).unwrap();
+        trie.root_hash(false, &cache.empty_proof_store).unwrap()
+    };
 
     let target_idx = receipts.len().checked_sub(1).unwrap();
     let nibbles = Nibbles::unpack(alloy_rlp::encode_fixed_size(&target_idx));
@@ -124,9 +171,10 @@ pub fn calculate_tx_root_and_placeholder_proof(
     cache: &mut TransactionRootCache,
     executed_tx_infos: &[TransactionExecutionInfo],
     faster_finalize: bool,
+    prefinalized: bool,
 ) -> (B256, Vec<Bytes>) {
     if faster_finalize {
-        calculate_tx_root_and_placeholder_proof_with_cache(cache, executed_tx_infos)
+        calculate_tx_root_and_placeholder_proof_with_cache(cache, executed_tx_infos, prefinalized)
     } else {
         calculate_tx_root_and_placeholder_proof_with_alloy(cache, executed_tx_infos)
     }
@@ -136,19 +184,32 @@ pub fn calculate_tx_root_and_placeholder_proof(
 fn calculate_tx_root_and_placeholder_proof_with_cache(
     cache: &mut TransactionRootCache,
     executed_tx_infos: &[TransactionExecutionInfo],
+    adjust_finalized_block: bool,
 ) -> (B256, Vec<Bytes>) {
     let trie = &mut cache.trie;
-    trie.clear_empty();
     let val = &mut cache.buff;
-    for (idx, executed_tx_info) in executed_tx_infos.iter().enumerate() {
-        let tx_with_blobs = &executed_tx_info.tx;
+
+    let root = if !adjust_finalized_block {
+        trie.clear_empty();
+        for (idx, executed_tx_info) in executed_tx_infos.iter().enumerate() {
+            let tx_with_blobs = &executed_tx_info.tx;
+            let index = alloy_rlp::encode_fixed_size(&idx);
+
+            val.clear();
+            tx_with_blobs.encode_2718(val);
+            trie.insert(&index, val).unwrap();
+        }
+        trie.root_hash(true, &cache.empty_proof_store).unwrap()
+    } else {
+        let idx = executed_tx_infos.len() - 1;
+        let tx_with_blobs = &executed_tx_infos[idx].tx;
         let index = alloy_rlp::encode_fixed_size(&idx);
 
         val.clear();
         tx_with_blobs.encode_2718(val);
         trie.insert(&index, val).unwrap();
-    }
-    let root = trie.root_hash(true, &cache.empty_proof_store).unwrap();
+        trie.root_hash(false, &cache.empty_proof_store).unwrap()
+    };
 
     let target_idx = executed_tx_infos.len().checked_sub(1).unwrap();
     let nibbles = Nibbles::unpack(alloy_rlp::encode_fixed_size(&target_idx));
@@ -284,7 +345,7 @@ mod tests {
         let mut cache = ReceiptsDataCache::default();
         for fast_finalize in [false, true, true] {
             let got_receipts_data =
-                calculate_receipts_data(&mut cache, &executed_tx_info, fast_finalize);
+                calculate_receipts_data(&mut cache, &executed_tx_info, fast_finalize, false);
             assert_eq!(expected_receipt_root, got_receipts_data.receipts_root);
             assert_eq!(expected_logs_bloom, got_receipts_data.logs_bloom);
         }
@@ -303,10 +364,10 @@ mod tests {
         }
 
         let mut cache = TransactionRootCache::default();
-        let expected = calculate_tx_root_and_placeholder_proof(&mut cache, &data, false);
+        let expected = calculate_tx_root_and_placeholder_proof(&mut cache, &data, false, false);
 
         for _ in 0..2 {
-            let got = calculate_tx_root_and_placeholder_proof(&mut cache, &data, true);
+            let got = calculate_tx_root_and_placeholder_proof(&mut cache, &data, true, false);
             assert_eq!(expected, got);
         }
     }

--- a/crates/rbuilder/src/utils/receipts.rs
+++ b/crates/rbuilder/src/utils/receipts.rs
@@ -208,7 +208,7 @@ mod tests {
     use alloy_primitives::{address, fixed_bytes};
     use reth_primitives::{logs_bloom, Log, LogData};
 
-    use crate::utils::test_utils::tx;
+    use crate::{building::BlockSpace, utils::test_utils::tx};
 
     use super::*;
 
@@ -276,7 +276,7 @@ mod tests {
             .map(|receipt| TransactionExecutionInfo {
                 tx: tx(1),
                 receipt,
-                gas_used: 0,
+                space_used: BlockSpace::ZERO,
                 coinbase_profit: Default::default(),
             })
             .collect::<Vec<_>>();
@@ -297,7 +297,7 @@ mod tests {
             data.push(TransactionExecutionInfo {
                 tx: tx(i),
                 receipt: Default::default(),
-                gas_used: 0,
+                space_used: BlockSpace::ZERO,
                 coinbase_profit: Default::default(),
             });
         }


### PR DESCRIPTION
## 📝 Summary

Adds a new way to seal blocks to enable it set `adjust_finalized_blocks = true` in the config. 

If set to true blocks will be processed in two steps:
1. block is finalized (root hash, receipts root, etc) is processed
2. finalized blocks is sent to the bidding service
3. When bidding service responds finalized block is adjusted with correct bid value

The advantage is that bidding response becomes faster (it takes around 0.5ms on average to adjust finalized block).

In addition this PR:
* adds blob gas to the BlockSpace structure
* allows only transactions payment as a way to pay a proposer 

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
