### PR TITLE
chore: remove nightly format config

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
 reorder_imports = true
-imports_granularity = "Crate"


### PR DESCRIPTION
`make lint` doesn't use nightly Rust and is just noise

```
Run make lint
cargo fmt -- --check
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
...
```
https://github.com/flashbots/rbuilder/actions/runs/17913195731/job/50929259682?pr=717


Alternatively use nightly as referenced in https://github.com/flashbots/rbuilder/blob/d1cdaf6d350c14c1c4091bd043499ea96b2b86eb/CONTRIBUTING.md?plain=1#L38