### PR TITLE
redistribution: make order filtering more generic

### DIFF
--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -2,7 +2,7 @@
 //! This code has lots of copy/paste from the example config but it's not really copy/paste since we use our own private types.
 //! @Pending make this copy/paste generic code on the library
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::U256;
 use alloy_signer_local::PrivateKeySigner;
 use derivative::Derivative;
 use eyre::Context;
@@ -111,10 +111,6 @@ pub struct FlashbotsConfig {
     /// For production we always need some tbv push (since it's used by smart-multiplexing.) so:
     /// !Some(key_registration_url) => Some(tbv_push_redis)
     tbv_push_redis: Option<TBVPushRedisConfig>,
-
-    /// Bundles with refund identity or signer set to these will not receive any redistributions.
-    #[serde(default)]
-    pub backtest_ignored_signers: Vec<Address>,
 }
 
 impl LiveBuilderConfig for FlashbotsConfig {

--- a/crates/rbuilder/src/backtest/backtest_build_range.rs
+++ b/crates/rbuilder/src/backtest/backtest_build_range.rs
@@ -20,7 +20,7 @@ use crate::{
     live_builder::cli::LiveBuilderConfig,
     utils::timestamp_ms_to_offset_datetime,
 };
-use alloy_primitives::{utils::format_ether, Address, U256};
+use alloy_primitives::{utils::format_ether, U256};
 use clap::Parser;
 use rayon::prelude::*;
 use rbuilder_config::load_toml_config;
@@ -58,8 +58,6 @@ struct Cli {
     compare_backtest: bool,
     #[clap(long, help = "Path to csv file to write output to")]
     csv: Option<PathBuf>,
-    #[clap(long, help = "Ignored signers")]
-    ignored_signers: Vec<Address>,
     #[clap(help = "Blocks")]
     blocks: Vec<u64>,
 }
@@ -145,7 +143,6 @@ where
         historical_data_storage,
         blocks.clone(),
         cli.build_block_lag_ms as i64,
-        cli.ignored_signers,
         cancel_token.clone(),
     );
 
@@ -409,7 +406,6 @@ fn spawn_block_fetcher(
     mut historical_data_storage: HistoricalDataStorage,
     blocks: Vec<u64>,
     build_block_lag_ms: i64,
-    ignored_signers: Vec<Address>,
     cancellation_token: CancellationToken,
 ) -> mpsc::Receiver<Vec<BlockData>> {
     let (sender, receiver) = mpsc::channel(10);
@@ -433,10 +429,7 @@ fn spawn_block_fetcher(
                         (full_block.winning_bid_trace.timestamp_ms as i64 - build_block_lag_ms)
                             as u64,
                     )) {
-                        Ok(mut block) => {
-                            block.filter_out_ignored_signers(&ignored_signers, false);
-                            Some(block)
-                        }
+                        Ok(block) => Some(block),
                         Err(err) => {
                             error!(
                                 err = ?err,

--- a/crates/rbuilder/src/backtest/mod.rs
+++ b/crates/rbuilder/src/backtest/mod.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 use crate::{mev_boost::BuilderBlockReceived, utils::offset_datetime_to_timestamp_ms};
 use alloy_consensus::Transaction as TransactionTrait;
 use alloy_network_primitives::TransactionResponse;
-use alloy_primitives::{Address, TxHash, I256};
+use alloy_primitives::{TxHash, I256};
 use alloy_rpc_types::{BlockTransactions, Transaction};
 pub use fetch::HistoricalDataFetcher;
 use rbuilder_primitives::{serialize::RawOrder, AccountNonce, Order, OrderId, OrderReplacementKey};
@@ -69,7 +69,12 @@ pub enum OrderFilteredReason {
     Ids,
     /// Order signer was explicitly filtered out
     Signer,
+    /// Order was filtered out for other reasons
+    Other { reason: String },
 }
+
+pub trait OrderFilterFn: Fn(&Order) -> Option<OrderFilteredReason> {}
+impl<T> OrderFilterFn for T where T: Fn(&Order) -> Option<OrderFilteredReason> {}
 
 #[derive(Debug, Clone)]
 pub struct BlockData {
@@ -199,30 +204,15 @@ impl BlockData {
         });
     }
 
-    pub fn filter_out_ignored_signers(
-        &mut self,
-        ignored_signers: &[Address],
-        use_refund_identity: bool,
-    ) {
+    pub fn filter_out_orders<Filter: OrderFilterFn>(&mut self, filter: Filter) {
         self.available_orders.retain(|orders| {
             let order = &orders.order;
-            let signer = if use_refund_identity {
-                order.metadata().refund_identity.or_else(|| order.signer())
-            } else {
-                order.signer()
-            };
-            let signer = if let Some(signer) = signer {
-                signer
-            } else {
-                return true;
-            };
-            if !ignored_signers.contains(&signer) {
-                true
-            } else {
-                trace!(order = ?order.id(), "order filtered by ignored signers");
-                self.filtered_orders
-                    .insert(order.id(), OrderFilteredReason::Signer);
+            if let Some(reason) = filter(order) {
+                trace!(order = ?order.id(), "order filtered out");
+                self.filtered_orders.insert(order.id(), reason);
                 false
+            } else {
+                true
             }
         });
     }

--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -33,7 +33,7 @@ use std::{
 use tracing::{debug, error, info, info_span, trace, warn};
 use uuid::Uuid;
 
-use super::{execute::backtest_simulate_block_with_context, OrderFilteredReason};
+use super::{execute::backtest_simulate_block_with_context, OrderFilterFn, OrderFilteredReason};
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -119,24 +119,24 @@ pub struct RedistributionBlockOutput {
     pub joint_contribution: Vec<JointContributionData>,
 }
 
-pub fn calc_redistributions<P, ConfigType>(
+pub fn calc_redistributions<P, ConfigType, OrderFilter>(
     provider: P,
     config: &ConfigType,
     block_data: BlockData,
     distribute_to_mempool_txs: bool,
     blocklist: BlockList,
-    ignored_signers: &[Address],
+    order_filter: OrderFilter,
 ) -> eyre::Result<RedistributionBlockOutput>
 where
     P: StateProviderFactory + Clone + 'static,
     ConfigType: LiveBuilderConfig,
+    OrderFilter: OrderFilterFn,
 {
     let _block_span = info_span!("block", block = block_data.block_number).entered();
     let protect_signers = config.base_config().backtest_protect_bundle_signers.clone();
 
     info!(
         ?protect_signers,
-        ?ignored_signers,
         blocklist_len = blocklist.len(),
         distribute_to_mempool_txs,
         "Started to calculate redistribution"
@@ -148,7 +148,7 @@ where
 
     let start = Instant::now();
     let (onchain_block_profit, block_data, built_block_data) =
-        prepare_block_data(config, block_data, ignored_signers)?;
+        prepare_block_data(config, block_data, order_filter)?;
 
     let included_orders_available =
         get_available_orders(&block_data, &built_block_data, distribute_to_mempool_txs);
@@ -274,13 +274,14 @@ where
     Ok(result)
 }
 
-fn prepare_block_data<ConfigType>(
+fn prepare_block_data<ConfigType, OrderFilter>(
     config: &ConfigType,
     mut block_data: BlockData,
-    ignored_signers: &[Address],
+    order_filter: OrderFilter,
 ) -> eyre::Result<(U256, BlockData, BuiltBlockData)>
 where
     ConfigType: LiveBuilderConfig,
+    OrderFilter: OrderFilterFn,
 {
     let built_block_data = if let Some(block_data) = block_data.built_block_data.clone() {
         block_data
@@ -305,7 +306,7 @@ where
     // @TODO filter cancellations properly, for this we need actual cancellations in the backtest data
     // filter bundles made out of mempool txs
     block_data.filter_bundles_from_mempool();
-    block_data.filter_out_ignored_signers(ignored_signers, true);
+    block_data.filter_out_orders(order_filter);
 
     let filtered = orders_before_filtering - block_data.available_orders.len();
 
@@ -367,6 +368,9 @@ fn get_available_orders(
                 }
                 Some(OrderFilteredReason::Signer) => {
                     info!(order = ?id, "Included order was filtered because signer is explicitly ignored");
+                }
+                Some(OrderFilteredReason::Other { reason }) => {
+                    info!(order = ?id, reason, "Included order was filtered explicitly");
                 }
                 Some(reason) => {
                     error!(order = ?id, ?reason, "Included order was filtered from available orders");


### PR DESCRIPTION
## 📝 Summary

To decouple redistribution code from details we:
1. add ability to pass a callback to filter orders out
2.  remove backtest_ignored_signers (its moved to internal redistribution binary with implementation details)

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
