### PR TITLE
feat: whitelisted system recipients

### DIFF
--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -120,7 +120,7 @@ pub struct BlockBuildingContext {
     pub mempool_tx_detector: Arc<MempoolTxsDetector>,
     pub faster_finalize: bool,
     pub adjustment_fee_payers: ahash::HashSet<Address>,
-    pub whitelisted_system_senders: Vec<Address>,
+    pub whitelisted_system_recipients: Vec<Address>,
     /// Cached from evm_env.block_env.number but as BlockNumber. Avoid conversions all over the code.
     block_number: BlockNumber,
 }
@@ -143,7 +143,7 @@ impl BlockBuildingContext {
         payload_id: InternalPayloadId,
         evm_caching_enable: bool,
         faster_finalize: bool,
-        whitelisted_system_senders: Vec<Address>,
+        whitelisted_system_recipients: Vec<Address>,
         adjustment_fee_payers: ahash::HashSet<Address>,
     ) -> Option<BlockBuildingContext> {
         let attributes = EthPayloadBuilderAttributes::try_new(
@@ -218,7 +218,7 @@ impl BlockBuildingContext {
             max_blob_gas_per_block,
             mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
             faster_finalize,
-            whitelisted_system_senders,
+            whitelisted_system_recipients,
             adjustment_fee_payers,
             block_number,
         })
@@ -324,7 +324,7 @@ impl BlockBuildingContext {
             max_blob_gas_per_block,
             mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
             faster_finalize: true,
-            whitelisted_system_senders: Default::default(),
+            whitelisted_system_recipients: Default::default(),
             adjustment_fee_payers: Default::default(),
             block_number,
         }

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -120,6 +120,7 @@ pub struct BlockBuildingContext {
     pub mempool_tx_detector: Arc<MempoolTxsDetector>,
     pub faster_finalize: bool,
     pub adjustment_fee_payers: ahash::HashSet<Address>,
+    pub whitelisted_system_senders: Vec<Address>,
     /// Cached from evm_env.block_env.number but as BlockNumber. Avoid conversions all over the code.
     block_number: BlockNumber,
 }
@@ -142,6 +143,7 @@ impl BlockBuildingContext {
         payload_id: InternalPayloadId,
         evm_caching_enable: bool,
         faster_finalize: bool,
+        whitelisted_system_senders: Vec<Address>,
         adjustment_fee_payers: ahash::HashSet<Address>,
     ) -> Option<BlockBuildingContext> {
         let attributes = EthPayloadBuilderAttributes::try_new(
@@ -216,6 +218,7 @@ impl BlockBuildingContext {
             max_blob_gas_per_block,
             mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
             faster_finalize,
+            whitelisted_system_senders,
             adjustment_fee_payers,
             block_number,
         })
@@ -321,6 +324,7 @@ impl BlockBuildingContext {
             max_blob_gas_per_block,
             mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
             faster_finalize: true,
+            whitelisted_system_senders: Default::default(),
             adjustment_fee_payers: Default::default(),
             block_number,
         }

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -695,15 +695,6 @@ impl<
             logs: res.result.logs().to_vec(),
         };
         let coinbase_balance_after = I256::try_from(self.coinbase_balance()?)?;
-        let coinbase_profit = if self
-            .ctx
-            .whitelisted_system_senders
-            .contains(tx.signer_ref())
-        {
-            I256::ZERO
-        } else {
-            coinbase_balance_after - coinbase_balance_before
-        };
         Ok(Ok(TransactionOk {
             exec_result: res.result,
             cumulative_space_used: space_state.space_used(),
@@ -711,7 +702,7 @@ impl<
                 tx: tx_with_blobs.clone(),
                 receipt,
                 space_used,
-                coinbase_profit,
+                coinbase_profit: coinbase_balance_after - coinbase_balance_before,
             },
             nonce_updated: (tx.signer(), tx.nonce() + 1),
         }))
@@ -1239,6 +1230,15 @@ impl<
                     Ok(ok) => {
                         let coinbase_profit = if !ok.tx_info.coinbase_profit.is_negative() {
                             ok.tx_info.coinbase_profit.unsigned_abs()
+                        } else if order.list_txs().first().is_some_and(|(tx, _)| {
+                            order.list_txs_len() == 1
+                                && tx.signer() == self.ctx.builder_signer.address
+                                && tx.to().is_some_and(|to| {
+                                    self.ctx.whitelisted_system_recipients.contains(&to)
+                                })
+                        }) {
+                            // This is a system transaction which should not be counted towards the block profit.
+                            U256::ZERO
                         } else {
                             return Ok(Err(OrderErr::NegativeProfit(
                                 ok.tx_info.coinbase_profit.unsigned_abs(),

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -695,6 +695,15 @@ impl<
             logs: res.result.logs().to_vec(),
         };
         let coinbase_balance_after = I256::try_from(self.coinbase_balance()?)?;
+        let coinbase_profit = if self
+            .ctx
+            .whitelisted_system_senders
+            .contains(tx.signer_ref())
+        {
+            I256::ZERO
+        } else {
+            coinbase_balance_after - coinbase_balance_before
+        };
         Ok(Ok(TransactionOk {
             exec_result: res.result,
             cumulative_space_used: space_state.space_used(),
@@ -702,7 +711,7 @@ impl<
                 tx: tx_with_blobs.clone(),
                 receipt,
                 space_used,
-                coinbase_profit: coinbase_balance_after - coinbase_balance_before,
+                coinbase_profit,
             },
             nonce_updated: (tx.signer(), tx.nonce() + 1),
         }))

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -1230,13 +1230,11 @@ impl<
                     Ok(ok) => {
                         let coinbase_profit = if !ok.tx_info.coinbase_profit.is_negative() {
                             ok.tx_info.coinbase_profit.unsigned_abs()
-                        } else if order.list_txs().first().is_some_and(|(tx, _)| {
-                            order.list_txs_len() == 1
-                                && tx.signer() == self.ctx.builder_signer.address
-                                && tx.to().is_some_and(|to| {
-                                    self.ctx.whitelisted_system_recipients.contains(&to)
-                                })
-                        }) {
+                        } else if tx.tx_with_blobs.signer() == self.ctx.builder_signer.address
+                            && tx.tx_with_blobs.to().is_some_and(|to| {
+                                self.ctx.whitelisted_system_recipients.contains(&to)
+                            })
+                        {
                             // This is a system transaction which should not be counted towards the block profit.
                             U256::ZERO
                         } else {

--- a/crates/rbuilder/src/building/testing/test_chain_state.rs
+++ b/crates/rbuilder/src/building/testing/test_chain_state.rs
@@ -408,6 +408,7 @@ impl TestBlockContextBuilder {
             true,
             true,
             Default::default(),
+            Default::default(),
         )
         .unwrap()
     }

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -144,7 +144,7 @@ pub struct BaseConfig {
     pub time_to_keep_mempool_txs_secs: u64,
 
     /// The array of senders incoming transactions from which will not be counted towards the coinbase profit.
-    pub whitelisted_system_senders: Vec<Address>,
+    pub whitelisted_system_recipients: Vec<Address>,
 
     // backtest config
     backtest_fetch_mempool_data_dir: EnvOrValue<String>,
@@ -223,7 +223,7 @@ impl BaseConfig {
             coinbase_signer: self.coinbase_signer()?,
             extra_data: self.extra_data.clone(),
             blocklist_provider,
-            whitelisted_system_senders: self.whitelisted_system_senders.clone(),
+            whitelisted_system_recipients: self.whitelisted_system_recipients.clone(),
 
             global_cancellation: cancellation_token,
 
@@ -499,7 +499,7 @@ impl Default for BaseConfig {
             evm_caching_enable: false,
             faster_finalize: false,
             time_to_keep_mempool_txs_secs: DEFAULT_TIME_TO_KEEP_MEMPOOL_TXS_SECS,
-            whitelisted_system_senders: Vec::new(),
+            whitelisted_system_recipients: Vec::new(),
         }
     }
 }

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -143,6 +143,9 @@ pub struct BaseConfig {
     /// See [OrderPool::time_to_keep_mempool_txs]
     pub time_to_keep_mempool_txs_secs: u64,
 
+    /// The array of senders incoming transactions from which will not be counted towards the coinbase profit.
+    pub whitelisted_system_senders: Vec<Address>,
+
     // backtest config
     backtest_fetch_mempool_data_dir: EnvOrValue<String>,
     pub backtest_fetch_eth_rpc_url: String,
@@ -220,6 +223,7 @@ impl BaseConfig {
             coinbase_signer: self.coinbase_signer()?,
             extra_data: self.extra_data.clone(),
             blocklist_provider,
+            whitelisted_system_senders: self.whitelisted_system_senders.clone(),
 
             global_cancellation: cancellation_token,
 
@@ -495,6 +499,7 @@ impl Default for BaseConfig {
             evm_caching_enable: false,
             faster_finalize: false,
             time_to_keep_mempool_txs_secs: DEFAULT_TIME_TO_KEEP_MEMPOOL_TXS_SECS,
+            whitelisted_system_senders: Vec::new(),
         }
     }
 }

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -129,6 +129,8 @@ where
     pub evm_caching_enable: bool,
     pub faster_finalize: bool,
     pub simulation_use_random_coinbase: bool,
+
+    pub whitelisted_system_senders: Vec<Address>,
 }
 
 impl<P> LiveBuilder<P>
@@ -304,6 +306,7 @@ where
                 payload.payload_id,
                 self.evm_caching_enable,
                 self.faster_finalize,
+                self.whitelisted_system_senders.clone(),
                 payload
                     .relay_registrations
                     .iter()

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -130,7 +130,7 @@ where
     pub faster_finalize: bool,
     pub simulation_use_random_coinbase: bool,
 
-    pub whitelisted_system_senders: Vec<Address>,
+    pub whitelisted_system_recipients: Vec<Address>,
 }
 
 impl<P> LiveBuilder<P>
@@ -306,7 +306,7 @@ where
                 payload.payload_id,
                 self.evm_caching_enable,
                 self.faster_finalize,
-                self.whitelisted_system_senders.clone(),
+                self.whitelisted_system_recipients.clone(),
                 payload
                     .relay_registrations
                     .iter()


### PR DESCRIPTION
## 📝 Summary

Add ability to specify whitelisted system recipients. If the transaction is from the builder signer to the recipient, the value would not be counted towards block profit.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
