### PR TITLE
feat(config): jsonrpc server max connections

### DIFF
--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -74,6 +74,7 @@ pub struct BaseConfig {
     pub jsonrpc_server_port: u16,
     #[serde(default = "default_ip")]
     pub jsonrpc_server_ip: Ipv4Addr,
+    pub jsonrpc_server_max_connections: Option<u32>,
 
     pub ignore_cancellable_orders: bool,
     pub ignore_blobs: bool,
@@ -464,6 +465,7 @@ impl Default for BaseConfig {
             el_node_ipc_path: None,
             jsonrpc_server_port: DEFAULT_INCOMING_BUNDLES_PORT,
             jsonrpc_server_ip: default_ip(),
+            jsonrpc_server_max_connections: None,
             ignore_cancellable_orders: true,
             ignore_blobs: false,
             chain: "mainnet".to_string(),

--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -151,6 +151,10 @@ impl OrderInputConfig {
     }
 
     pub fn from_config(config: &BaseConfig) -> eyre::Result<Self> {
+        let serve_max_connections = config
+            .jsonrpc_server_max_connections
+            .unwrap_or(DEFAULT_SERVE_MAX_CONNECTIONS);
+
         let mempool = if let Some(provider) = &config.ipc_provider {
             Some(MempoolSource::Ws(provider.mempool_server_url.clone()))
         } else if let Some(path) = &config.el_node_ipc_path {
@@ -166,7 +170,7 @@ impl OrderInputConfig {
             mempool_source: mempool,
             server_port: config.jsonrpc_server_port,
             server_ip: config.jsonrpc_server_ip,
-            serve_max_connections: 4096,
+            serve_max_connections,
             results_channel_timeout: Duration::from_millis(50),
             input_channel_buffer_size: 10_000,
             time_to_keep_mempool_txs: Duration::from_secs(config.time_to_keep_mempool_txs_secs),
@@ -182,7 +186,7 @@ impl OrderInputConfig {
             ignore_cancellable_orders: false,
             ignore_blobs: false,
             input_channel_buffer_size: 10,
-            serve_max_connections: 4096,
+            serve_max_connections: DEFAULT_SERVE_MAX_CONNECTIONS,
             server_ip: Ipv4Addr::new(127, 0, 0, 1),
             server_port: 0,
             time_to_keep_mempool_txs: Duration::from_secs(DEFAULT_TIME_TO_KEEP_MEMPOOL_TXS_SECS),

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -17,6 +17,7 @@ Every field has a default if omitted.
 |el_node_ipc_path|optional string| Path for Ipc communication with reth's mempool, Usually something like "/tmp/reth.ipc". If not set mempool will not be used as a source of txs|None|
 |jsonrpc_server_port| int| |8645|
 |jsonrpc_server_ip|string||"0.0.0.0"|
+|jsonrpc_server_max_connections|int|The maximum number of connections|4096|
 |ignore_cancellable_orders|bool|If true any order with replacement id will be dropped|true|
 |ignore_blobs|bool|If true txs with blobs will be ignored|false|
 |chain|string| |"mainnet"|


### PR DESCRIPTION
## 📝 Summary

Add an option to specify max jsonrpc server connections in rbuilder toml config. 

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
