### PR TITLE
eth-sparse-mpt fix empty proofs, improve unchanged accounts proofs

### DIFF
--- a/crates/eth-sparse-mpt/src/v2/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/mod.rs
@@ -1030,7 +1030,7 @@ impl RootHashCalculator {
                 stats.start();
                 self.fetch_missing_account_trie_nodes(&consistent_db_view, &mut stats)?;
                 stats.measure_proof_fetch(false);
-                // if we needed to fetch some proofs we need to rehash trie
+                // if we fetched proofs we need to rehash account trie
                 stats.start();
                 self.account_trie
                     .trie

--- a/crates/eth-sparse-mpt/src/v2/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/mod.rs
@@ -881,7 +881,9 @@ impl RootHashCalculator {
                         .proof_result
                         .push((account_trie.proof_account_keys[i], proof));
                 }
-                Err(ProofError::TrieIsDirty) => panic!("Trie is not hashed before fetching proofs"),
+                Err(ProofError::TrieIsDirty) => {
+                    eyre::bail!("Trie is not hashed before fetching proofs")
+                }
                 Err(ProofError::NodeNotFound(NodeNotFound(missing_node))) => {
                     account_trie.missing_nodes.push(missing_node);
                 }
@@ -1030,7 +1032,12 @@ impl RootHashCalculator {
                 stats.measure_proof_fetch(false);
                 // if we needed to fetch some proofs we need to rehash trie
                 stats.start();
-                self.hash_account_trie(&shared_cache);
+                self.account_trie
+                    .trie
+                    .root_hash(true, &shared_cache.account_trie)
+                    .map_err(|err| {
+                        eyre::eyre!("failed to hash account trie (account proofs) {err:?}")
+                    })?;
                 stats.measure_other();
                 continue;
             }

--- a/crates/eth-sparse-mpt/src/v2/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/mod.rs
@@ -12,7 +12,10 @@ use revm::{
 };
 use rustc_hash::FxBuildHasher;
 use std::{ops::Range, sync::Arc, time::Instant};
-use trie::{proof_store::ProofStore, DeletionError, InsertValue, NodeNotFound, Trie};
+use trie::{
+    proof_store::ProofStore, DeletionError, InsertValue, NodeNotFound, ProofError, ProofWithValue,
+    Trie,
+};
 
 use crate::{
     utils::{HashMap, HashSet},
@@ -110,6 +113,11 @@ struct AccountTrieCalculator {
     delete_account_keys: Vec<Address>,
     delete_ok: Vec<bool>,
 
+    proof_keys: Vec<Nibbles>,
+    proof_account_keys: Vec<Address>,
+    proof_ok: Vec<bool>,
+    proof_result: Vec<(Address, Vec<(Nibbles, Vec<u8>)>)>,
+
     missing_nodes: Vec<Nibbles>,
     missing_nodes_requested: Vec<Nibbles>,
 
@@ -131,6 +139,11 @@ impl AccountTrieCalculator {
         self.delete_account_keys.clear();
         self.delete_ok.clear();
         self.missing_nodes.clear();
+
+        self.proof_keys.clear();
+        self.proof_account_keys.clear();
+        self.proof_ok.clear();
+        self.proof_result.clear();
         // self.trie.clear();
     }
 }
@@ -367,11 +380,7 @@ impl RootHashCalculator {
         }
     }
 
-    fn prepare_changes_for_storage_trie(
-        &mut self,
-        outcome: &BundleState,
-        proof_targets: &HashSet<Address>,
-    ) -> eyre::Result<()> {
+    fn prepare_changes_for_storage_trie(&mut self, outcome: &BundleState) -> eyre::Result<()> {
         self.changed_account.write().clear();
 
         let incremental_change = !self.incremental_account_change.is_empty();
@@ -390,8 +399,7 @@ impl RootHashCalculator {
                 .map(|(a, acc)| (*a, acc))
                 .par_bridge()
                 .for_each(|(address, bundle_account)| {
-                    if bundle_account.status.is_not_modified() && !proof_targets.contains(&address)
-                    {
+                    if bundle_account.status.is_not_modified() {
                         return;
                     }
                     self.prepare_changes_for_one_storage_trie(address, bundle_account)
@@ -681,7 +689,7 @@ impl RootHashCalculator {
             });
     }
 
-    fn prepare_changes_account_trie(&mut self) {
+    fn prepare_changes_account_trie(&mut self, proof_targets: &HashSet<Address>) {
         self.account_trie.clear();
 
         for (address, _) in &*self.changed_account.read() {
@@ -744,6 +752,15 @@ impl RootHashCalculator {
                 self.account_trie.revert_account_ops.push(applied_op);
                 self.account_trie.revert_account_ops_done.push(false);
             }
+        }
+
+        for address in proof_targets {
+            let storage_calc = self.get_account_storage(address);
+            let storage_calc = storage_calc.lock();
+            let key = storage_calc.unpacked_hashed_address.clone();
+            self.account_trie.proof_keys.push(key);
+            self.account_trie.proof_account_keys.push(*address);
+            self.account_trie.proof_ok.push(false);
         }
     }
 
@@ -847,6 +864,32 @@ impl RootHashCalculator {
         Ok(account_trie.missing_nodes.is_empty())
     }
 
+    fn process_account_trie_proofs(&mut self, shared_cache: &SharedCacheV2) -> eyre::Result<bool> {
+        let account_trie = &mut self.account_trie;
+        account_trie.missing_nodes.clear();
+        for i in 0..account_trie.proof_ok.len() {
+            if account_trie.proof_ok[i] {
+                continue;
+            }
+            let proof_result = account_trie
+                .trie
+                .get_proof_nibbles_key(&account_trie.proof_keys[i], &shared_cache.account_trie);
+            match proof_result {
+                Ok(ProofWithValue { proof, .. }) => {
+                    account_trie.proof_ok[i] = true;
+                    account_trie
+                        .proof_result
+                        .push((account_trie.proof_account_keys[i], proof));
+                }
+                Err(ProofError::TrieIsDirty) => panic!("Trie is not hashed before fetching proofs"),
+                Err(ProofError::NodeNotFound(NodeNotFound(missing_node))) => {
+                    account_trie.missing_nodes.push(missing_node);
+                }
+            }
+        }
+        Ok(account_trie.missing_nodes.is_empty())
+    }
+
     fn fetch_missing_account_trie_nodes<Provider>(
         &mut self,
         consistent_db_view: &ConsistentDbView<Provider>,
@@ -927,7 +970,7 @@ impl RootHashCalculator {
         self.shared_cache = shared_cache.clone();
 
         stats.start();
-        self.prepare_changes_for_storage_trie(outcome, proof_targets)?;
+        self.prepare_changes_for_storage_trie(outcome)?;
         stats.measure_prepare(true);
         if self.incremental_account_change.is_empty() {
             self.do_first_fetch(&consistent_db_view, &mut stats)?;
@@ -953,7 +996,7 @@ impl RootHashCalculator {
         assert!(loop_break, "storage trie are not processed after 10 iters");
 
         stats.start();
-        self.prepare_changes_account_trie();
+        self.prepare_changes_account_trie(proof_targets);
         stats.measure_prepare(false);
 
         let mut loop_break = false;
@@ -976,15 +1019,42 @@ impl RootHashCalculator {
         }
         assert!(loop_break, "account trie are not processed after 10 iters");
 
+        let mut loop_break = false;
+        for _ in 0..10 {
+            stats.start();
+            let ok = self.process_account_trie_proofs(&shared_cache)?;
+            stats.measure_other();
+            if !ok {
+                stats.start();
+                self.fetch_missing_account_trie_nodes(&consistent_db_view, &mut stats)?;
+                stats.measure_proof_fetch(false);
+                // if we needed to fetch some proofs we need to rehash trie
+                stats.start();
+                self.hash_account_trie(&shared_cache);
+                stats.measure_other();
+                continue;
+            }
+            loop_break = true;
+            break;
+        }
+        assert!(
+            loop_break,
+            "account trie proofs are not processed after 10 iters"
+        );
+
         let mut proofs = HashMap::default();
+        for (address, proof) in self.account_trie.proof_result.drain(..) {
+            proofs.insert(
+                address,
+                proof.into_iter().map(|(_, node)| node.into()).collect(),
+            );
+        }
         for proof_target in proof_targets {
-            let nibbles = Nibbles::unpack(keccak256(proof_target));
-            let proof = self
-                .account_trie
-                .trie
-                .proof(&nibbles, &shared_cache.account_trie)
-                .map_err(|err| SparseTrieError::Other(err.into()))?;
-            proofs.insert(*proof_target, proof);
+            if !proofs.contains_key(proof_target) {
+                return Err(SparseTrieError::Other(eyre::eyre!(
+                    "Proof was not fethed correctly"
+                )));
+            }
         }
 
         let mut metrics = SparseTrieMetrics::default();

--- a/crates/eth-sparse-mpt/src/v2/trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/mod.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use alloy_primitives::{keccak256, Bytes, B256};
+use alloy_primitives::{keccak256, B256};
 use alloy_rlp::EMPTY_STRING_CODE;
 use arrayvec::ArrayVec;
 
@@ -938,14 +938,6 @@ impl Trie {
         }
 
         Ok(result)
-    }
-
-    pub fn proof(
-        &self,
-        _target_key: &Nibbles,
-        _proof_store: &ProofStore,
-    ) -> Result<Vec<Bytes>, ProofError> {
-        unimplemented!()
     }
 
     pub fn debug_print_node(&self, node_idx: usize) {

--- a/crates/eth-sparse-mpt/src/v2/trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/mod.rs
@@ -1068,6 +1068,7 @@ impl Trie {
                 .nodes
                 .get(current_node)
                 .ok_or_else(|| NodeNotFound::new(&path[..path_walked]))?;
+            self.hashed_nodes[current_node] = false;
             match node {
                 DiffTrieNode::Branch { children } => {
                     let children = *children;

--- a/crates/eth-sparse-mpt/src/v2/trie/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/mod.rs
@@ -86,8 +86,6 @@ pub enum ProofError {
     NodeNotFound(#[from] NodeNotFound),
     #[error("Trie is dirty")]
     TrieIsDirty,
-    #[error("Key node not found in the trie")]
-    KeyNotFound,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -104,6 +102,12 @@ impl NodeNotFound {
 pub enum InsertValue<'a> {
     Value(&'a [u8]),
     StoredValue(Range<usize>),
+}
+
+#[derive(Debug, Clone)]
+pub struct ProofWithValue {
+    pub proof: Vec<(Nibbles, Vec<u8>)>,
+    pub value: Option<Vec<u8>>,
 }
 
 impl Trie {
@@ -848,14 +852,26 @@ impl Trie {
         }
     }
 
+    pub fn get_proof(
+        &self,
+        key: &[u8],
+        proof_store: &ProofStore,
+    ) -> Result<ProofWithValue, ProofError> {
+        let n = Nibbles::unpack(key);
+        self.get_proof_nibbles_key(&n, proof_store)
+    }
+
     /// Generate proof for the target key.
-    pub fn proof(
+    pub fn get_proof_nibbles_key(
         &self,
         target_key: &Nibbles,
         proof_store: &ProofStore,
-    ) -> Result<Vec<Bytes>, ProofError> {
+    ) -> Result<ProofWithValue, ProofError> {
         let mut buf = Vec::new();
-        let mut proof = Vec::new();
+        let mut result = ProofWithValue {
+            proof: Vec::new(),
+            value: None,
+        };
 
         let mut current_node = 0;
         let mut path_walked = 0;
@@ -870,17 +886,20 @@ impl Trie {
                 return Err(ProofError::TrieIsDirty);
             }
 
+            self.rlp_encode_node(current_node, &mut buf, proof_store);
+            let current_node_path =
+                Nibbles::from_nibbles_unchecked(&target_key.as_slice()[..path_walked]);
+            result.proof.push((current_node_path, buf.clone()));
+
             match node {
                 DiffTrieNode::Branch { children } => {
                     if target_key.len() == path_walked {
-                        return Err(ProofError::KeyNotFound);
+                        break;
                     }
 
                     let children = *children;
 
                     let n = target_key[path_walked];
-                    self.rlp_encode_node(current_node, &mut buf, proof_store);
-                    proof.push(Bytes::copy_from_slice(&buf));
                     path_walked += 1;
 
                     if let Some(child_ptr) = self.branch_node_children[children][n as usize] {
@@ -890,15 +909,13 @@ impl Trie {
                         continue;
                     }
 
-                    return Err(ProofError::KeyNotFound);
+                    break;
                 }
                 DiffTrieNode::Extension { key, next_node } => {
                     let key = key.clone();
                     let next_node = *next_node;
 
                     if target_key[path_walked..].starts_with(&self.keys[key.clone()]) {
-                        self.rlp_encode_node(current_node, &mut buf, proof_store);
-                        proof.push(Bytes::copy_from_slice(&buf));
                         path_walked += key.len();
                         current_node = next_node
                             .as_local()
@@ -906,23 +923,29 @@ impl Trie {
                         continue;
                     }
 
-                    return Err(ProofError::KeyNotFound);
+                    break;
                 }
-                DiffTrieNode::Leaf { key, .. } => {
+                DiffTrieNode::Leaf { key, value } => {
                     if self.keys[key.clone()] == target_key[path_walked..] {
-                        self.rlp_encode_node(current_node, &mut buf, proof_store);
-                        proof.push(Bytes::copy_from_slice(&buf));
-                        break;
+                        result.value = Some(self.values[value.clone()].to_vec());
                     }
-                    return Err(ProofError::KeyNotFound);
+                    break;
                 }
                 DiffTrieNode::Null => {
-                    return Err(ProofError::KeyNotFound);
+                    break;
                 }
             }
         }
 
-        Ok(proof)
+        Ok(result)
+    }
+
+    pub fn proof(
+        &self,
+        _target_key: &Nibbles,
+        _proof_store: &ProofStore,
+    ) -> Result<Vec<Bytes>, ProofError> {
+        unimplemented!()
     }
 
     pub fn debug_print_node(&self, node_idx: usize) {

--- a/crates/eth-sparse-mpt/src/v2/trie/proof_store.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/proof_store.rs
@@ -1,4 +1,3 @@
-use alloy_primitives::Bytes;
 use alloy_rlp::Decodable;
 use parking_lot::{lock_api::RwLockReadGuard, RawRwLock, RwLock};
 use std::sync::Arc;
@@ -52,10 +51,10 @@ impl ProofStore {
         self.proofs.contains_key(key)
     }
 
-    pub fn add_proof(
+    pub fn add_proof<P: AsRef<[u8]>>(
         &self,
         key: Nibbles,
-        proof: Vec<(Nibbles, Bytes)>,
+        proof: Vec<(Nibbles, P)>,
     ) -> Result<(), alloy_rlp::Error> {
         if self.proofs.contains_key(&key) {
             return Ok(());

--- a/crates/eth-sparse-mpt/src/v2/trie/tests.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/tests.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{collections::HashMap, env};
 
 use super::*;
 use crate::{test_utils::reference_trie_hash_vec, utils::HashSet};
@@ -6,19 +6,30 @@ use proptest::prelude::*;
 
 fn compare_impls(data: &[(Vec<u8>, Vec<u8>)]) {
     let mut trie = Trie::new_empty();
+    let empty_proof_store = ProofStore::default();
     for (key, value) in data {
         trie.insert(key, value).unwrap();
     }
-    let got_hash = trie.root_hash(false, &ProofStore::default()).unwrap();
+    let got_hash = trie.root_hash(false, &empty_proof_store).unwrap();
+
     if std::env::var("ETH_SPARSE_MPT_TEST_PRINT").is_ok() {
         trie.debug_print_node(0);
     }
     let expected_hash = reference_trie_hash_vec(data);
     assert_eq!(expected_hash, got_hash);
+
+    for (key, expected_value) in calculate_final_trie_values(data, &[]) {
+        let ProofWithValue { proof, value } = trie
+            .get_proof(&key, &empty_proof_store)
+            .expect("failed to get proof");
+        assert_eq!(expected_value, value, "proof value mismatch");
+        let proof_hash = verify_proof(&key, proof);
+        assert_eq!(got_hash, proof_hash);
+    }
 }
 
 fn compare_with_removals(data: &[(Vec<u8>, Vec<u8>)], remove: &[Vec<u8>]) -> eyre::Result<()> {
-    let proof_store = ProofStore::default();
+    let empty_proof_store = ProofStore::default();
     let mut trie = Trie::new_empty();
     for (key, value) in data {
         trie.insert(key, value)?;
@@ -32,7 +43,7 @@ fn compare_with_removals(data: &[(Vec<u8>, Vec<u8>)], remove: &[Vec<u8>]) -> eyr
     for key in remove {
         trie.delete(key)?;
     }
-    let got_hash = trie.root_hash(false, &proof_store).unwrap();
+    let got_hash = trie.root_hash(false, &empty_proof_store).unwrap();
     if env::var("ETH_SPARSE_MPT_TEST_PRINT").is_ok() {
         println!("Trie after deletes");
         trie.debug_print_node(0);
@@ -52,13 +63,55 @@ fn compare_with_removals(data: &[(Vec<u8>, Vec<u8>)], remove: &[Vec<u8>]) -> eyr
         for (key, value) in &filtered_data {
             trie.insert(key, value).unwrap();
         }
-        trie.root_hash(false, &proof_store).unwrap();
+        trie.root_hash(false, &empty_proof_store).unwrap();
         trie.debug_print_node(0);
         println!();
     }
     let expected_hash = reference_trie_hash_vec(&filtered_data);
     assert_eq!(expected_hash, got_hash);
+
+    for (key, expected_value) in calculate_final_trie_values(data, remove) {
+        let ProofWithValue { proof, value } = trie
+            .get_proof(&key, &empty_proof_store)
+            .expect("failed to get proof");
+        assert_eq!(expected_value, value, "proof value mismatch");
+        let proof_hash = verify_proof(&key, proof);
+        assert_eq!(got_hash, proof_hash);
+    }
+
     Ok(())
+}
+
+// resolves multiple inserts and removals
+fn calculate_final_trie_values(
+    data: &[(Vec<u8>, Vec<u8>)],
+    remove: &[Vec<u8>],
+) -> Vec<(Vec<u8>, Option<Vec<u8>>)> {
+    let mut result: HashMap<Vec<u8>, Option<Vec<u8>>> = HashMap::default();
+    for (key, value) in data {
+        result.insert(key.clone(), Some(value.clone()));
+    }
+    for key in remove {
+        result.insert(key.clone(), None);
+    }
+    let mut result: Vec<_> = result.into_iter().collect();
+    result.sort_by_key(|(k, _)| k.clone());
+    result
+}
+
+fn verify_proof(key: &[u8], proof: Vec<(Nibbles, Vec<u8>)>) -> B256 {
+    let nibble_key = Nibbles::unpack(key);
+    let proof_store = ProofStore::default();
+    proof_store
+        .add_proof(nibble_key.clone(), proof)
+        .expect("failed to add proof to proof store");
+    let mut trie = Trie::default();
+    let found = trie
+        .try_add_proof_from_proof_store(&nibble_key, &proof_store)
+        .expect("failed to add proof to the trie");
+    assert!(found, "proof was not found in proof store");
+    trie.root_hash(false, &proof_store)
+        .expect("failed to calc root hash from proof")
 }
 
 #[test]
@@ -69,7 +122,7 @@ fn do_empty_trie() {
 #[test]
 fn do_one_element_trie() {
     let data = [(vec![1, 1], vec![0xa, 0xa])];
-    compare_impls(&data)
+    compare_impls(&data);
 }
 
 #[test]

--- a/crates/eth-sparse-mpt/src/v2/trie/tests.rs
+++ b/crates/eth-sparse-mpt/src/v2/trie/tests.rs
@@ -116,7 +116,7 @@ fn verify_proof(key: &[u8], proof: Vec<(Nibbles, Vec<u8>)>) -> B256 {
 
 #[test]
 fn do_empty_trie() {
-    compare_impls(&[])
+    compare_impls(&[]);
 }
 
 #[test]
@@ -473,7 +473,7 @@ proptest! {
             }
             (k.to_vec(), v)
         }).collect();
-        compare_with_removals(&data, &keys_to_remove).unwrap()
+        compare_with_removals(&data, &keys_to_remove).unwrap();
     }
 
     #[test]

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -3,6 +3,7 @@
 //! It downloads block after the last one synced and re-executes all the txs in it.
 use alloy_consensus::TxEnvelope;
 use alloy_eips::Decodable2718;
+use alloy_primitives::address;
 use alloy_provider::Provider;
 use clap::Parser;
 use eyre::Context;
@@ -111,7 +112,14 @@ async fn main() -> eyre::Result<()> {
     let mut build_times_ms = Vec::new();
     let mut finalize_time_ms = Vec::new();
     for _ in 0..cli.iters {
-        let ctx = ctx.clone();
+        let mut ctx = ctx.clone();
+        // add one random empty account and real adjusted fee payer to hit a code path for creating bid adjustment data in finalization
+        ctx.adjustment_fee_payers = [
+            address!("a41772428931BE72C28011f114A15B4211DFdfE5"),
+            address!("59CadF9199248b50d40a6891c9E329eA13a88d31"),
+        ]
+        .into_iter()
+        .collect();
         let txs = txs.clone();
         let state_provider = state_provider.clone();
         let (build_time, finalize_time) =

--- a/crates/rbuilder/src/building/bid_adjustments.rs
+++ b/crates/rbuilder/src/building/bid_adjustments.rs
@@ -4,15 +4,13 @@ use rbuilder_primitives::mev_boost::{
     ssz_roots::{tx_ssz_leaf_root, CompactSszTransactionTree},
     BidAdjustmentStateProofs,
 };
-use reth::revm::database::StateProviderDatabase;
 use reth_primitives::TransactionSigned;
-use revm::{database::BundleAccount, Database as _};
-use std::collections::{hash_map, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use tracing::*;
 
 use crate::building::{
-    cached_reads::CachedDB, BlockBuildingContext, BlockState, FinalizeError,
-    ThreadBlockBuildingContext, TransactionSszLeafRootCache,
+    BlockBuildingContext, BlockState, FinalizeError, ThreadBlockBuildingContext,
+    TransactionSszLeafRootCache,
 };
 
 /// Generate bid adjustment state proofs.
@@ -34,29 +32,6 @@ pub fn generate_bid_adjustment_state_proofs(
             .into_iter()
             .chain(ctx.adjustment_fee_payers.clone()),
     );
-
-    // Pre-load all proof targets that are missing from the bundle state.
-    // This is a requirement for accounts to become a part of the trie and be able to generate proofs for them.
-    let mut cachedb = CachedDB::new(
-        StateProviderDatabase::new(block_state.state_provider()),
-        &mut local_ctx.cached_reads,
-        &ctx.shared_cached_reads,
-    );
-    for fee_payer in &ctx.adjustment_fee_payers {
-        if let hash_map::Entry::Vacant(entry) =
-            block_state.bundle_state_mut().state.entry(*fee_payer)
-        {
-            let account_info = cachedb
-                .basic(*fee_payer)
-                .map_err(|error| FinalizeError::Other(error.into()))?;
-            entry.insert(BundleAccount {
-                original_info: account_info.clone(),
-                info: account_info,
-                status: revm::database::AccountStatus::Loaded,
-                storage: Default::default(),
-            });
-        }
-    }
 
     let mut account_proofs =
         ctx.root_hasher

--- a/crates/rbuilder/src/utils/receipts.rs
+++ b/crates/rbuilder/src/utils/receipts.rs
@@ -142,7 +142,14 @@ fn calculate_receipts_root_and_placeholder_proof_with_cache(
 
     let target_idx = receipts.len().checked_sub(1).unwrap();
     let nibbles = Nibbles::unpack(alloy_rlp::encode_fixed_size(&target_idx));
-    let proof = trie.proof(&nibbles, &cache.empty_proof_store).unwrap();
+    let proof_with_value = trie
+        .get_proof_nibbles_key(&nibbles, &cache.empty_proof_store)
+        .unwrap();
+    let proof = proof_with_value
+        .proof
+        .into_iter()
+        .map(|(_, n)| n.into())
+        .collect();
 
     (root, proof)
 }
@@ -217,7 +224,14 @@ fn calculate_tx_root_and_placeholder_proof_with_cache(
 
     let target_idx = executed_tx_infos.len().checked_sub(1).unwrap();
     let nibbles = Nibbles::unpack(alloy_rlp::encode_fixed_size(&target_idx));
-    let proof = trie.proof(&nibbles, &cache.empty_proof_store).unwrap();
+    let proof_with_value = trie
+        .get_proof_nibbles_key(&nibbles, &cache.empty_proof_store)
+        .unwrap();
+    let proof = proof_with_value
+        .proof
+        .into_iter()
+        .map(|(_, n)| n.into())
+        .collect();
 
     (root, proof)
 }


### PR DESCRIPTION
## 📝 Summary

Fix proofs in eth-sparse-mpt so that empty accounts are handled correctly and you don't need to calculate changes for the storage trie for account that you don't change in the block.

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
