### PR TITLE
feat(primitives): decoding with signer lookups

### DIFF
--- a/crates/rbuilder-primitives/src/lib.rs
+++ b/crates/rbuilder-primitives/src/lib.rs
@@ -912,6 +912,49 @@ impl TransactionSignedEcRecoveredWithBlobs {
             }
         }
     }
+
+    /// Decodes the "raw" format of transaction (e.g. `eth_sendRawTransaction`) with the blob data (network format)
+    pub fn decode_enveloped_with_real_blobs_with_lookup(
+        raw_tx: Bytes,
+        lookup: impl Fn(B256) -> Option<Address>,
+    ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
+        let raw_tx = &mut raw_tx.as_ref();
+        let pooled_tx = PooledTransactionVariant::decode_2718(raw_tx)
+            .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
+
+        let signer = if let Some(signer) = lookup(*pooled_tx.tx_hash()) {
+            signer
+        } else {
+            pooled_tx
+                .recover_signer()
+                .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?
+        };
+
+        match pooled_tx {
+            PooledTransactionVariant::Legacy(_)
+            | PooledTransactionVariant::Eip2930(_)
+            | PooledTransactionVariant::Eip1559(_)
+            | PooledTransactionVariant::Eip7702(_) => {
+                let tx_signed = TransactionSigned::from(pooled_tx);
+                TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx_signed.with_signer(signer))
+            }
+            PooledTransactionVariant::Eip4844(blob_tx) => {
+                let (blob_tx, signature, hash) = blob_tx.into_parts();
+                let (blob_tx, sidecar) = blob_tx.into_parts();
+                let tx_signed = TransactionSigned::new_unchecked(
+                    Transaction::Eip4844(blob_tx),
+                    signature,
+                    hash,
+                );
+                Ok(TransactionSignedEcRecoveredWithBlobs {
+                    tx: tx_signed.with_signer(signer),
+                    blobs_sidecar: Arc::new(sidecar),
+                    metadata: Metadata::default(),
+                })
+            }
+        }
+    }
+
     /// Decodes the "raw" canonical format of transaction (NOT the one used in `eth_sendRawTransaction`) generating fake blob data for backtesting
     pub fn decode_enveloped_with_fake_blobs(
         raw_tx: Bytes,
@@ -920,6 +963,38 @@ impl TransactionSignedEcRecoveredWithBlobs {
             .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
         let tx = SignerRecoverable::try_into_recovered(decoded)
             .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?;
+        let mut fake_sidecar = BlobTransactionSidecar::default();
+        for _ in 0..tx.blob_versioned_hashes().map_or(0, |hashes| hashes.len()) {
+            fake_sidecar.blobs.push(Blob::from([0u8; BYTES_PER_BLOB]));
+            fake_sidecar
+                .commitments
+                .push(Bytes48::from([0u8; BYTES_PER_COMMITMENT]));
+            fake_sidecar
+                .proofs
+                .push(Bytes48::from([0u8; BYTES_PER_PROOF]));
+        }
+        Ok(TransactionSignedEcRecoveredWithBlobs {
+            tx,
+            blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(fake_sidecar)),
+            metadata: Metadata::default(),
+        })
+    }
+
+    /// Decodes the "raw" canonical format of transaction (NOT the one used in `eth_sendRawTransaction`) generating fake blob data for backtesting
+    pub fn decode_enveloped_with_fake_blobs_with_lookup(
+        raw_tx: Bytes,
+        lookup: impl Fn(B256) -> Option<Address>,
+    ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
+        let decoded = TransactionSigned::decode_2718(&mut raw_tx.as_ref())
+            .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
+
+        let tx = if let Some(signer) = lookup(*decoded.tx_hash()) {
+            Recovered::new_unchecked(decoded, signer)
+        } else {
+            SignerRecoverable::try_into_recovered(decoded)
+                .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?
+        };
+
         let mut fake_sidecar = BlobTransactionSidecar::default();
         for _ in 0..tx.blob_versioned_hashes().map_or(0, |hashes| hashes.len()) {
             fake_sidecar.blobs.push(Blob::from([0u8; BYTES_PER_BLOB]));

--- a/crates/rbuilder-primitives/src/lib.rs
+++ b/crates/rbuilder-primitives/src/lib.rs
@@ -1005,22 +1005,12 @@ impl<T: SignerLookup> RawTransactionDecodable<T> {
         let pooled_tx = PooledTransactionVariant::decode_2718(raw_tx)
             .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
 
-        let recover_signer = || {
-            pooled_tx
-                .recover_signer()
-                .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)
-        };
-
-        // TODO: clean this after rust 1.89 and if let chains
-        let signer = if let Some(ref lookup) = self.signer_lookup {
-            if let Some(signer) = lookup.lookup(*pooled_tx.tx_hash()) {
-                signer
-            } else {
-                recover_signer()?
-            }
-        } else {
-            recover_signer()?
-        };
+        let signer = self
+            .signer_lookup
+            .as_ref()
+            .and_then(|sl| sl.lookup(*pooled_tx.tx_hash()))
+            .or_else(|| pooled_tx.recover_signer().ok())
+            .ok_or(TxWithBlobsCreateError::InvalidTransactionSignature)?;
 
         Recovered::<PooledTransactionVariant>::new_unchecked(pooled_tx, signer).try_into()
     }
@@ -1034,19 +1024,14 @@ impl<T: SignerLookup> RawTransactionDecodable<T> {
 
         let hash = *decoded.hash();
 
-        // TODO: clean this after rust 1.89 and if let chains
-        let tx = if let Some(ref lookup) = self.signer_lookup {
-            if let Some(signer) = lookup.lookup(hash) {
-                Recovered::new_unchecked(decoded, signer)
-            } else {
-                SignerRecoverable::try_into_recovered(decoded)
-                    .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?
-            }
-        } else {
-            SignerRecoverable::try_into_recovered(decoded)
-                .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?
-        };
+        let signer = self
+            .signer_lookup
+            .as_ref()
+            .and_then(|sl| sl.lookup(hash))
+            .or_else(|| decoded.recover_signer().ok())
+            .ok_or(TxWithBlobsCreateError::InvalidTransactionSignature)?;
 
+        let tx = Recovered::new_unchecked(decoded, signer);
         let hashes_len = tx.blob_versioned_hashes().map_or(0, |hashes| hashes.len());
         let fake_sidecar = BlobTransactionSidecar::fake_sidecar(hashes_len);
 

--- a/crates/rbuilder-primitives/src/lib.rs
+++ b/crates/rbuilder-primitives/src/lib.rs
@@ -933,42 +933,25 @@ impl TransactionSignedEcRecoveredWithBlobs {
     }
 }
 
-/// Trait to lookup the signer of a tx by its hash.
-pub trait SignerLookup {
-    fn lookup(&self, tx_hash: B256) -> Option<Address>;
-}
-
-/// Default implementation that does nothing.
-pub struct NoOpSignerLookup;
-
-impl SignerLookup for NoOpSignerLookup {
-    fn lookup(&self, _tx_hash: B256) -> Option<Address> {
-        None
-    }
-}
-
-/// Allows using a closure as a [`SignerLookup`].
-impl<T: Fn(B256) -> Option<Address>> SignerLookup for T {
-    fn lookup(&self, tx_hash: B256) -> Option<Address> {
-        self(tx_hash)
-    }
-}
+/// Trait alias to lookup the signer of a tx by its hash.
+pub trait SignerLookup: Fn(B256) -> Option<Address> {}
+impl<T: Fn(B256) -> Option<Address>> SignerLookup for T {}
 
 /// Raw transaction bytes along with:
 /// - the encoding used (with or without blob data)
 /// - an optional signer lookup to avoid signature recovery when we already know the signer
-pub struct RawTransactionDecodable<T: SignerLookup = NoOpSignerLookup> {
+pub struct RawTransactionDecodable<T: SignerLookup> {
     pub raw: Bytes,
     pub encoding: TxEncoding,
     signer_lookup: Option<T>,
 }
 
-impl RawTransactionDecodable<NoOpSignerLookup> {
+impl RawTransactionDecodable<fn(B256) -> Option<Address>> {
     pub fn new(raw: Bytes, encoding: TxEncoding) -> Self {
         Self {
             raw,
             encoding,
-            signer_lookup: None,
+            signer_lookup: Option::<fn(B256) -> Option<Address>>::None,
         }
     }
 }
@@ -1008,7 +991,7 @@ impl<T: SignerLookup> RawTransactionDecodable<T> {
         let signer = self
             .signer_lookup
             .as_ref()
-            .and_then(|sl| sl.lookup(*pooled_tx.tx_hash()))
+            .and_then(|sl| sl(*pooled_tx.tx_hash()))
             .or_else(|| pooled_tx.recover_signer().ok())
             .ok_or(TxWithBlobsCreateError::InvalidTransactionSignature)?;
 
@@ -1027,7 +1010,7 @@ impl<T: SignerLookup> RawTransactionDecodable<T> {
         let signer = self
             .signer_lookup
             .as_ref()
-            .and_then(|sl| sl.lookup(hash))
+            .and_then(|sl| sl(hash))
             .or_else(|| decoded.recover_signer().ok())
             .ok_or(TxWithBlobsCreateError::InvalidTransactionSignature)?;
 

--- a/crates/rbuilder-primitives/src/lib.rs
+++ b/crates/rbuilder-primitives/src/lib.rs
@@ -40,6 +40,8 @@ pub use test_data_generator::TestDataGenerator;
 use thiserror::Error;
 use uuid::Uuid;
 
+use crate::serialize::TxEncoding;
+
 /// Extra metadata for an order.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Metadata {
@@ -167,7 +169,7 @@ pub struct BundleRefund {
     pub delayed: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BundleVersion {
     V1,
     V2,
@@ -670,6 +672,47 @@ impl ShareBundle {
     }
 }
 
+#[derive(Error, Debug, derive_more::From)]
+pub enum TxWithBlobsCreateError {
+    #[error("Failed to decode transaction, error: {0}")]
+    FailedToDecodeTransaction(Eip2718Error),
+    #[error("Invalid transaction signature")]
+    InvalidTransactionSignature,
+    #[error("UnexpectedError")]
+    UnexpectedError,
+    /// This error is generated when we fail (like FailedToDecodeTransaction) parsing in TxEncoding::WithBlobData mode (Network encoding) but the header looks
+    /// like the beginning of an ethereum mainnet Canonical encoding 4484 tx.
+    /// To avoid consuming resources the generation of this error might not be perfect but helps 99% of the time.
+    #[error("Failed to decode transaction, error: {0}. It probably is a 4484 canonical tx.")]
+    FailedToDecodeTransactionProbablyIs4484Canonical(alloy_rlp::Error),
+    #[error("Tried to create an EIP4844 transaction without a blob")]
+    Eip4844MissingBlobSidecar,
+    #[error("Tried to create a non-EIP4844 transaction while passing blobs")]
+    BlobsMissingEip4844,
+    #[error("BlobStoreError: {0}")]
+    BlobStore(BlobStoreError),
+}
+
+trait FakeSidecar {
+    fn fake_sidecar(blob_versioned_hashes_len: usize) -> BlobTransactionSidecar;
+}
+
+impl FakeSidecar for BlobTransactionSidecar {
+    fn fake_sidecar(blob_versioned_hashes_len: usize) -> BlobTransactionSidecar {
+        let mut fake_sidecar = BlobTransactionSidecar::default();
+        for _ in 0..blob_versioned_hashes_len {
+            fake_sidecar.blobs.push(Blob::from([0u8; BYTES_PER_BLOB]));
+            fake_sidecar
+                .commitments
+                .push(Bytes48::from([0u8; BYTES_PER_COMMITMENT]));
+            fake_sidecar
+                .proofs
+                .push(Bytes48::from([0u8; BYTES_PER_PROOF]));
+        }
+        fake_sidecar
+    }
+}
+
 /// First idea to handle blobs, might change.
 /// Don't like the fact that blobs_sidecar exists no matter if Recovered<TransactionSigned> contains a non blob tx.
 /// Great effort was put in avoiding simple access to the internal tx so we don't accidentally leak information on logs (particularly the tx sign).
@@ -721,25 +764,36 @@ impl std::fmt::Debug for TransactionSignedEcRecoveredWithBlobs {
     }
 }
 
-#[derive(Error, Debug, derive_more::From)]
-pub enum TxWithBlobsCreateError {
-    #[error("Failed to decode transaction, error: {0}")]
-    FailedToDecodeTransaction(Eip2718Error),
-    #[error("Invalid transaction signature")]
-    InvalidTransactionSignature,
-    #[error("UnexpectedError")]
-    UnexpectedError,
-    /// This error is generated when we fail (like FailedToDecodeTransaction) parsing in TxEncoding::WithBlobData mode (Network encoding) but the header looks
-    /// like the beginning of an ethereum mainnet Canonical encoding 4484 tx.
-    /// To avoid consuming resources the generation of this error might not be perfect but helps 99% of the time.
-    #[error("Failed to decode transaction, error: {0}. It probably is a 4484 canonical tx.")]
-    FailedToDecodeTransactionProbablyIs4484Canonical(alloy_rlp::Error),
-    #[error("Tried to create an EIP4844 transaction without a blob")]
-    Eip4844MissingBlobSidecar,
-    #[error("Tried to create a non-EIP4844 transaction while passing blobs")]
-    BlobsMissingEip4844,
-    #[error("BlobStoreError: {0}")]
-    BlobStore(BlobStoreError),
+impl TryFrom<Recovered<PooledTransactionVariant>> for TransactionSignedEcRecoveredWithBlobs {
+    type Error = TxWithBlobsCreateError;
+
+    fn try_from(value: Recovered<PooledTransactionVariant>) -> Result<Self, Self::Error> {
+        let (tx, signer) = value.into_parts();
+
+        match tx {
+            PooledTransactionVariant::Legacy(_)
+            | PooledTransactionVariant::Eip2930(_)
+            | PooledTransactionVariant::Eip1559(_)
+            | PooledTransactionVariant::Eip7702(_) => {
+                let tx_signed = TransactionSigned::from(tx);
+                TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx_signed.with_signer(signer))
+            }
+            PooledTransactionVariant::Eip4844(blob_tx) => {
+                let (blob_tx, signature, hash) = blob_tx.into_parts();
+                let (blob_tx, sidecar) = blob_tx.into_parts();
+                let tx_signed = TransactionSigned::new_unchecked(
+                    Transaction::Eip4844(blob_tx),
+                    signature,
+                    hash,
+                );
+                Ok(TransactionSignedEcRecoveredWithBlobs {
+                    tx: tx_signed.with_signer(signer),
+                    blobs_sidecar: Arc::new(sidecar),
+                    metadata: Metadata::default(),
+                })
+            }
+        }
+    }
 }
 
 impl TransactionSignedEcRecoveredWithBlobs {
@@ -877,134 +931,125 @@ impl TransactionSignedEcRecoveredWithBlobs {
         self.tx.encode_2718(&mut buf);
         buf.into()
     }
+}
 
-    /// Decodes the "raw" format of transaction (e.g. `eth_sendRawTransaction`) with the blob data (network format)
-    pub fn decode_enveloped_with_real_blobs(
-        raw_tx: Bytes,
+/// Trait to lookup the signer of a tx by its hash.
+pub trait SignerLookup {
+    fn lookup(&self, tx_hash: B256) -> Option<Address>;
+}
+
+/// Default implementation that does nothing.
+pub struct NoOpSignerLookup;
+
+impl SignerLookup for NoOpSignerLookup {
+    fn lookup(&self, _tx_hash: B256) -> Option<Address> {
+        None
+    }
+}
+
+/// Allows using a closure as a [`SignerLookup`].
+impl<T: Fn(B256) -> Option<Address>> SignerLookup for T {
+    fn lookup(&self, tx_hash: B256) -> Option<Address> {
+        self(tx_hash)
+    }
+}
+
+/// Raw transaction bytes along with:
+/// - the encoding used (with or without blob data)
+/// - an optional signer lookup to avoid signature recovery when we already know the signer
+pub struct RawTransactionDecodable<T: SignerLookup = NoOpSignerLookup> {
+    pub raw: Bytes,
+    pub encoding: TxEncoding,
+    signer_lookup: Option<T>,
+}
+
+impl RawTransactionDecodable<NoOpSignerLookup> {
+    pub fn new(raw: Bytes, encoding: TxEncoding) -> Self {
+        Self {
+            raw,
+            encoding,
+            signer_lookup: None,
+        }
+    }
+}
+
+impl<T: SignerLookup> RawTransactionDecodable<T> {
+    /// Allows to set a custom signer lookup.
+    pub fn with_signer_lookup<U: SignerLookup>(self, lookup: U) -> RawTransactionDecodable<U> {
+        RawTransactionDecodable {
+            raw: self.raw,
+            encoding: self.encoding,
+            signer_lookup: Some(lookup),
+        }
+    }
+
+    /// Decodes the raw transaction bytes into a [`TransactionSignedEcRecoveredWithBlobs`].
+    ///
+    /// If the encoding is `TxEncoding::WithBlobData`, the blob data is expected to be
+    /// present in the raw bytes. Otherwise, fake blob data is generated.
+    pub fn decode_enveloped(
+        &self,
     ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
-        let raw_tx = &mut raw_tx.as_ref();
-        let pooled_tx = PooledTransactionVariant::decode_2718(raw_tx)
-            .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
-        let signer = pooled_tx
-            .recover_signer()
-            .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?;
-        match pooled_tx {
-            PooledTransactionVariant::Legacy(_)
-            | PooledTransactionVariant::Eip2930(_)
-            | PooledTransactionVariant::Eip1559(_)
-            | PooledTransactionVariant::Eip7702(_) => {
-                let tx_signed = TransactionSigned::from(pooled_tx);
-                TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx_signed.with_signer(signer))
-            }
-            PooledTransactionVariant::Eip4844(blob_tx) => {
-                let (blob_tx, signature, hash) = blob_tx.into_parts();
-                let (blob_tx, sidecar) = blob_tx.into_parts();
-                let tx_signed = TransactionSigned::new_unchecked(
-                    Transaction::Eip4844(blob_tx),
-                    signature,
-                    hash,
-                );
-                Ok(TransactionSignedEcRecoveredWithBlobs {
-                    tx: tx_signed.with_signer(signer),
-                    blobs_sidecar: Arc::new(sidecar),
-                    metadata: Metadata::default(),
-                })
-            }
+        match self.encoding {
+            TxEncoding::WithBlobData => self.decode_enveloped_with_real_blobs(),
+            TxEncoding::NoBlobData => self.decode_enveloped_with_fake_blobs(),
         }
     }
 
     /// Decodes the "raw" format of transaction (e.g. `eth_sendRawTransaction`) with the blob data (network format)
-    pub fn decode_enveloped_with_real_blobs_with_lookup(
-        raw_tx: Bytes,
-        lookup: impl Fn(B256) -> Option<Address>,
+    fn decode_enveloped_with_real_blobs(
+        &self,
     ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
-        let raw_tx = &mut raw_tx.as_ref();
+        let raw_tx = &mut self.raw.as_ref();
+
         let pooled_tx = PooledTransactionVariant::decode_2718(raw_tx)
             .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
 
-        let signer = if let Some(signer) = lookup(*pooled_tx.tx_hash()) {
-            signer
-        } else {
+        let recover_signer = || {
             pooled_tx
                 .recover_signer()
-                .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?
+                .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)
         };
 
-        match pooled_tx {
-            PooledTransactionVariant::Legacy(_)
-            | PooledTransactionVariant::Eip2930(_)
-            | PooledTransactionVariant::Eip1559(_)
-            | PooledTransactionVariant::Eip7702(_) => {
-                let tx_signed = TransactionSigned::from(pooled_tx);
-                TransactionSignedEcRecoveredWithBlobs::new_no_blobs(tx_signed.with_signer(signer))
+        // TODO: clean this after rust 1.89 and if let chains
+        let signer = if let Some(ref lookup) = self.signer_lookup {
+            if let Some(signer) = lookup.lookup(*pooled_tx.tx_hash()) {
+                signer
+            } else {
+                recover_signer()?
             }
-            PooledTransactionVariant::Eip4844(blob_tx) => {
-                let (blob_tx, signature, hash) = blob_tx.into_parts();
-                let (blob_tx, sidecar) = blob_tx.into_parts();
-                let tx_signed = TransactionSigned::new_unchecked(
-                    Transaction::Eip4844(blob_tx),
-                    signature,
-                    hash,
-                );
-                Ok(TransactionSignedEcRecoveredWithBlobs {
-                    tx: tx_signed.with_signer(signer),
-                    blobs_sidecar: Arc::new(sidecar),
-                    metadata: Metadata::default(),
-                })
-            }
-        }
+        } else {
+            recover_signer()?
+        };
+
+        Recovered::<PooledTransactionVariant>::new_unchecked(pooled_tx, signer).try_into()
     }
 
     /// Decodes the "raw" canonical format of transaction (NOT the one used in `eth_sendRawTransaction`) generating fake blob data for backtesting
-    pub fn decode_enveloped_with_fake_blobs(
-        raw_tx: Bytes,
+    fn decode_enveloped_with_fake_blobs(
+        &self,
     ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
-        let decoded = TransactionSigned::decode_2718(&mut raw_tx.as_ref())
-            .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
-        let tx = SignerRecoverable::try_into_recovered(decoded)
-            .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?;
-        let mut fake_sidecar = BlobTransactionSidecar::default();
-        for _ in 0..tx.blob_versioned_hashes().map_or(0, |hashes| hashes.len()) {
-            fake_sidecar.blobs.push(Blob::from([0u8; BYTES_PER_BLOB]));
-            fake_sidecar
-                .commitments
-                .push(Bytes48::from([0u8; BYTES_PER_COMMITMENT]));
-            fake_sidecar
-                .proofs
-                .push(Bytes48::from([0u8; BYTES_PER_PROOF]));
-        }
-        Ok(TransactionSignedEcRecoveredWithBlobs {
-            tx,
-            blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(fake_sidecar)),
-            metadata: Metadata::default(),
-        })
-    }
-
-    /// Decodes the "raw" canonical format of transaction (NOT the one used in `eth_sendRawTransaction`) generating fake blob data for backtesting
-    pub fn decode_enveloped_with_fake_blobs_with_lookup(
-        raw_tx: Bytes,
-        lookup: impl Fn(B256) -> Option<Address>,
-    ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
-        let decoded = TransactionSigned::decode_2718(&mut raw_tx.as_ref())
+        let decoded = TransactionSigned::decode_2718(&mut self.raw.as_ref())
             .map_err(TxWithBlobsCreateError::FailedToDecodeTransaction)?;
 
-        let tx = if let Some(signer) = lookup(*decoded.tx_hash()) {
-            Recovered::new_unchecked(decoded, signer)
+        let hash = *decoded.hash();
+
+        // TODO: clean this after rust 1.89 and if let chains
+        let tx = if let Some(ref lookup) = self.signer_lookup {
+            if let Some(signer) = lookup.lookup(hash) {
+                Recovered::new_unchecked(decoded, signer)
+            } else {
+                SignerRecoverable::try_into_recovered(decoded)
+                    .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?
+            }
         } else {
             SignerRecoverable::try_into_recovered(decoded)
                 .map_err(|_| TxWithBlobsCreateError::InvalidTransactionSignature)?
         };
 
-        let mut fake_sidecar = BlobTransactionSidecar::default();
-        for _ in 0..tx.blob_versioned_hashes().map_or(0, |hashes| hashes.len()) {
-            fake_sidecar.blobs.push(Blob::from([0u8; BYTES_PER_BLOB]));
-            fake_sidecar
-                .commitments
-                .push(Bytes48::from([0u8; BYTES_PER_COMMITMENT]));
-            fake_sidecar
-                .proofs
-                .push(Bytes48::from([0u8; BYTES_PER_PROOF]));
-        }
+        let hashes_len = tx.blob_versioned_hashes().map_or(0, |hashes| hashes.len());
+        let fake_sidecar = BlobTransactionSidecar::fake_sidecar(hashes_len);
+
         Ok(TransactionSignedEcRecoveredWithBlobs {
             tx,
             blobs_sidecar: Arc::new(BlobTransactionSidecarVariant::Eip4844(fake_sidecar)),

--- a/crates/rbuilder-primitives/src/serialize.rs
+++ b/crates/rbuilder-primitives/src/serialize.rs
@@ -54,6 +54,36 @@ impl TxEncoding {
         }
     }
 
+    pub fn decode_with_lookup(
+        &self,
+        raw_tx: Bytes,
+        lookup: impl Fn(B256) -> Option<Address>,
+    ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
+        match self {
+            TxEncoding::NoBlobData => {
+                TransactionSignedEcRecoveredWithBlobs::decode_enveloped_with_fake_blobs_with_lookup(
+                    raw_tx, lookup,
+                )
+            }
+            TxEncoding::WithBlobData => {
+                let raw_tx_clone = raw_tx.clone(); // This clone is supposed to be cheap
+                let res =
+                    TransactionSignedEcRecoveredWithBlobs::decode_enveloped_with_real_blobs_with_lookup(raw_tx,lookup);
+                if let Err(TxWithBlobsCreateError::FailedToDecodeTransaction(
+                    Eip2718Error::RlpError(err),
+                )) = res
+                {
+                    if Self::looks_like_canonical_blob_tx(raw_tx_clone) {
+                        return Err(TxWithBlobsCreateError::FailedToDecodeTransactionProbablyIs4484Canonical(
+                            err,
+                        ));
+                    }
+                }
+                res
+            }
+        }
+    }
+
     fn looks_like_canonical_blob_tx(raw_tx: Bytes) -> bool {
         // For full check we could call TransactionSigned::decode_enveloped and fully try to decode it is way more expensive.
         // We expect EIP4844_TX_TYPE_ID + rlp(chainId = 01,.....)
@@ -214,6 +244,69 @@ impl RawBundle {
                 Err(RawBundleConvertError::FoundCancelExpectingBundle)
             }
         }
+    }
+    pub fn decode_with_lookup(
+        mut self,
+        encoding: TxEncoding,
+        lookup: &impl Fn(B256) -> Option<Address>,
+    ) -> Result<RawBundleDecodeResult, RawBundleConvertError> {
+        let replacement_data = Self::decode_replacement_data(
+            self.replacement_uuid,
+            self.uuid,
+            self.signing_address,
+            self.replacement_nonce,
+            self.first_seen_at,
+        )?;
+        // Check for cancellation
+        if self.txs.is_empty() {
+            match replacement_data {
+                Some(replacement_data) => {
+                    return Ok(RawBundleDecodeResult::CancelBundle(replacement_data))
+                }
+                None => return Err(RawBundleConvertError::EmptyBundle),
+            }
+        }
+        let version = Self::decode_version(self.version.clone())?;
+        self.validate_fields(version.clone())?;
+        let mut decoded = Vec::with_capacity(self.txs.len());
+        for (idx, tx) in self.txs.into_iter().enumerate() {
+            let res = encoding
+                .decode_with_lookup(tx, lookup)
+                .map_err(|e| RawBundleConvertError::FailedToDecodeTransaction(idx, e));
+            decoded.push(res?);
+        }
+        let txs = decoded;
+        let refund = Self::parse_refund(
+            self.refund_percent,
+            self.refund_recipient,
+            self.refund_tx_hashes,
+            self.delayed_refund,
+            &txs,
+        )?;
+
+        self.reverting_tx_hashes.sort();
+        self.dropping_tx_hashes.sort();
+
+        let block = self.block_number.unwrap_or_default().to();
+
+        let mut bundle = Bundle {
+            block: if block != 0 { Some(block) } else { None },
+            txs,
+            reverting_tx_hashes: self.reverting_tx_hashes,
+            hash: Default::default(),
+            uuid: Default::default(),
+            replacement_data,
+            // we assume that 0 timestamp is the same as timestamp not set
+            min_timestamp: self.min_timestamp,
+            max_timestamp: self.max_timestamp.filter(|t| *t != 0),
+            signer: self.signing_address,
+            metadata: Default::default(),
+            dropping_tx_hashes: self.dropping_tx_hashes,
+            refund,
+            version,
+        };
+        bundle.hash_slow();
+        Ok(RawBundleDecodeResult::NewBundle(bundle))
     }
 
     pub fn decode(

--- a/crates/rbuilder-primitives/src/serialize.rs
+++ b/crates/rbuilder-primitives/src/serialize.rs
@@ -1,9 +1,7 @@
-use crate::RawTransactionDecodable;
-
 use super::{
     Bundle, BundleRefund, BundleReplacementData, BundleReplacementKey, BundleVersion, MempoolTx,
-    Order, Refund, RefundConfig, ShareBundle, ShareBundleBody, ShareBundleInner,
-    ShareBundleReplacementData, ShareBundleReplacementKey, ShareBundleTx,
+    Order, RawTransactionDecodable, Refund, RefundConfig, ShareBundle, ShareBundleBody,
+    ShareBundleInner, ShareBundleReplacementData, ShareBundleReplacementKey, ShareBundleTx,
     TransactionSignedEcRecoveredWithBlobs, TxRevertBehavior, TxWithBlobsCreateError,
     LAST_BUNDLE_VERSION,
 };

--- a/crates/rbuilder-primitives/src/serialize.rs
+++ b/crates/rbuilder-primitives/src/serialize.rs
@@ -1,3 +1,5 @@
+use crate::RawTransactionDecodable;
+
 use super::{
     Bundle, BundleRefund, BundleReplacementData, BundleReplacementKey, BundleVersion, MempoolTx,
     Order, Refund, RefundConfig, ShareBundle, ShareBundleBody, ShareBundleInner,
@@ -18,6 +20,7 @@ use tracing::error;
 use uuid::Uuid;
 
 /// Encoding mode for raw transactions (https://eips.ethereum.org/EIPS/eip-4844)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TxEncoding {
     /// Canonical encoding, for 4844 is only tx_payload_body
     NoBlobData,
@@ -31,52 +34,20 @@ impl TxEncoding {
         &self,
         raw_tx: Bytes,
     ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
-        match self {
-            TxEncoding::NoBlobData => {
-                TransactionSignedEcRecoveredWithBlobs::decode_enveloped_with_fake_blobs(raw_tx)
-            }
-            TxEncoding::WithBlobData => {
-                let raw_tx_clone = raw_tx.clone(); // This clone is supposed to be cheap
-                let res =
-                    TransactionSignedEcRecoveredWithBlobs::decode_enveloped_with_real_blobs(raw_tx);
-                if let Err(TxWithBlobsCreateError::FailedToDecodeTransaction(
-                    Eip2718Error::RlpError(err),
-                )) = res
-                {
-                    if Self::looks_like_canonical_blob_tx(raw_tx_clone) {
-                        return Err(TxWithBlobsCreateError::FailedToDecodeTransactionProbablyIs4484Canonical(
-                            err,
-                        ));
-                    }
-                }
-                res
-            }
-        }
-    }
+        // This clone is supposed to be cheap
+        let res = RawTransactionDecodable::new(raw_tx.clone(), *self).decode_enveloped();
 
-    pub fn decode_with_lookup(
-        &self,
-        raw_tx: Bytes,
-        lookup: impl Fn(B256) -> Option<Address>,
-    ) -> Result<TransactionSignedEcRecoveredWithBlobs, TxWithBlobsCreateError> {
         match self {
-            TxEncoding::NoBlobData => {
-                TransactionSignedEcRecoveredWithBlobs::decode_enveloped_with_fake_blobs_with_lookup(
-                    raw_tx, lookup,
-                )
-            }
+            TxEncoding::NoBlobData => res,
             TxEncoding::WithBlobData => {
-                let raw_tx_clone = raw_tx.clone(); // This clone is supposed to be cheap
-                let res =
-                    TransactionSignedEcRecoveredWithBlobs::decode_enveloped_with_real_blobs_with_lookup(raw_tx,lookup);
                 if let Err(TxWithBlobsCreateError::FailedToDecodeTransaction(
                     Eip2718Error::RlpError(err),
                 )) = res
                 {
-                    if Self::looks_like_canonical_blob_tx(raw_tx_clone) {
+                    if Self::looks_like_canonical_blob_tx(raw_tx) {
                         return Err(TxWithBlobsCreateError::FailedToDecodeTransactionProbablyIs4484Canonical(
-                            err,
-                        ));
+                    err,
+                ));
                     }
                 }
                 res
@@ -121,33 +92,17 @@ where
     deserialize_vec_from_null_or_string(deserializer)
 }
 
-fn deserialize_vec_bytes_from_null_or_string<'de, D>(
-    deserializer: D,
-) -> Result<Vec<Bytes>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_vec_from_null_or_string(deserializer)
-}
-
-/// Struct to de/serialize json Bundles from bundles APIs and from/db.
-/// Does not assume a particular format on txs.
+/// Struct to de/serialize JSON bundles data from bundles APIs and from/db, except transactions.
+/// To be used long with `RawBundle<T>`.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, Derivative)]
 #[derivative(PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct RawBundle {
+pub struct RawBundleMetadata {
     pub version: Option<String>,
     /// blockNumber (Optional) `String`, a hex encoded block number for which this bundle is valid
     /// on. If nil or 0, blockNumber will default to the current pending block
     pub block_number: Option<U64>,
-    /// txs `Array[String]`, A list of signed transactions to execute in an atomic bundle, list can
-    /// be empty for bundle cancellations
-    #[serde(
-        default,
-        deserialize_with = "deserialize_vec_bytes_from_null_or_string"
-    )]
-    pub txs: Vec<Bytes>,
     /// revertingTxHashes (Optional) `Array[String]`, A list of tx hashes that are allowed to
     /// revert
     #[serde(default, deserialize_with = "deserialize_vec_b256_from_null_or_string")]
@@ -202,6 +157,112 @@ pub struct RawBundle {
     pub delayed_refund: Option<bool>,
 }
 
+impl RawBundleMetadata {
+    /// consistency checks on raw data.
+    /// uuid takes priority over replacement_nonce
+    fn decode_replacement_data(
+        &self,
+    ) -> Result<Option<BundleReplacementData>, RawBundleConvertError> {
+        let uuid = self.uuid.or(self.replacement_uuid);
+
+        match uuid {
+            Some(uuid) => {
+                let replacement_nonce = self
+                    .replacement_nonce
+                    .ok_or(RawBundleConvertError::IncorrectReplacementData)?;
+
+                let signer = self
+                    .signing_address
+                    .ok_or(RawBundleConvertError::IncorrectReplacementData)?;
+
+                Ok(Some(BundleReplacementData {
+                    key: BundleReplacementKey::new(uuid, Some(signer)),
+                    sequence_number: replacement_nonce,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn decode_version(&self) -> Result<BundleVersion, RawBundleConvertError> {
+        if let Some(version) = self.version.as_deref() {
+            match version {
+                BUNDLE_VERSION_V1 => Ok(BundleVersion::V1),
+                BUNDLE_VERSION_V2 => Ok(BundleVersion::V2),
+                _ => Err(RawBundleConvertError::UnsupportedVersion(
+                    version.to_string(),
+                )),
+            }
+        } else {
+            Ok(LAST_BUNDLE_VERSION)
+        }
+    }
+
+    /// Validates if all fields are valid for the version.
+    fn validate_fields(&self, version: BundleVersion) -> Result<(), RawBundleConvertError> {
+        match version {
+            BundleVersion::V1 => {
+                // Fields add on V2
+                if !self.dropping_tx_hashes.is_empty() {
+                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
+                        "dropping_tx_hashes".to_owned(),
+                        version,
+                    ));
+                }
+                if self.refund_percent.is_some() {
+                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
+                        "refund_percent".to_owned(),
+                        version,
+                    ));
+                }
+                if self.refund_recipient.is_some() {
+                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
+                        "refund_recipient".to_owned(),
+                        version,
+                    ));
+                }
+                if self.refund_tx_hashes.is_some() {
+                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
+                        "refund_tx_hashes".to_owned(),
+                        version,
+                    ));
+                }
+                if self.delayed_refund.is_some() {
+                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
+                        "delayed_refund".to_owned(),
+                        version,
+                    ));
+                }
+                Ok(())
+            }
+            BundleVersion::V2 => Ok(()),
+        }
+    }
+}
+
+/// Struct to de/serialize json Bundles from bundles APIs and from/db.
+/// Does not assume a particular format on txs.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, Derivative)]
+#[derivative(PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RawBundle {
+    #[serde(flatten)]
+    pub metadata: RawBundleMetadata,
+    /// txs `Array[String]`, A list of signed transactions to execute in an atomic bundle, list can
+    /// be empty for bundle cancellations.
+    #[serde(default, deserialize_with = "deserialize_vec_from_null_or_string")]
+    pub txs: Vec<Bytes>,
+}
+
+/// A [`RawBundle`] with transactions already decoded and recovered.
+struct RawBundleRecovered {
+    pub metadata: RawBundleMetadata,
+    /// txs `Array[String]`, A list of signed transactions to execute in an atomic bundle, list can
+    /// be empty for bundle cancellations.
+    pub txs: Vec<TransactionSignedEcRecoveredWithBlobs>,
+}
+
 #[derive(Error, Debug)]
 pub enum RawBundleConvertError {
     #[error("Failed to decode transaction, idx: {0}, error: {1}")]
@@ -245,81 +306,28 @@ impl RawBundle {
             }
         }
     }
-    pub fn decode_with_lookup(
-        mut self,
-        encoding: TxEncoding,
-        lookup: &impl Fn(B256) -> Option<Address>,
-    ) -> Result<RawBundleDecodeResult, RawBundleConvertError> {
-        let replacement_data = Self::decode_replacement_data(
-            self.replacement_uuid,
-            self.uuid,
-            self.signing_address,
-            self.replacement_nonce,
-            self.first_seen_at,
-        )?;
-        // Check for cancellation
-        if self.txs.is_empty() {
-            match replacement_data {
-                Some(replacement_data) => {
-                    return Ok(RawBundleDecodeResult::CancelBundle(replacement_data))
-                }
-                None => return Err(RawBundleConvertError::EmptyBundle),
-            }
-        }
-        let version = Self::decode_version(self.version.clone())?;
-        self.validate_fields(version.clone())?;
-        let mut decoded = Vec::with_capacity(self.txs.len());
-        for (idx, tx) in self.txs.into_iter().enumerate() {
-            let res = encoding
-                .decode_with_lookup(tx, lookup)
-                .map_err(|e| RawBundleConvertError::FailedToDecodeTransaction(idx, e));
-            decoded.push(res?);
-        }
-        let txs = decoded;
-        let refund = Self::parse_refund(
-            self.refund_percent,
-            self.refund_recipient,
-            self.refund_tx_hashes,
-            self.delayed_refund,
-            &txs,
-        )?;
-
-        self.reverting_tx_hashes.sort();
-        self.dropping_tx_hashes.sort();
-
-        let block = self.block_number.unwrap_or_default().to();
-
-        let mut bundle = Bundle {
-            block: if block != 0 { Some(block) } else { None },
-            txs,
-            reverting_tx_hashes: self.reverting_tx_hashes,
-            hash: Default::default(),
-            uuid: Default::default(),
-            replacement_data,
-            // we assume that 0 timestamp is the same as timestamp not set
-            min_timestamp: self.min_timestamp,
-            max_timestamp: self.max_timestamp.filter(|t| *t != 0),
-            signer: self.signing_address,
-            metadata: Default::default(),
-            dropping_tx_hashes: self.dropping_tx_hashes,
-            refund,
-            version,
-        };
-        bundle.hash_slow();
-        Ok(RawBundleDecodeResult::NewBundle(bundle))
-    }
 
     pub fn decode(
-        mut self,
+        self,
         encoding: TxEncoding,
     ) -> Result<RawBundleDecodeResult, RawBundleConvertError> {
-        let replacement_data = Self::decode_replacement_data(
-            self.replacement_uuid,
-            self.uuid,
-            self.signing_address,
-            self.replacement_nonce,
-        )?;
-        // Check for cancellation
+        self.decode_inner(encoding, Option::<fn(B256) -> Option<Address>>::None)
+    }
+
+    pub fn decode_with_signer_lookup(
+        self,
+        encoding: TxEncoding,
+        signer_lookup: impl Fn(B256) -> Option<Address>,
+    ) -> Result<RawBundleDecodeResult, RawBundleConvertError> {
+        self.decode_inner(encoding, Some(signer_lookup))
+    }
+
+    fn decode_inner(
+        mut self,
+        encoding: TxEncoding,
+        signer_lookup: Option<impl Fn(B256) -> Option<Address>>,
+    ) -> Result<RawBundleDecodeResult, RawBundleConvertError> {
+        let replacement_data = self.metadata.decode_replacement_data()?; // Check for cancellation
         if self.txs.is_empty() {
             match replacement_data {
                 Some(replacement_data) => {
@@ -328,162 +336,56 @@ impl RawBundle {
                 None => return Err(RawBundleConvertError::EmptyBundle),
             }
         }
-        let version = Self::decode_version(self.version.clone())?;
-        self.validate_fields(version.clone())?;
-        let txs = self
-            .txs
+        let version = self.metadata.decode_version()?;
+        self.metadata.validate_fields(version)?;
+
+        self.metadata.reverting_tx_hashes.sort();
+        self.metadata.dropping_tx_hashes.sort();
+
+        let recovered_txs = std::mem::take(&mut self.txs)
             .into_iter()
             .enumerate()
             .map(|(idx, tx)| {
-                encoding
-                    .decode(tx)
+                let decodable = RawTransactionDecodable {
+                    raw: tx,
+                    encoding,
+                    signer_lookup: signer_lookup.as_ref(),
+                };
+                decodable
+                    .decode_enveloped()
                     .map_err(|e| RawBundleConvertError::FailedToDecodeTransaction(idx, e))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let refund = Self::parse_refund(
-            self.refund_percent,
-            self.refund_recipient,
-            self.refund_tx_hashes,
-            self.delayed_refund,
-            &txs,
-        )?;
 
-        self.reverting_tx_hashes.sort();
-        self.dropping_tx_hashes.sort();
+        let mut recovered_bundle = self.into_recovered(recovered_txs);
 
-        let block = self.block_number.unwrap_or_default().to();
+        let refund = recovered_bundle.parse_refund()?;
+        let block = recovered_bundle
+            .metadata
+            .block_number
+            .unwrap_or_default()
+            .to();
 
+        let RawBundleRecovered { metadata, txs } = recovered_bundle;
         let mut bundle = Bundle {
             block: if block != 0 { Some(block) } else { None },
             txs,
-            reverting_tx_hashes: self.reverting_tx_hashes,
+            reverting_tx_hashes: metadata.reverting_tx_hashes,
             hash: Default::default(),
             uuid: Default::default(),
             replacement_data,
             // we assume that 0 timestamp is the same as timestamp not set
-            min_timestamp: self.min_timestamp,
-            max_timestamp: self.max_timestamp.filter(|t| *t != 0),
-            signer: self.signing_address,
-            refund_identity: self.refund_identity,
+            min_timestamp: metadata.min_timestamp,
+            max_timestamp: metadata.max_timestamp.filter(|t| *t != 0),
+            signer: metadata.signing_address,
+            refund_identity: metadata.refund_identity,
             metadata: Default::default(),
-            dropping_tx_hashes: self.dropping_tx_hashes,
+            dropping_tx_hashes: metadata.dropping_tx_hashes,
             refund,
             version,
         };
         bundle.hash_slow();
         Ok(RawBundleDecodeResult::NewBundle(bundle))
-    }
-
-    /// Validates if all fields are valid for the version.
-    fn validate_fields(&self, version: BundleVersion) -> Result<(), RawBundleConvertError> {
-        match version {
-            BundleVersion::V1 => {
-                // Fields add on V2
-                if !self.dropping_tx_hashes.is_empty() {
-                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
-                        "dropping_tx_hashes".to_owned(),
-                        version,
-                    ));
-                }
-                if self.refund_percent.is_some() {
-                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
-                        "refund_percent".to_owned(),
-                        version,
-                    ));
-                }
-                if self.refund_recipient.is_some() {
-                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
-                        "refund_recipient".to_owned(),
-                        version,
-                    ));
-                }
-                if self.refund_tx_hashes.is_some() {
-                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
-                        "refund_tx_hashes".to_owned(),
-                        version,
-                    ));
-                }
-                if self.delayed_refund.is_some() {
-                    return Err(RawBundleConvertError::FieldNotSupportedByVersion(
-                        "delayed_refund".to_owned(),
-                        version,
-                    ));
-                }
-                Ok(())
-            }
-            BundleVersion::V2 => Ok(()),
-        }
-    }
-
-    fn parse_refund(
-        mut refund_percent: Option<u8>,
-        refund_recipient: Option<Address>,
-        refund_tx_hashes: Option<Vec<TxHash>>,
-        delayed_refund: Option<bool>,
-        txs: &[TransactionSignedEcRecoveredWithBlobs],
-    ) -> Result<Option<BundleRefund>, RawBundleConvertError> {
-        // Validate refund percent setting.
-        if let Some(percent) = refund_percent {
-            if percent >= 100 {
-                return Err(RawBundleConvertError::InvalidRefundPercent(percent));
-            }
-            if percent == 0 {
-                refund_percent = None
-            }
-        }
-
-        let mut refund = None;
-        if let Some(percent) = refund_percent {
-            // Refund can be configured only if bundle is not empty.
-            // If bundle contains only one transaction, first == last.
-            // If refund_tx_hashes is empty we use the last tx.
-            if let Some((first_tx, last_tx)) = txs.first().zip(txs.last()) {
-                let tx_hash = if let Some(refund_tx_hashes) = refund_tx_hashes {
-                    if refund_tx_hashes.len() > 1 {
-                        return Err(RawBundleConvertError::MoreThanOneRefundTxHash);
-                    }
-                    refund_tx_hashes.first().copied()
-                } else {
-                    None
-                }
-                .unwrap_or(last_tx.hash());
-
-                refund = Some(BundleRefund {
-                    percent,
-                    recipient: refund_recipient.unwrap_or_else(|| first_tx.signer()),
-                    tx_hash,
-                    delayed: delayed_refund.unwrap_or_default(),
-                });
-            }
-        }
-        Ok(refund)
-    }
-
-    /// consistency checks on raw data.
-    /// uuid takes priority over replacement_nonce
-    fn decode_replacement_data(
-        replacement_uuid: Option<Uuid>,
-        mut uuid: Option<Uuid>,
-        signing_address: Option<Address>,
-        replacement_nonce: Option<u64>,
-    ) -> Result<Option<BundleReplacementData>, RawBundleConvertError> {
-        uuid = uuid.or(replacement_uuid);
-
-        match uuid {
-            Some(uuid) => {
-                let replacement_nonce =
-                    replacement_nonce.ok_or(RawBundleConvertError::IncorrectReplacementData)?;
-
-                let signer =
-                    signing_address.ok_or(RawBundleConvertError::IncorrectReplacementData)?;
-
-                Ok(Some(BundleReplacementData {
-                    key: BundleReplacementKey::new(uuid, Some(signer)),
-                    sequence_number: replacement_nonce,
-                }))
-            }
-            None => Ok(None),
-        }
     }
 
     /// See [TransactionSignedEcRecoveredWithBlobs::envelope_encoded_no_blobs]
@@ -497,38 +399,28 @@ impl RawBundle {
                 .and_then(|r| r.key.key().signer)
         });
         Self {
-            block_number: value.block.map(U64::from),
             txs: value
                 .txs
                 .into_iter()
                 .map(|tx| tx.envelope_encoded_no_blobs())
                 .collect(),
-            reverting_tx_hashes: value.reverting_tx_hashes,
-            dropping_tx_hashes: value.dropping_tx_hashes,
-            replacement_uuid,
-            uuid: replacement_uuid,
-            signing_address,
-            refund_identity: value.refund_identity,
-            min_timestamp: value.min_timestamp,
-            max_timestamp: value.max_timestamp,
-            replacement_nonce,
-            refund_percent: value.refund.as_ref().map(|br| br.percent),
-            refund_recipient: value.refund.as_ref().map(|br| br.recipient),
-            refund_tx_hashes: value.refund.as_ref().map(|br| vec![br.tx_hash]),
-            delayed_refund: value.refund.as_ref().map(|br| br.delayed),
-            version: Some(Self::encode_version(value.version)),
-        }
-    }
-
-    fn decode_version(version: Option<String>) -> Result<BundleVersion, RawBundleConvertError> {
-        if let Some(version) = version {
-            match version.as_str() {
-                BUNDLE_VERSION_V1 => Ok(BundleVersion::V1),
-                BUNDLE_VERSION_V2 => Ok(BundleVersion::V2),
-                _ => Err(RawBundleConvertError::UnsupportedVersion(version)),
-            }
-        } else {
-            Ok(LAST_BUNDLE_VERSION)
+            metadata: RawBundleMetadata {
+                block_number: value.block.map(U64::from),
+                reverting_tx_hashes: value.reverting_tx_hashes,
+                dropping_tx_hashes: value.dropping_tx_hashes,
+                replacement_uuid,
+                uuid: replacement_uuid,
+                signing_address,
+                refund_identity: value.refund_identity,
+                min_timestamp: value.min_timestamp,
+                max_timestamp: value.max_timestamp,
+                replacement_nonce,
+                refund_percent: value.refund.as_ref().map(|br| br.percent),
+                refund_recipient: value.refund.as_ref().map(|br| br.recipient),
+                refund_tx_hashes: value.refund.as_ref().map(|br| vec![br.tx_hash]),
+                delayed_refund: value.refund.as_ref().map(|br| br.delayed),
+                version: Some(Self::encode_version(value.version)),
+            },
         }
     }
 
@@ -537,6 +429,56 @@ impl RawBundle {
             BundleVersion::V1 => BUNDLE_VERSION_V1.to_string(),
             BundleVersion::V2 => BUNDLE_VERSION_V2.to_string(),
         }
+    }
+
+    fn into_recovered(self, txs: Vec<TransactionSignedEcRecoveredWithBlobs>) -> RawBundleRecovered {
+        RawBundleRecovered {
+            txs,
+            metadata: self.metadata,
+        }
+    }
+}
+
+impl RawBundleRecovered {
+    fn parse_refund(&mut self) -> Result<Option<BundleRefund>, RawBundleConvertError> {
+        // Validate refund percent setting.
+        if let Some(percent) = self.metadata.refund_percent {
+            if percent >= 100 {
+                return Err(RawBundleConvertError::InvalidRefundPercent(percent));
+            }
+            if percent == 0 {
+                self.metadata.refund_percent = None
+            }
+        }
+
+        let mut refund = None;
+        if let Some(percent) = self.metadata.refund_percent {
+            // Refund can be configured only if bundle is not empty.
+            // If bundle contains only one transaction, first == last.
+            // If refund_tx_hashes is empty we use the last tx.
+            if let Some((first_tx, last_tx)) = self.txs.first().zip(self.txs.last()) {
+                let tx_hash = if let Some(ref refund_tx_hashes) = self.metadata.refund_tx_hashes {
+                    if refund_tx_hashes.len() > 1 {
+                        return Err(RawBundleConvertError::MoreThanOneRefundTxHash);
+                    }
+                    refund_tx_hashes.first().copied()
+                } else {
+                    None
+                }
+                .unwrap_or(last_tx.hash());
+
+                refund = Some(BundleRefund {
+                    percent,
+                    recipient: self
+                        .metadata
+                        .refund_recipient
+                        .unwrap_or_else(|| first_tx.signer()),
+                    tx_hash,
+                    delayed: self.metadata.delayed_refund.unwrap_or_default(),
+                });
+            }
+        }
+        Ok(refund)
     }
 }
 

--- a/crates/rbuilder/src/backtest/backtest_build_range.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_range.rs
@@ -230,7 +230,10 @@ where
                 print_backtest_value_diff(&stored_result, &o);
             } else if cli.store_backtest {
                 backtest_results_storage
-                    .store_backtest_results(time::OffsetDateTime::now_utc(), &[o.clone()])
+                    .store_backtest_results(
+                        time::OffsetDateTime::now_utc(),
+                        std::slice::from_ref(&o),
+                    )
                     .await?;
                 print_backtest_value(o);
             } else {

--- a/crates/rbuilder/src/backtest/results_store.rs
+++ b/crates/rbuilder/src/backtest/results_store.rs
@@ -195,7 +195,7 @@ mod tests {
             .await
             .expect("create db");
         storage
-            .store_backtest_results(time, &[backtest_value.clone()])
+            .store_backtest_results(time, std::slice::from_ref(&backtest_value))
             .await
             .unwrap();
         let res = storage

--- a/crates/rbuilder/src/backtest/store.rs
+++ b/crates/rbuilder/src/backtest/store.rs
@@ -704,7 +704,7 @@ mod test {
     use alloy_primitives::{address, hex, Address, Signature, B256, U256, U64};
     use alloy_rpc_types::{Block, BlockTransactions, Header, Transaction};
     use rbuilder_primitives::{
-        serialize::{RawBundle, RawTx},
+        serialize::{RawBundle, RawBundleMetadata, RawTx},
         BundleReplacementKey, ShareBundleReplacementKey, LAST_BUNDLE_VERSION,
     };
     use reth_primitives::Recovered;
@@ -733,24 +733,26 @@ mod test {
             RawReplaceableOrderPoolCommandWithTimestamp {
                 timestamp_ms: 11,
                 command: RawReplaceableOrderPoolCommand::Order(RawOrder::Bundle(RawBundle {
-                    block_number: Some(U64::from(12)),
                     txs: vec![tx.clone().into()],
-                    reverting_tx_hashes: vec![],
-                    replacement_uuid: Some(uuid::Uuid::from_u128(11)),
-                    signing_address: Some(alloy_primitives::address!(
-                        "0101010101010101010101010101010101010101"
-                    )),
-                    min_timestamp: None,
-                    max_timestamp: Some(100),
-                    replacement_nonce: Some(0),
-                    dropping_tx_hashes: vec![],
-                    uuid: None,
-                    refund_percent: None,
-                    refund_recipient: None,
-                    refund_tx_hashes: None,
-                    delayed_refund: None,
-                    refund_identity: None,
-                    version: Some(RawBundle::encode_version(LAST_BUNDLE_VERSION)),
+                    metadata: RawBundleMetadata {
+                        block_number: Some(U64::from(12)),
+                        reverting_tx_hashes: vec![],
+                        replacement_uuid: Some(uuid::Uuid::from_u128(11)),
+                        signing_address: Some(alloy_primitives::address!(
+                            "0101010101010101010101010101010101010101"
+                        )),
+                        min_timestamp: None,
+                        max_timestamp: Some(100),
+                        replacement_nonce: Some(0),
+                        dropping_tx_hashes: vec![],
+                        uuid: None,
+                        refund_percent: None,
+                        refund_recipient: None,
+                        refund_tx_hashes: None,
+                        delayed_refund: None,
+                        refund_identity: None,
+                        version: Some(RawBundle::encode_version(LAST_BUNDLE_VERSION)),
+                    },
                 })),
             }
             .decode(TxEncoding::WithBlobData)

--- a/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
+++ b/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
@@ -3,7 +3,10 @@ use crate::telemetry::{add_txfetcher_time_to_query, mark_command_received};
 use alloy_primitives::FixedBytes;
 use alloy_provider::{IpcConnect, Provider, ProviderBuilder};
 use futures::StreamExt;
-use rbuilder_primitives::{MempoolTx, Order, TransactionSignedEcRecoveredWithBlobs};
+use rbuilder_primitives::{
+    serialize::TxEncoding, MempoolTx, Order, RawTransactionDecodable,
+    TransactionSignedEcRecoveredWithBlobs,
+};
 use std::{pin::pin, time::Instant};
 use time::OffsetDateTime;
 use tokio::{
@@ -105,9 +108,8 @@ async fn get_tx_with_blobs(
     let Some(response) = provider.get_raw_transaction_by_hash(tx_hash).await? else {
         return Ok(None);
     };
-    Ok(Some(
-        TransactionSignedEcRecoveredWithBlobs::decode_enveloped_with_real_blobs(response)?,
-    ))
+    let raw_decodable = RawTransactionDecodable::new(response, TxEncoding::WithBlobData);
+    Ok(Some(raw_decodable.decode_enveloped()?))
 }
 
 #[cfg(test)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "1.88.0"
+channel = "stable"
+version = "1.88.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## 📝 Summary

Modifies the `rbuilder-primitives` crate so that it is possible to decode bundles specifying a signer lookup, to save on signature recovery compute.

## 💡 Motivation and Context

Most bundles received contain transactions already heard, as such we can reduce a lot of compute from the hot path.

**Summary of the changes**:
- `RawBundle` now feature a `decode_with_signer_lookup` that allows to specify a closure to check whether the signer is already known for a certain hash.
	- It calls an underlying `RawBundle::decode_inner` that takes this the closure as an `Option`.
- Inside `RawBundle::decode_inner`, an helper struct `RawTransactionDecodable` (naming can be improved) that contains the raw bytes, the `TxEncoding` and the optional signer lookup is used for decoding. Transaction decoding and recovering can't really be decoupled from bundle decoding because it's required for parsing refunds data.
- A `RawBundleMetadata` struct has been introduced to simplify a bit the code and for separation of concerns.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
