### PR TITLE
chore: add `rbuilder-rebalancer` to default workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ default-members = [
     "crates/rbuilder",
     "crates/rbuilder-operator",    
     "crates/reth-rbuilder",
+    "crates/rbuilder-rebalancer",
     "crates/rbuilder-primitives",
     "crates/test-relay",
     "crates/bid-scraper",


### PR DESCRIPTION
## 📝 Summary

Add `rbuilder-rebalancer` to default workspace members.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
