### PR TITLE
deps: remove `primitive-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9107,7 +9107,6 @@ dependencies = [
  "mev-share-sse",
  "mockall",
  "parking_lot",
- "primitive-types",
  "priority-queue",
  "prometheus",
  "prost",

--- a/crates/rbuilder/Cargo.toml
+++ b/crates/rbuilder/Cargo.toml
@@ -63,7 +63,6 @@ metrics_macros = { path = "src/telemetry/metrics_macros" }
 
 reqwest = { workspace = true, features = ["blocking"] }
 serde_with = { workspace = true, features = ["time_0_3"] }
-primitive-types = "0.12.1"
 url.workspace = true
 sqlx = { version = "0.7.1", features = [
     "runtime-tokio-native-tls",

--- a/crates/rbuilder/benches/benchmarks/mev_boost.rs
+++ b/crates/rbuilder/benches/benchmarks/mev_boost.rs
@@ -1,8 +1,8 @@
 use alloy_consensus::{Block, Header};
 use alloy_eips::{eip4844::BlobTransactionSidecar, eip7594::BlobTransactionSidecarVariant};
 use alloy_primitives::U256;
+use alloy_rpc_types_beacon::BlsPublicKey;
 use criterion::{criterion_group, Criterion};
-use primitive_types::H384;
 use rbuilder::mev_boost::{
     rpc::TestDataGenerator, sign_block_for_relay, submission::DenebSubmitBlockRequest,
     BLSBlockSigner,
@@ -88,8 +88,8 @@ fn bench_mevboost_sign(c: &mut Criterion) {
                 &signer,
                 &sealed_block,
                 &payload,
-                H384::default(),
-                U256::default(),
+                BlsPublicKey::ZERO,
+                U256::ZERO,
             )
             .unwrap();
         })
@@ -113,8 +113,8 @@ fn bench_mevboost_sign(c: &mut Criterion) {
                 &signer,
                 &sealed_block_deneb,
                 &payload,
-                H384::default(),
-                U256::default(),
+                BlsPublicKey::ZERO,
+                U256::ZERO,
             )
             .unwrap();
         })

--- a/crates/rbuilder/src/integration/playground.rs
+++ b/crates/rbuilder/src/integration/playground.rs
@@ -4,10 +4,9 @@ use crate::{
 };
 use alloy_network::EthereumWallet;
 use alloy_primitives::{address, Address};
-use alloy_rpc_types_beacon::events::PayloadAttributesEvent;
+use alloy_rpc_types_beacon::{events::PayloadAttributesEvent, BlsPublicKey};
 use alloy_signer_local::PrivateKeySigner;
 use futures::StreamExt;
-use primitive_types::H384;
 use std::{
     fs::{File, OpenOptions},
     io,
@@ -170,7 +169,7 @@ impl Playground {
             .map_err(|_err| PayloadDeliveredError::RelayError)?
             .ok_or(PayloadDeliveredError::ProposalNotFound)?;
 
-        let builder_pubkey = H384::from_str("0xa1885d66bef164889a2e35845c3b626545d7b0e513efe335e97c3a45e534013fa3bc38c3b7e6143695aecc4872ac52c4").unwrap();
+        let builder_pubkey = BlsPublicKey::from_str("0xa1885d66bef164889a2e35845c3b626545d7b0e513efe335e97c3a45e534013fa3bc38c3b7e6143695aecc4872ac52c4").unwrap();
         if payload.builder_pubkey == builder_pubkey {
             Ok(payload)
         } else {

--- a/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
+++ b/crates/rbuilder/src/live_builder/payload_events/relay_epoch_cache.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use ahash::{HashMap, HashSet};
 use alloy_primitives::Address;
+use alloy_rpc_types_beacon::BlsPublicKey;
 use parking_lot::RwLock;
-use primitive_types::H384;
 use std::{sync::Arc, time::Duration};
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
@@ -19,7 +19,7 @@ pub struct SlotData {
     pub fee_recipient: Address,
     pub gas_limit: u64,
     /// Selected registered validator for the slot key.
-    pub pubkey: H384,
+    pub pubkey: BlsPublicKey,
 }
 
 /// Validator slot data by relay.
@@ -216,12 +216,11 @@ fn resolve_relay_slot_data(
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use crate::{
         mev_boost::{ValidatorRegistration, ValidatorRegistrationMessage},
         utils::set_test_debug_tracing_subscriber,
     };
-
-    use super::*;
     use alloy_primitives::{address, Bytes};
 
     fn make_test_data(fee_recipient: Address, timestamp: u64) -> RelaySlotData {
@@ -232,7 +231,7 @@ mod test {
                         fee_recipient,
                         gas_limit: 30000000,
                         timestamp,
-                        pubkey: H384::zero(),
+                        pubkey: BlsPublicKey::ZERO,
                     },
                     signature: Bytes::new(),
                 },
@@ -266,7 +265,7 @@ mod test {
             SlotData {
                 fee_recipient: address!("1111111111111111111111111111111111111111"),
                 gas_limit: 30000000,
-                pubkey: H384::zero(),
+                pubkey: BlsPublicKey::ZERO,
             },
             slot_data
         );
@@ -296,7 +295,7 @@ mod test {
             SlotData {
                 fee_recipient: address!("2222222222222222222222222222222222222222"),
                 gas_limit: 30000000,
-                pubkey: H384::zero(),
+                pubkey: BlsPublicKey::ZERO,
             },
             slot_data
         );
@@ -323,7 +322,7 @@ mod test {
             SlotData {
                 fee_recipient: address!("2222222222222222222222222222222222222222"),
                 gas_limit: 30000000,
-                pubkey: H384::zero(),
+                pubkey: BlsPublicKey::ZERO,
             },
             slot_data
         );
@@ -345,7 +344,7 @@ mod test {
             SlotData {
                 fee_recipient: address!("2222222222222222222222222222222222222222"),
                 gas_limit: 30000000,
-                pubkey: H384::zero(),
+                pubkey: BlsPublicKey::ZERO,
             },
             slot_data
         );

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -11,9 +11,9 @@ use crate::mev_boost::bloxroute_grpc::GrpcRelayClient;
 use super::utils::u256decimal_serde_helper;
 
 use alloy_primitives::{Address, BlockHash, Bytes, U256};
+use alloy_rpc_types_beacon::BlsPublicKey;
 use flate2::{write::GzEncoder, Compression};
 use itertools::Itertools;
-use primitive_types::H384;
 use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_ENCODING, CONTENT_TYPE},
     Body, Response, StatusCode,
@@ -236,8 +236,8 @@ pub struct ProposerPayloadDelivered {
     pub slot: u64,
     pub parent_hash: BlockHash,
     pub block_hash: BlockHash,
-    pub builder_pubkey: H384,
-    pub proposer_pubkey: H384,
+    pub builder_pubkey: BlsPublicKey,
+    pub proposer_pubkey: BlsPublicKey,
     pub proposer_fee_recipient: Address,
     #[serde_as(as = "DisplayFromStr")]
     pub gas_limit: u64,
@@ -258,8 +258,8 @@ pub struct BuilderBlockReceived {
     pub slot: u64,
     pub parent_hash: BlockHash,
     pub block_hash: BlockHash,
-    pub builder_pubkey: H384,
-    pub proposer_pubkey: H384,
+    pub builder_pubkey: BlsPublicKey,
+    pub proposer_pubkey: BlsPublicKey,
     pub proposer_fee_recipient: Address,
     #[serde_as(as = "DisplayFromStr")]
     pub gas_limit: u64,
@@ -287,7 +287,7 @@ pub struct ValidatorRegistrationMessage {
     pub gas_limit: u64,
     #[serde_as(as = "DisplayFromStr")]
     pub timestamp: u64,
-    pub pubkey: H384,
+    pub pubkey: BlsPublicKey,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash)]
@@ -503,7 +503,7 @@ impl RelayClient {
 
     pub async fn validator_registration(
         &self,
-        pubkey: H384,
+        pubkey: BlsPublicKey,
     ) -> Result<Option<ValidatorRegistration>, RelayError> {
         let url = {
             let mut url = self.url.clone();
@@ -913,8 +913,8 @@ mod tests {
             slot: 7251671,
             parent_hash: BlockHash::from_str("0xe57c063ad96fb5b6fe7696dc8509f3a986ace89d06a19951f3e4404f877bb0ca").unwrap(),
             block_hash: BlockHash::from_str("0xf2ae3ad64c285ab1de2195f23c19b2b2dcf4949b6f71a4a3406bac9734e1ff27").unwrap(),
-            builder_pubkey: H384::from_str("0x945fc51bf63613257792926c9155d7ae32db73155dc13bdfe61cd476f1fd2297b66601e8721b723cef11e4e6682e9d87").unwrap(),
-            proposer_pubkey: H384::from_str("0xb097a69fa420d01c293fed6b2596778d0722a2b076e401c2789cabce773a17c865285ff71b5dd545c7e77bee6ef8a41b").unwrap(),
+            builder_pubkey: BlsPublicKey::from_str("0x945fc51bf63613257792926c9155d7ae32db73155dc13bdfe61cd476f1fd2297b66601e8721b723cef11e4e6682e9d87").unwrap(),
+            proposer_pubkey: BlsPublicKey::from_str("0xb097a69fa420d01c293fed6b2596778d0722a2b076e401c2789cabce773a17c865285ff71b5dd545c7e77bee6ef8a41b").unwrap(),
             proposer_fee_recipient: Address::from_str("0xeBec795c9c8bBD61FFc14A6662944748F299cAcf").unwrap(),
             gas_limit: 30000000,
             gas_used: 20152932,
@@ -944,8 +944,8 @@ mod tests {
             slot: 7251671,
             parent_hash: BlockHash::from_str("0xe57c063ad96fb5b6fe7696dc8509f3a986ace89d06a19951f3e4404f877bb0ca").unwrap(),
             block_hash: BlockHash::from_str("0xae52fd69bb83fbe20802b8c130bed111d2f0b9620ab6d8ee369eee11e15b845e").unwrap(),
-            builder_pubkey: H384::from_str("0x945fc51bf63613257792926c9155d7ae32db73155dc13bdfe61cd476f1fd2297b66601e8721b723cef11e4e6682e9d87").unwrap(),
-            proposer_pubkey: H384::from_str("0xb097a69fa420d01c293fed6b2596778d0722a2b076e401c2789cabce773a17c865285ff71b5dd545c7e77bee6ef8a41b").unwrap(),
+            builder_pubkey: BlsPublicKey::from_str("0x945fc51bf63613257792926c9155d7ae32db73155dc13bdfe61cd476f1fd2297b66601e8721b723cef11e4e6682e9d87").unwrap(),
+            proposer_pubkey: BlsPublicKey::from_str("0xb097a69fa420d01c293fed6b2596778d0722a2b076e401c2789cabce773a17c865285ff71b5dd545c7e77bee6ef8a41b").unwrap(),
             proposer_fee_recipient: Address::from_str("0xeBec795c9c8bBD61FFc14A6662944748F299cAcf").unwrap(),
             gas_limit: 30000000,
             gas_used: 20585314,
@@ -964,7 +964,7 @@ mod tests {
     async fn test_validator_registration() {
         let relay = create_relay_provider();
         let result = relay
-            .validator_registration(H384::from_str("0x904e01b37a8db98695483da0025f4cc1c0ecc2b9a37ab53604c21d6788ad2a8996748ea0ce838d2926767eee0228ec69").unwrap())
+            .validator_registration(BlsPublicKey::from_str("0x904e01b37a8db98695483da0025f4cc1c0ecc2b9a37ab53604c21d6788ad2a8996748ea0ce838d2926767eee0228ec69").unwrap())
             .await
             .expect("Failed to get validator registration")
         .expect("Validator registration not found");
@@ -974,7 +974,7 @@ mod tests {
                 fee_recipient: Address::from_str("0x388c818ca8b9251b393131c08a736a67ccb19297").unwrap(),
                 gas_limit: 30000000,
                 timestamp: 1707146537,
-                pubkey: H384::from_str("0x904e01b37a8db98695483da0025f4cc1c0ecc2b9a37ab53604c21d6788ad2a8996748ea0ce838d2926767eee0228ec69").unwrap(),
+                pubkey: BlsPublicKey::from_str("0x904e01b37a8db98695483da0025f4cc1c0ecc2b9a37ab53604c21d6788ad2a8996748ea0ce838d2926767eee0228ec69").unwrap(),
             },
             signature: Bytes::from_str("0xa1d5118053d39665319909d099db64f174e62ffee22c4c65f7c86f549bde1225148af3e4623dc17f2bf8a292249693bb0556ef3bd13b7ea79fe58298e3a97f93c225777376ee07e49e8db9265a32716306288f5117f24bbac445babc78a81888").unwrap(),
         };
@@ -1040,7 +1040,7 @@ mod tests {
                     timestamp: 0,
                     gas_limit: 30_000_000,
                     fee_recipient: Address::random(),
-                    pubkey: H384::random(),
+                    pubkey: BlsPublicKey::random(),
                 },
                 signature: Default::default(),
             },

--- a/crates/rbuilder/src/mev_boost/sign_payload.rs
+++ b/crates/rbuilder/src/mev_boost/sign_payload.rs
@@ -9,7 +9,6 @@ use ethereum_consensus::{
     signing::sign_with_domain,
     ssz::prelude::*,
 };
-use primitive_types::H384;
 use reth_primitives::SealedBlock;
 use serde_with::{serde_as, DisplayFromStr};
 
@@ -39,8 +38,8 @@ impl BLSBlockSigner {
         Ok(signature.to_vec())
     }
 
-    pub fn pub_key(&self) -> H384 {
-        H384::from_slice(self.sec.public_key().as_slice())
+    pub fn pub_key(&self) -> BlsPublicKey {
+        BlsPublicKey::from_slice(&self.sec.public_key())
     }
 
     pub fn test_signer() -> Self {
@@ -92,7 +91,7 @@ fn a2e_hash32(h: &BlockHash) -> Hash32 {
 }
 
 fn a2e_pubkey(k: &BlsPublicKey) -> BlsPublicKey2 {
-    // Should not panic since H384 matches BlsPublicKey size
+    // Should not panic since both types are equal in size
     BlsPublicKey2::try_from(k.as_slice()).unwrap()
 }
 
@@ -105,15 +104,15 @@ pub fn sign_block_for_relay(
     signer: &BLSBlockSigner,
     sealed_block: &SealedBlock,
     attrs: &PayloadAttributesData,
-    pubkey: H384,
+    proposer_pubkey: BlsPublicKey,
     value: U256,
 ) -> eyre::Result<(BidTrace, BlsSignature)> {
     let message = BidTrace {
         slot: attrs.proposal_slot,
         parent_hash: attrs.parent_block_hash,
         block_hash: sealed_block.hash(),
-        builder_pubkey: FixedBytes::from_slice(signer.pub_key().as_bytes()),
-        proposer_pubkey: FixedBytes::from_slice(pubkey.as_bytes()),
+        builder_pubkey: signer.pub_key(),
+        proposer_pubkey,
         proposer_fee_recipient: attrs.payload_attributes.suggested_fee_recipient,
         gas_limit: sealed_block.gas_limit,
         gas_used: sealed_block.gas_used,
@@ -137,7 +136,7 @@ mod test {
             super::BLSBlockSigner::new(sec, Default::default()).expect("failed to contruct signer");
 
         let pub_key = signer.pub_key();
-        let expected_key = H384::from_slice(&alloy_primitives::bytes!("a1885d66bef164889a2e35845c3b626545d7b0e513efe335e97c3a45e534013fa3bc38c3b7e6143695aecc4872ac52c4").0);
+        let expected_key = BlsPublicKey::from_slice(&alloy_primitives::bytes!("a1885d66bef164889a2e35845c3b626545d7b0e513efe335e97c3a45e534013fa3bc38c3b7e6143695aecc4872ac52c4").0);
         assert_eq!(pub_key, expected_key);
     }
 


### PR DESCRIPTION
## 📝 Summary

Remove obsolete usage of `primitive-types` crate. Use only alloy types instead.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
