### PR TITLE
feat: delayed refunds

### DIFF
--- a/crates/rbuilder-primitives/src/lib.rs
+++ b/crates/rbuilder-primitives/src/lib.rs
@@ -295,7 +295,6 @@ impl Bundle {
             // We used to allow multiple hashes and encode the len, we keep the 1 to be backwards compatible.
             buff.append(&mut (1u64).encode_var_vec());
             buff.extend_from_slice(refund.tx_hash.as_slice());
-            // TODO: buff.push(refund.delayed as u8);
         }
         Self::uuid_from_buffer(buff)
     }

--- a/crates/rbuilder-primitives/src/lib.rs
+++ b/crates/rbuilder-primitives/src/lib.rs
@@ -130,6 +130,8 @@ pub struct BundleRefund {
     /// Transaction hash to refund.
     /// This means that part (percent%) of the profit from the execution this txs goes to refund.recipient
     pub tx_hash: TxHash,
+    /// Boolean for whether the refund should be delayed.
+    pub delayed: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -293,6 +295,7 @@ impl Bundle {
             // We used to allow multiple hashes and encode the len, we keep the 1 to be backwards compatible.
             buff.append(&mut (1u64).encode_var_vec());
             buff.extend_from_slice(refund.tx_hash.as_slice());
+            // TODO: buff.push(refund.delayed as u8);
         }
         Self::uuid_from_buffer(buff)
     }

--- a/crates/rbuilder-primitives/src/serialize.rs
+++ b/crates/rbuilder-primitives/src/serialize.rs
@@ -164,6 +164,9 @@ pub struct RawBundle {
     /// Only for version None or >= v2
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refund_tx_hashes: Option<Vec<TxHash>>,
+    /// delayedRefund (Optional) `Boolean`, A flag indicating whether the refund should be delayed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delayed_refund: Option<bool>,
     /// firstSeenAt `Number`, timestamp (seconds) at which bundle was first seen,
     /// used for ensuring we respect the order of uuid bundles that
     /// were first received elsewhere
@@ -252,6 +255,7 @@ impl RawBundle {
             self.refund_percent,
             self.refund_recipient,
             self.refund_tx_hashes,
+            self.delayed_refund,
             &txs,
         )?;
 
@@ -309,6 +313,12 @@ impl RawBundle {
                         version,
                     ));
                 }
+                if self.delayed_refund.is_some() {
+                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
+                        "delayed_refund".to_owned(),
+                        version,
+                    ));
+                }
                 Ok(())
             }
             BundleVersion::V2 => Ok(()),
@@ -319,6 +329,7 @@ impl RawBundle {
         mut refund_percent: Option<u8>,
         refund_recipient: Option<Address>,
         refund_tx_hashes: Option<Vec<TxHash>>,
+        delayed_refund: Option<bool>,
         txs: &[TransactionSignedEcRecoveredWithBlobs],
     ) -> Result<Option<BundleRefund>, RawBundleConvertError> {
         // Validate refund percent setting.
@@ -351,6 +362,7 @@ impl RawBundle {
                     percent,
                     recipient: refund_recipient.unwrap_or_else(|| first_tx.signer()),
                     tx_hash,
+                    delayed: delayed_refund.unwrap_or_default(),
                 });
             }
         }
@@ -422,7 +434,8 @@ impl RawBundle {
             replacement_nonce,
             refund_percent: value.refund.as_ref().map(|br| br.percent),
             refund_recipient: value.refund.as_ref().map(|br| br.recipient),
-            refund_tx_hashes: value.refund.map(|br| vec![br.tx_hash]),
+            refund_tx_hashes: value.refund.as_ref().map(|br| vec![br.tx_hash]),
+            delayed_refund: value.refund.as_ref().map(|br| br.delayed),
             first_seen_at: None,
             version: Some(Self::encode_version(value.version)),
         }
@@ -1149,6 +1162,7 @@ mod tests {
                 tx_hash: b256!(
                     "0x75662ab9cb6d1be7334723db5587435616352c7e581a52867959ac24006ac1fe"
                 ),
+                delayed: false,
             })
         );
         assert_eq!(bundle.uuid, uuid!("e2bdb8cd-9473-5a1b-b425-57fa7ecfe2c1"));
@@ -1196,6 +1210,7 @@ mod tests {
                     tx_hash: b256!(
                         "0x84310f7f7860f0cd65407fe340d471ca008d0c58976746a560312d4aebba3f4a"
                     ),
+                    delayed: false,
                 })
             );
             assert_eq!(bundle.uuid, uuid!("ea9954e1-b7be-5af0-9c39-6b11c9d24c05"));

--- a/crates/rbuilder/src/backtest/restore_landed_orders/find_landed_orders.rs
+++ b/crates/rbuilder/src/backtest/restore_landed_orders/find_landed_orders.rs
@@ -999,6 +999,7 @@ mod tests {
                 percent: 10,
                 recipient: Default::default(),
                 tx_hash: hash(0x01),
+                delayed: false,
             }),
             version: LAST_BUNDLE_VERSION,
         });

--- a/crates/rbuilder/src/backtest/store.rs
+++ b/crates/rbuilder/src/backtest/store.rs
@@ -748,6 +748,7 @@ mod test {
                     refund_percent: None,
                     refund_recipient: None,
                     refund_tx_hashes: None,
+                    delayed_refund: None,
                     first_seen_at: None,
                     version: Some(RawBundle::encode_version(LAST_BUNDLE_VERSION)),
                 })),

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -539,8 +539,10 @@ pub struct PartialBlock<
     pub coinbase_profit: U256,
     /// Tx execution info belonging to successfully executed orders.
     pub executed_tx_infos: Vec<TransactionExecutionInfo>,
-    /// Combined refunds.
+    /// Combined refunds to be paid at the end of the block.
     pub combined_refunds: HashMap<Address, U256>,
+    /// Cumulative delayed refund value which will be refunded via BuilderNet refund pipeline.
+    pub delayed_refund: U256,
     pub tracer: Tracer,
     partial_block_execution_tracer: PartialBlockExecutionTracerType,
 }
@@ -688,6 +690,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             coinbase_profit: self.coinbase_profit,
             executed_tx_infos: self.executed_tx_infos,
             combined_refunds: self.combined_refunds,
+            delayed_refund: self.delayed_refund,
             tracer,
             partial_block_execution_tracer: self.partial_block_execution_tracer,
         }
@@ -770,11 +773,16 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             recipient,
             payout_value,
             payout_tx_space_needed,
+            should_pay_in_block,
             ..
         }) = ok_result.delayed_kickback
         {
-            self.space_state.reserve_block_space(payout_tx_space_needed);
-            *self.combined_refunds.entry(recipient).or_default() += payout_value;
+            if should_pay_in_block {
+                self.space_state.reserve_block_space(payout_tx_space_needed);
+                *self.combined_refunds.entry(recipient).or_default() += payout_value;
+            } else {
+                self.delayed_refund += payout_value;
+            }
         }
 
         Ok(Ok(ExecutionResult {
@@ -1296,6 +1304,7 @@ impl PartialBlock<(), NullPartialBlockExecutionTracer> {
             coinbase_profit: U256::ZERO,
             executed_tx_infos: Vec::new(),
             combined_refunds: HashMap::default(),
+            delayed_refund: U256::ZERO,
             tracer: (),
             partial_block_execution_tracer: NullPartialBlockExecutionTracer {},
         }
@@ -1315,6 +1324,7 @@ impl<PartialBlockExecutionTracerType: PartialBlockExecutionTracer>
             coinbase_profit: U256::ZERO,
             executed_tx_infos: Vec::new(),
             combined_refunds: HashMap::default(),
+            delayed_refund: U256::ZERO,
             tracer: (),
             partial_block_execution_tracer,
         }

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -768,7 +768,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
         self.coinbase_profit += ok_result.coinbase_profit;
         self.executed_tx_infos.extend(ok_result.tx_infos.clone());
 
-        // Update combined refunds
+        // Update combined or delayed refunds
         if let Some(DelayedKickback {
             recipient,
             payout_value,

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -254,6 +254,7 @@ pub struct DelayedKickback {
     pub payout_value: U256,
     pub payout_tx_fee: U256,
     pub payout_tx_space_needed: BlockSpace,
+    pub should_pay_in_block: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -905,6 +906,17 @@ impl<
             // Calculate the refund value without refund tx cost.
             let refundable_value = get_percent(refundable_profit, refunds_cfg.percent as usize);
 
+            if refunds_cfg.delayed {
+                // The refund value will be delayed to the BuilderNet refund pipeline.
+                insert.delayed_kickback = Some(DelayedKickback {
+                    recipient: refunds_cfg.recipient,
+                    payout_value: refundable_value,
+                    payout_tx_fee: U256::ZERO,
+                    payout_tx_space_needed: BlockSpace::ZERO,
+                    should_pay_in_block: false,
+                });
+            }
+
             if combined_refunds.contains_key(&refunds_cfg.recipient) {
                 // We already determined that refund for this recipient will cost [`BASE_TX_GAS`]
                 // and previously inserted a bundle that is capable of paying this cost.
@@ -914,6 +926,7 @@ impl<
                     payout_value: refundable_value,
                     payout_tx_fee: U256::ZERO,
                     payout_tx_space_needed: BlockSpace::ZERO,
+                    should_pay_in_block: true,
                 });
                 break 'refund;
             }
@@ -938,6 +951,7 @@ impl<
                     payout_value: payout.tx_value,
                     payout_tx_fee: payout.base_fee,
                     payout_tx_space_needed: payout.space_limit,
+                    should_pay_in_block: true,
                 });
                 break 'refund;
             }

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -915,6 +915,7 @@ impl<
                     payout_tx_space_needed: BlockSpace::ZERO,
                     should_pay_in_block: false,
                 });
+                break 'refund;
             }
 
             if combined_refunds.contains_key(&refunds_cfg.recipient) {

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -403,6 +403,83 @@ fn test_bundle_combined_refunds() -> eyre::Result<()> {
     Ok(())
 }
 
+/// Test delayed refunds
+#[test]
+fn test_bundle_delayed_refunds() -> eyre::Result<()> {
+    let target_block = 11;
+    let profit: u64 = 100_000;
+    let refund_percent: u8 = 90;
+    let refundable_value = int_percentage(profit, refund_percent as usize);
+    let coinbase_profit = profit - refundable_value;
+
+    let mut test_setup = TestSetup::gen_test_setup(BlockArgs::default().number(target_block))?;
+    let recipient = NamedAddr::User(2);
+    let recipient_address = test_setup.named_address(recipient)?;
+    let recipient_balance_before = test_setup.balance(recipient)?;
+
+    let commit_refund_order =
+        |setup: &mut TestSetup, recipient: Address| -> eyre::Result<ExecutionResult> {
+            setup.begin_bundle_order(target_block);
+            setup.add_dummy_tx_0_1_no_rev()?;
+            let profit_tx_hash = setup.add_send_to_coinbase_tx(NamedAddr::User(1), profit)?;
+            setup.set_bundle_refund(BundleRefund {
+                recipient,
+                percent: refund_percent,
+                tx_hash: profit_tx_hash,
+                delayed: true,
+            });
+            Ok(setup.commit_order_ok())
+        };
+
+    let result = commit_refund_order(&mut test_setup, recipient_address).unwrap();
+    let partial_block = test_setup.partial_block();
+    assert_eq!(test_setup.balance(recipient)?, recipient_balance_before);
+    assert!(result.paid_kickbacks.is_empty());
+    assert_eq!(result.coinbase_profit, U256::from(coinbase_profit));
+    assert!(partial_block.combined_refunds.is_empty());
+    assert_eq!(partial_block.delayed_refund, U256::from(refundable_value));
+    assert_eq!(partial_block.coinbase_profit, U256::from(coinbase_profit));
+
+    let result = commit_refund_order(&mut test_setup, recipient_address).unwrap();
+    let partial_block = test_setup.partial_block();
+    assert_eq!(test_setup.balance(recipient)?, recipient_balance_before);
+    assert!(result.paid_kickbacks.is_empty());
+    assert_eq!(result.coinbase_profit, U256::from(coinbase_profit));
+    assert!(partial_block.combined_refunds.is_empty());
+    assert_eq!(
+        partial_block.delayed_refund,
+        U256::from(refundable_value * 2)
+    );
+    assert_eq!(
+        partial_block.coinbase_profit,
+        U256::from(coinbase_profit * 2)
+    );
+
+    let second_recipient = NamedAddr::User(3);
+    let second_recipient_address = test_setup.named_address(second_recipient)?;
+    let second_recipient_balance_before = test_setup.balance(second_recipient)?;
+
+    let result = commit_refund_order(&mut test_setup, second_recipient_address).unwrap();
+    let partial_block = test_setup.partial_block();
+    assert_eq!(
+        test_setup.balance(second_recipient)?,
+        second_recipient_balance_before
+    );
+    assert!(result.paid_kickbacks.is_empty());
+    assert_eq!(result.coinbase_profit, U256::from(coinbase_profit));
+    assert!(partial_block.combined_refunds.is_empty());
+    assert_eq!(
+        partial_block.delayed_refund,
+        U256::from(refundable_value * 3)
+    );
+    assert_eq!(
+        partial_block.coinbase_profit,
+        U256::from(coinbase_profit * 3)
+    );
+
+    Ok(())
+}
+
 /// Test immediate refunds to contract recipients
 #[test]
 fn test_bundle_contract_refunds() -> eyre::Result<()> {

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -349,6 +349,7 @@ fn test_bundle_combined_refunds() -> eyre::Result<()> {
                 recipient,
                 percent: refund_percent,
                 tx_hash: profit_tx_hash,
+                delayed: false,
             });
             Ok(setup.commit_order_ok())
         };
@@ -429,6 +430,7 @@ fn test_bundle_contract_refunds() -> eyre::Result<()> {
         percent: refund_percent,
         recipient: recipient_contract_address,
         tx_hash: profit_tx_hash,
+        delayed: false,
     });
     let result = test_setup.commit_order_ok();
     let recipient_balance_after = test_setup.balance(recipient_named_address)?;


### PR DESCRIPTION
## 📝 Summary

Add a new bundle field which allows orderflow senders to opt into being refunded via BuilderNet refund pipeline thus saving the gas costs on the payout transaction.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
