### PR TITLE
Removed 10 min reset in metrics and fixed a label

### DIFF
--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         watchdog::spawn_watchdog_thread,
     },
     provider::StateProviderFactory,
-    telemetry::{inc_active_slots, mark_building_started, reset_histogram_metrics},
+    telemetry::{inc_active_slots, mark_building_started},
     utils::{
         error_storage::spawn_error_storage_writer, format_offset_datetime_rfc3339,
         mevblocker::get_mevblocker_price, provider_head_state::ProviderHeadState, Signer,
@@ -210,8 +210,6 @@ where
 
         ready_to_build.store(true, Ordering::Relaxed);
         while let Some(payload) = payload_events_channel.recv().await {
-            reset_histogram_metrics();
-
             let blocklist = self.blocklist_provider.get_blocklist()?;
             if blocklist.contains(&payload.fee_recipient()) {
                 warn!(

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -25,10 +25,7 @@ use prometheus::{
     Opts, Registry,
 };
 use rbuilder_primitives::mev_boost::MevBoostRelayID;
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::time::Duration;
 use time::OffsetDateTime;
 use tracing::error;
 
@@ -416,45 +413,6 @@ register_metrics! {
     )
     .unwrap();
 
-}
-
-// This function should be called periodically to reset histogram metrics.
-// If metrics are not reset histogram quantiles become rigid.
-// Reset period is 10 minutes.
-pub fn reset_histogram_metrics() {
-    const HISTOGRAM_METRIC_RESET_PERIOD: Duration = Duration::from_secs(10 * 60);
-
-    lazy_static! {
-        static ref LAST_RESET: Arc<Mutex<Instant>> = Arc::new(Mutex::new(Instant::now()));
-    }
-
-    let now = Instant::now();
-    let mut last_reset = LAST_RESET.lock();
-    if now.duration_since(*last_reset) < HISTOGRAM_METRIC_RESET_PERIOD {
-        return;
-    }
-    *last_reset = now;
-
-    // Reset all histogram metrics
-    BLOCK_BUILT_TXS.reset();
-    BLOCK_BUILT_BLOBS.reset();
-    BLOCK_BUILT_GAS_USED.reset();
-    BLOCK_BUILT_SIM_GAS_USED.reset();
-    BLOCK_VALIDATION_TIME.reset();
-    BLOCK_FILL_TIME.reset();
-    BLOCK_FINALIZE_TIME.reset();
-    BLOCK_ROOT_HASH_TIME.reset();
-    ORDER_SIMULATION_TIME.reset();
-    RELAY_SUBMIT_TIME.reset();
-    TXFETCHER_TRANSACTION_QUERY_TIME.reset();
-    SUBSIDY_VALUE.reset();
-    ORDER_RECEIVED_TO_SIM_END_TIME.reset();
-    ORDER_SIM_END_TO_FIRST_BUILD_STARTED_TIME.reset();
-    ORDER_SIM_END_TO_FIRST_BUILD_STARTED_MIN_TIME.reset();
-    BLOCK_FILL_START_SEAL_END_TIME.reset();
-    BLOCK_SEAL_END_SUBMIT_START_TIME.reset();
-    ORDERING_BUILDER_EXECUTED_ORDERS.reset();
-    ORDERING_BUILDER_EXECUTED_ORDERS_INCLUDE_RATIO.reset();
 }
 
 pub(super) fn set_version(version: Version) {

--- a/crates/rbuilder/src/telemetry/metrics/tracing_metrics.rs
+++ b/crates/rbuilder/src/telemetry/metrics/tracing_metrics.rs
@@ -103,7 +103,7 @@ pub fn mark_command_received(command: &ReplaceableOrderPoolCommand, received_at:
             }
         }
         ReplaceableOrderPoolCommand::CancelShareBundle(_)
-        | ReplaceableOrderPoolCommand::CancelBundle(_) => "replacement",
+        | ReplaceableOrderPoolCommand::CancelBundle(_) => "cancel",
     };
     ORDERPOOL_ORDERS_RECEIVED.with_label_values(&[kind]).inc();
 }


### PR DESCRIPTION
## 📝 Summary

Metric don't get reset every 10 mins anymore since this can be fixed when displaying the info.
On order metrics "replacement" was really a "cancel".

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
