### PR TITLE
fix: use rust:1.89-bookworm image in the rbuilder Dockerfile

### DIFF
--- a/docker/Dockerfile.rbuilder
+++ b/docker/Dockerfile.rbuilder
@@ -9,7 +9,7 @@
 ARG FEATURES
 ARG RBUILDER_BIN="rbuilder"
 
-FROM rust:1.89 AS base
+FROM rust:1.89-bookworm AS base
 ARG TARGETPLATFORM
 
 RUN apt-get update \


### PR DESCRIPTION
## 📝 Summary

https://github.com/flashbots/rbuilder/pull/790 updated the rbuilder docker base image to use rust:1.89 which broke the latest develop images with:
```
/app/rbuilder: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /app/rbuilder)
/app/rbuilder: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /app/rbuilder)
```

Use `rust:1.89-bookworm` to fix this issue


## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
