### PR TITLE
perf: arc block submission to avoid redundant clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14582,6 +14582,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 1.4.1",
  "alloy-provider",
+ "alloy-rpc-types-beacon",
  "clap",
  "clap_builder",
  "ctor",

--- a/crates/bid-scraper/src/bloxroute_ws_publisher.rs
+++ b/crates/bid-scraper/src/bloxroute_ws_publisher.rs
@@ -22,6 +22,8 @@ use tokio_tungstenite::{
 };
 use tracing::{debug, error, info};
 
+pub type BloxrouteWsPublisher = Service<BloxrouteWsConnectionHandler>;
+
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct BloxrouteWsPublisherConfig {
     /// Url to connect to. Example: "wss://mev-eth.blxrbdn.com/ws"
@@ -189,5 +191,3 @@ mod tests {
         assert!(serde_json::from_str::<BloxrouteWsBid>(raw).is_ok());
     }
 }
-
-pub type BloxrouteWsPublisher = Service<BloxrouteWsConnectionHandler>;

--- a/crates/rbuilder-operator/src/blocks_processor.rs
+++ b/crates/rbuilder-operator/src/blocks_processor.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::{Address, BlockHash, B256, U256};
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use exponential_backoff::Backoff;
 use jsonrpsee::core::{client::ClientT, traits::ToRpcParams};
 use rbuilder::{
@@ -9,7 +10,6 @@ use rbuilder::{
     utils::error_storage::store_error_event,
 };
 use rbuilder_primitives::{
-    mev_boost::SubmitBlockRequest,
     serialize::{RawBundle, RawShareBundle},
     Bundle, Order, OrderId,
 };
@@ -135,12 +135,23 @@ impl<HttpClientType: ClientT> BlocksProcessorClient<HttpClientType> {
     }
     pub async fn submit_built_block(
         &self,
-        submit_block_request: &SubmitBlockRequest,
+        submit_block_request: &AlloySubmitBlockRequest,
         built_block_trace: &BuiltBlockTrace,
         builder_name: String,
         best_bid_value: U256,
     ) -> eyre::Result<()> {
-        let execution_payload_v1 = submit_block_request.execution_payload_v1();
+        let execution_payload_v1 = match submit_block_request {
+            AlloySubmitBlockRequest::Capella(request) => &request.execution_payload.payload_inner,
+            AlloySubmitBlockRequest::Deneb(request) => {
+                &request.execution_payload.payload_inner.payload_inner
+            }
+            AlloySubmitBlockRequest::Electra(request) => {
+                &request.execution_payload.payload_inner.payload_inner
+            }
+            AlloySubmitBlockRequest::Fulu(request) => {
+                &request.execution_payload.payload_inner.payload_inner
+            }
+        };
         let header = BlocksProcessorHeader {
             hash: execution_payload_v1.block_hash,
             gas_limit: U256::from(execution_payload_v1.gas_limit),
@@ -345,7 +356,7 @@ impl<HttpClientType: ClientT + Clone + Send + Sync + std::fmt::Debug + 'static> 
     fn block_submitted(
         &self,
         _slot_data: &MevBoostSlotData,
-        submit_block_request: &SubmitBlockRequest,
+        submit_block_request: &AlloySubmitBlockRequest,
         built_block_trace: &BuiltBlockTrace,
         builder_name: String,
         best_bid_value: U256,

--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -3,6 +3,7 @@
 //! @Pending make this copy/paste generic code on the library
 
 use alloy_primitives::U256;
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use alloy_signer_local::PrivateKeySigner;
 use derivative::Derivative;
 use eyre::Context;
@@ -29,7 +30,6 @@ use rbuilder::{
     utils::build_info::Version,
 };
 use rbuilder_config::EnvOrValue;
-use rbuilder_primitives::mev_boost::SubmitBlockRequest;
 use serde::Deserialize;
 use serde_with::serde_as;
 use tokio_util::sync::CancellationToken;
@@ -431,7 +431,7 @@ impl BidObserver for RbuilderOperatorBidObserver {
     fn block_submitted(
         &self,
         slot_data: &MevBoostSlotData,
-        submit_block_request: &SubmitBlockRequest,
+        submit_block_request: &AlloySubmitBlockRequest,
         built_block_trace: &BuiltBlockTrace,
         builder_name: String,
         best_bid_value: U256,

--- a/crates/rbuilder-operator/src/true_block_value_push/best_true_value_observer.rs
+++ b/crates/rbuilder-operator/src/true_block_value_push/best_true_value_observer.rs
@@ -1,3 +1,4 @@
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use alloy_signer_local::PrivateKeySigner;
 use rbuilder::{
     building::BuiltBlockTrace,
@@ -5,7 +6,6 @@ use rbuilder::{
         block_output::bidding_service_interface::BidObserver, payload_events::MevBoostSlotData,
     },
 };
-use rbuilder_primitives::mev_boost::SubmitBlockRequest;
 use redis::RedisError;
 use tokio_util::sync::CancellationToken;
 
@@ -73,7 +73,7 @@ impl BidObserver for BestTrueValueObserver {
     fn block_submitted(
         &self,
         slot_data: &MevBoostSlotData,
-        _submit_block_request: &SubmitBlockRequest,
+        _submit_block_request: &AlloySubmitBlockRequest,
         built_block_trace: &BuiltBlockTrace,
         builder_name: String,
         _best_bid_value: alloy_primitives::U256,

--- a/crates/rbuilder-primitives/src/built_block.rs
+++ b/crates/rbuilder-primitives/src/built_block.rs
@@ -1,7 +1,3 @@
-use crate::mev_boost::{
-    BidAdjustmentDataV1, CapellaSubmitBlockRequest, DenebSubmitBlockRequest,
-    ElectraSubmitBlockRequest, FuluSubmitBlockRequest, SubmitBlockRequest,
-};
 use alloy_eips::{
     eip2718::Encodable2718,
     eip4844::BlobTransactionSidecar,
@@ -10,6 +6,7 @@ use alloy_eips::{
 };
 use alloy_primitives::{Bytes, U256};
 use alloy_rpc_types::Withdrawals;
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use alloy_rpc_types_beacon::{
     events::PayloadAttributesData,
     relay::{
@@ -37,42 +34,18 @@ pub struct SignedBuiltBlock {
 }
 
 impl SignedBuiltBlock {
-    /// Convert the signed block into [`SubmitBlockRequest`].
-    /// NOTE: This does not set bid adjustment data. Use [`Self::into_request_with_adjustment_data`] instead.
-    pub fn into_request(self, chain_spec: &ChainSpec) -> eyre::Result<SubmitBlockRequest> {
-        self.into_request_inner(chain_spec, None)
-    }
-
-    /// Convert the signed block into [`SubmitBlockRequest`] with ad
-    pub fn into_request_with_adjustment_data(
-        self,
-        chain_spec: &ChainSpec,
-        adjustment_data: Option<BidAdjustmentDataV1>,
-    ) -> eyre::Result<SubmitBlockRequest> {
-        self.into_request_inner(chain_spec, adjustment_data)
-    }
-
-    /// Convert the signed block into [`SubmitBlockRequest`].
-    /// NOTE:
-    fn into_request_inner(
-        self,
-        chain_spec: &ChainSpec,
-        adjustment_data: Option<BidAdjustmentDataV1>,
-    ) -> eyre::Result<SubmitBlockRequest> {
+    /// Convert the signed block into [`SubmitBlockRequest`](`alloy_rpc_types_beacon::relay::SubmitBlockRequest`).
+    pub fn into_request(self, chain_spec: &ChainSpec) -> eyre::Result<AlloySubmitBlockRequest> {
         match self.execution_payload {
             ExecutionPayload::V1(_v1) => {
                 eyre::bail!("v1 payloads are not supported");
             }
             ExecutionPayload::V2(v2) => {
-                let submission = SignedBidSubmissionV2 {
+                Ok(AlloySubmitBlockRequest::Capella(SignedBidSubmissionV2 {
                     message: self.message,
                     execution_payload: v2,
                     signature: self.signature,
-                };
-                Ok(SubmitBlockRequest::capella(CapellaSubmitBlockRequest::new(
-                    submission,
-                    adjustment_data,
-                )))
+                }))
             }
             ExecutionPayload::V3(v3) => {
                 if chain_spec.is_osaka_active_at_timestamp(v3.timestamp()) {
@@ -80,17 +53,13 @@ impl SignedBuiltBlock {
                         self.execution_requests.to_vec(),
                     ))?;
                     let blobs_bundle_v2 = marshall_txs_blobs_sidecars_v2(&self.blob_sidecars);
-                    let submission = SignedBidSubmissionV5 {
+                    return Ok(AlloySubmitBlockRequest::Fulu(SignedBidSubmissionV5 {
                         message: self.message,
                         execution_payload: v3,
                         blobs_bundle: blobs_bundle_v2,
                         signature: self.signature,
                         execution_requests,
-                    };
-                    return Ok(SubmitBlockRequest::fulu(FuluSubmitBlockRequest::new(
-                        submission,
-                        adjustment_data,
-                    )));
+                    }));
                 }
 
                 let blobs_bundle = marshal_txs_blobs_sidecars(&self.blob_sidecars);
@@ -98,29 +67,21 @@ impl SignedBuiltBlock {
                     let execution_requests = ExecutionRequestsV4::try_from(Requests::new(
                         self.execution_requests.to_vec(),
                     ))?;
-                    let submission = SignedBidSubmissionV4 {
+                    return Ok(AlloySubmitBlockRequest::Electra(SignedBidSubmissionV4 {
                         message: self.message,
                         execution_payload: v3,
                         blobs_bundle,
                         signature: self.signature,
                         execution_requests,
-                    };
-                    return Ok(SubmitBlockRequest::electra(ElectraSubmitBlockRequest::new(
-                        submission,
-                        adjustment_data,
-                    )));
+                    }));
                 }
 
-                let submission = SignedBidSubmissionV3 {
+                Ok(AlloySubmitBlockRequest::Deneb(SignedBidSubmissionV3 {
                     message: self.message,
                     execution_payload: v3,
                     blobs_bundle,
                     signature: self.signature,
-                };
-                Ok(SubmitBlockRequest::deneb(DenebSubmitBlockRequest::new(
-                    submission,
-                    adjustment_data,
-                )))
+                }))
             }
         }
     }

--- a/crates/rbuilder-primitives/src/mev_boost/mod.rs
+++ b/crates/rbuilder-primitives/src/mev_boost/mod.rs
@@ -1,13 +1,10 @@
 use crate::OrderId;
 use alloy_primitives::{Address, Bytes, B256, U256};
-use alloy_rpc_types_beacon::{
-    relay::BidTrace, requests::ExecutionRequestsV4, BlsPublicKey, BlsSignature,
-};
-use alloy_rpc_types_engine::{BlobsBundleV1, BlobsBundleV2, ExecutionPayloadV3};
+use alloy_rpc_types_beacon::BlsPublicKey;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 mod submit_block;
 pub use submit_block::*;
@@ -216,85 +213,6 @@ pub struct BidValueMetadata {
 
 #[derive(Clone, Debug)]
 pub struct SubmitBlockRequestWithMetadata {
-    pub submission: Arc<SubmitBlockRequest>,
+    pub submission: SubmitBlockRequest,
     pub metadata: BidMetadata,
-}
-
-/// Signed bid submission that is serialized without blobs bundle.
-#[derive(Debug)]
-pub struct SubmitBlockRequestNoBlobs<'a>(pub &'a SubmitBlockRequest);
-
-impl serde::Serialize for SubmitBlockRequestNoBlobs<'_> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self.0 {
-            SubmitBlockRequest::Capella(v2) => v2.serialize(serializer),
-            SubmitBlockRequest::Deneb(v3) => {
-                #[derive(serde::Serialize)]
-                struct SignedBidSubmissionV3Ref<'a> {
-                    message: &'a BidTrace,
-                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
-                    execution_payload: &'a ExecutionPayloadV3,
-                    blobs_bundle: &'a BlobsBundleV1,
-                    signature: &'a BlsSignature,
-                    #[serde(skip_serializing_if = "Option::is_none")]
-                    adjustment_data: &'a Option<BidAdjustmentDataV1>,
-                }
-
-                SignedBidSubmissionV3Ref {
-                    message: &v3.message,
-                    execution_payload: &v3.execution_payload,
-                    blobs_bundle: &BlobsBundleV1::new([]), // override blobs bundle with empty one
-                    signature: &v3.signature,
-                    adjustment_data: &v3.adjustment_data,
-                }
-                .serialize(serializer)
-            }
-            SubmitBlockRequest::Electra(v4) => {
-                #[derive(serde::Serialize)]
-                struct SignedBidSubmissionV4Ref<'a> {
-                    message: &'a BidTrace,
-                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
-                    execution_payload: &'a ExecutionPayloadV3,
-                    blobs_bundle: &'a BlobsBundleV1,
-                    execution_requests: &'a ExecutionRequestsV4,
-                    signature: &'a BlsSignature,
-                    #[serde(skip_serializing_if = "Option::is_none")]
-                    adjustment_data: &'a Option<BidAdjustmentDataV1>,
-                }
-
-                SignedBidSubmissionV4Ref {
-                    message: &v4.message,
-                    execution_payload: &v4.execution_payload,
-                    blobs_bundle: &BlobsBundleV1::new([]), // override blobs bundle with empty one
-                    signature: &v4.signature,
-                    execution_requests: &v4.execution_requests,
-                    adjustment_data: &v4.adjustment_data,
-                }
-                .serialize(serializer)
-            }
-            SubmitBlockRequest::Fulu(v5) => {
-                #[derive(serde::Serialize)]
-                struct SignedBidSubmissionV5Ref<'a> {
-                    message: &'a BidTrace,
-                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
-                    execution_payload: &'a ExecutionPayloadV3,
-                    blobs_bundle: &'a BlobsBundleV2,
-                    execution_requests: &'a ExecutionRequestsV4,
-                    signature: &'a BlsSignature,
-                }
-
-                SignedBidSubmissionV5Ref {
-                    message: &v5.message,
-                    execution_payload: &v5.execution_payload,
-                    blobs_bundle: &BlobsBundleV2::new([]), // override blobs bundle with empty one
-                    signature: &v5.signature,
-                    execution_requests: &v5.execution_requests,
-                }
-                .serialize(serializer)
-            }
-        }
-    }
 }

--- a/crates/rbuilder-primitives/src/mev_boost/submit_block.rs
+++ b/crates/rbuilder-primitives/src/mev_boost/submit_block.rs
@@ -2,7 +2,7 @@ use crate::mev_boost::BidAdjustmentDataV1;
 use alloy_rpc_types_beacon::{
     relay::{
         BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4,
-        SignedBidSubmissionV5,
+        SignedBidSubmissionV5, SubmitBlockRequest as AlloySubmitBlockRequest,
     },
     requests::ExecutionRequestsV4,
     BlsSignature,
@@ -12,120 +12,195 @@ use alloy_rpc_types_engine::{
 };
 use derive_more::Deref;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
-#[derive(Debug, Clone, Serialize, Deserialize, ssz_derive::Encode)]
-#[ssz(enum_behaviour = "transparent")]
-#[serde(untagged)]
-pub enum SubmitBlockRequest {
-    Fulu(FuluSubmitBlockRequest),
-    Capella(CapellaSubmitBlockRequest),
-    Deneb(DenebSubmitBlockRequest),
-    Electra(ElectraSubmitBlockRequest),
+#[derive(Debug, Clone, Serialize, Deserialize, Deref)]
+pub struct SubmitBlockRequest {
+    /// Inner submit block request.
+    #[deref]
+    #[serde(flatten)]
+    pub request: Arc<AlloySubmitBlockRequest>,
+    /// Bid adjustment data if present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adjustment_data: Option<BidAdjustmentDataV1>,
+}
+
+impl ssz::Encode for SubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        let mut offset = <AlloySubmitBlockRequest as ssz::Encode>::ssz_fixed_len();
+        if self.adjustment_data.is_some() {
+            offset += <BidAdjustmentDataV1 as ssz::Encode>::ssz_fixed_len();
+        }
+
+        let mut encoder = ssz::SszEncoder::container(buf, offset);
+
+        match self.request.as_ref() {
+            AlloySubmitBlockRequest::Fulu(request) => {
+                let SignedBidSubmissionV5 {
+                    message,
+                    execution_payload,
+                    blobs_bundle,
+                    execution_requests,
+                    signature,
+                } = request;
+                encoder.append(&message);
+                encoder.append(&execution_payload);
+                encoder.append(&blobs_bundle);
+                encoder.append(&execution_requests);
+                encoder.append(&signature);
+            }
+            AlloySubmitBlockRequest::Electra(request) => {
+                let SignedBidSubmissionV4 {
+                    message,
+                    execution_payload,
+                    blobs_bundle,
+                    execution_requests,
+                    signature,
+                } = request;
+                encoder.append(&message);
+                encoder.append(&execution_payload);
+                encoder.append(&blobs_bundle);
+                encoder.append(&execution_requests);
+                encoder.append(&signature);
+            }
+            AlloySubmitBlockRequest::Deneb(request) => {
+                let SignedBidSubmissionV3 {
+                    message,
+                    execution_payload,
+                    blobs_bundle,
+                    signature,
+                } = request;
+                encoder.append(&message);
+                encoder.append(&execution_payload);
+                encoder.append(&blobs_bundle);
+                encoder.append(&signature);
+            }
+            AlloySubmitBlockRequest::Capella(request) => {
+                let SignedBidSubmissionV2 {
+                    message,
+                    execution_payload,
+                    signature,
+                } = request;
+                encoder.append(&message);
+                encoder.append(&execution_payload);
+                encoder.append(&signature);
+            }
+        };
+        if let Some(adjustment) = &self.adjustment_data {
+            encoder.append(&adjustment);
+        }
+
+        encoder.finalize();
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        let mut len = <AlloySubmitBlockRequest as ssz::Encode>::ssz_bytes_len(&self.request);
+        if let Some(adjustment) = &self.adjustment_data {
+            len += <BidAdjustmentDataV1 as ssz::Encode>::ssz_bytes_len(adjustment);
+        }
+        len
+    }
+}
+
+impl ssz::Decode for SubmitBlockRequest {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    // A naive implementation of decoding where we attempt to decode each variant with or without adjustments.
+    // Optimize this if it becomes latency sensitive.
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        // Fulu (with adjustments)
+        if let Ok(request) = ssz_helpers::FuluSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
+            return Ok(request.into());
+        }
+
+        // Electra (with adjustments)
+        if let Ok(request) = ssz_helpers::ElectraSubmitBlockRequestSszHelper::from_ssz_bytes(bytes)
+        {
+            return Ok(request.into());
+        }
+
+        // Deneb (with adjustments)
+        if let Ok(request) = ssz_helpers::DenebSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
+            return Ok(request.into());
+        }
+
+        // Capella (with adjustments)
+        if let Ok(request) = ssz_helpers::CapellaSubmitBlockRequestSszHelper::from_ssz_bytes(bytes)
+        {
+            return Ok(request.into());
+        }
+
+        // Any (no adjustments)
+        let request = Arc::new(AlloySubmitBlockRequest::from_ssz_bytes(bytes)?);
+        Ok(Self {
+            request,
+            adjustment_data: None,
+        })
+    }
 }
 
 impl SubmitBlockRequest {
-    #[inline]
-    pub fn capella(request: CapellaSubmitBlockRequest) -> Self {
-        Self::Capella(request)
-    }
-
-    #[inline]
-    pub fn deneb(request: DenebSubmitBlockRequest) -> Self {
-        Self::Deneb(request)
-    }
-
-    #[inline]
-    pub fn electra(request: ElectraSubmitBlockRequest) -> Self {
-        Self::Electra(request)
-    }
-
-    #[inline]
-    pub fn fulu(request: FuluSubmitBlockRequest) -> Self {
-        Self::Fulu(request)
-    }
-
-    pub fn bid_trace(&self) -> &BidTrace {
-        match self {
-            SubmitBlockRequest::Capella(req) => &req.message,
-            SubmitBlockRequest::Deneb(req) => &req.message,
-            SubmitBlockRequest::Electra(req) => &req.message,
-            SubmitBlockRequest::Fulu(req) => &req.message,
-        }
-    }
-
     pub fn signature(&self) -> BlsSignature {
-        match self {
-            SubmitBlockRequest::Capella(req) => req.signature,
-            SubmitBlockRequest::Deneb(req) => req.signature,
-            SubmitBlockRequest::Electra(req) => req.signature,
-            SubmitBlockRequest::Fulu(req) => req.signature,
+        match self.request.as_ref() {
+            AlloySubmitBlockRequest::Capella(req) => req.signature,
+            AlloySubmitBlockRequest::Deneb(req) => req.signature,
+            AlloySubmitBlockRequest::Electra(req) => req.signature,
+            AlloySubmitBlockRequest::Fulu(req) => req.signature,
         }
     }
 
     pub fn execution_payload_v1(&self) -> &ExecutionPayloadV1 {
-        match self {
-            SubmitBlockRequest::Capella(req) => &req.execution_payload.payload_inner,
-            SubmitBlockRequest::Deneb(req) => &req.execution_payload.payload_inner.payload_inner,
-            SubmitBlockRequest::Electra(req) => &req.execution_payload.payload_inner.payload_inner,
-            SubmitBlockRequest::Fulu(req) => &req.execution_payload.payload_inner.payload_inner,
+        match self.request.as_ref() {
+            AlloySubmitBlockRequest::Capella(req) => &req.execution_payload.payload_inner,
+            AlloySubmitBlockRequest::Deneb(req) => {
+                &req.execution_payload.payload_inner.payload_inner
+            }
+            AlloySubmitBlockRequest::Electra(req) => {
+                &req.execution_payload.payload_inner.payload_inner
+            }
+            AlloySubmitBlockRequest::Fulu(req) => {
+                &req.execution_payload.payload_inner.payload_inner
+            }
         }
     }
 
     pub fn execution_payload_v2(&self) -> &ExecutionPayloadV2 {
-        match self {
-            SubmitBlockRequest::Capella(req) => &req.execution_payload,
-            SubmitBlockRequest::Deneb(req) => &req.execution_payload.payload_inner,
-            SubmitBlockRequest::Electra(req) => &req.execution_payload.payload_inner,
-            SubmitBlockRequest::Fulu(req) => &req.execution_payload.payload_inner,
+        match self.request.as_ref() {
+            AlloySubmitBlockRequest::Capella(req) => &req.execution_payload,
+            AlloySubmitBlockRequest::Deneb(req) => &req.execution_payload.payload_inner,
+            AlloySubmitBlockRequest::Electra(req) => &req.execution_payload.payload_inner,
+            AlloySubmitBlockRequest::Fulu(req) => &req.execution_payload.payload_inner,
         }
     }
 
     pub fn execution_payload_v3(&self) -> Option<&ExecutionPayloadV3> {
-        match self {
-            SubmitBlockRequest::Capella(_) => None,
-            SubmitBlockRequest::Deneb(req) => Some(&req.execution_payload),
-            SubmitBlockRequest::Electra(req) => Some(&req.execution_payload),
-            SubmitBlockRequest::Fulu(req) => Some(&req.execution_payload),
+        match self.request.as_ref() {
+            AlloySubmitBlockRequest::Capella(_) => None,
+            AlloySubmitBlockRequest::Deneb(req) => Some(&req.execution_payload),
+            AlloySubmitBlockRequest::Electra(req) => Some(&req.execution_payload),
+            AlloySubmitBlockRequest::Fulu(req) => Some(&req.execution_payload),
         }
     }
 
     /// Returns `true` if block has adjustment data.
     pub fn has_adjustment_data(&self) -> bool {
-        let maybe_adjustment_data = match self {
-            SubmitBlockRequest::Capella(req) => &req.adjustment_data,
-            SubmitBlockRequest::Deneb(req) => &req.adjustment_data,
-            SubmitBlockRequest::Electra(req) => &req.adjustment_data,
-            SubmitBlockRequest::Fulu(req) => &req.adjustment_data,
-        };
-        maybe_adjustment_data.is_some()
-    }
-
-    /// Return mutable reference to bid adjustment data.
-    fn adjustment_data_mut(&mut self) -> &mut Option<BidAdjustmentDataV1> {
-        match self {
-            Self::Capella(CapellaSubmitBlockRequest {
-                adjustment_data, ..
-            })
-            | Self::Deneb(DenebSubmitBlockRequest {
-                adjustment_data, ..
-            })
-            | Self::Electra(ElectraSubmitBlockRequest {
-                adjustment_data, ..
-            })
-            | Self::Fulu(FuluSubmitBlockRequest {
-                adjustment_data, ..
-            }) => adjustment_data,
-        }
+        self.adjustment_data.is_some()
     }
 
     /// Set the bid adjustment data on the request.
     pub fn set_adjustment_data(&mut self, data: BidAdjustmentDataV1) {
-        *self.adjustment_data_mut() = Some(data);
+        self.adjustment_data = Some(data);
     }
 
     /// Remove adjustment data from the bid.
     pub fn remove_adjustment_data(&mut self) {
-        self.adjustment_data_mut().take();
+        self.adjustment_data.take();
     }
 
     /// Remove adjustment data from the bid and return it.
@@ -135,213 +210,151 @@ impl SubmitBlockRequest {
     }
 }
 
-impl ssz::Decode for SubmitBlockRequest {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
+/// Signed bid submission that is serialized without blobs bundle.
+#[derive(Debug)]
+pub struct SubmitBlockRequestNoBlobs<'a>(pub &'a SubmitBlockRequest);
 
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        if let Ok(result) = FuluSubmitBlockRequest::from_ssz_bytes(bytes) {
-            return Ok(Self::fulu(result));
+impl serde::Serialize for SubmitBlockRequestNoBlobs<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.0.request.as_ref() {
+            AlloySubmitBlockRequest::Capella(v2) => v2.serialize(serializer),
+            AlloySubmitBlockRequest::Deneb(v3) => {
+                #[derive(serde::Serialize)]
+                struct SignedBidSubmissionV3Ref<'a> {
+                    message: &'a BidTrace,
+                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
+                    execution_payload: &'a ExecutionPayloadV3,
+                    blobs_bundle: &'a BlobsBundleV1,
+                    signature: &'a BlsSignature,
+                }
+
+                SignedBidSubmissionV3Ref {
+                    message: &v3.message,
+                    execution_payload: &v3.execution_payload,
+                    blobs_bundle: &BlobsBundleV1::new([]), // override blobs bundle with empty one
+                    signature: &v3.signature,
+                }
+                .serialize(serializer)
+            }
+            AlloySubmitBlockRequest::Electra(v4) => {
+                #[derive(serde::Serialize)]
+                struct SignedBidSubmissionV4Ref<'a> {
+                    message: &'a BidTrace,
+                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
+                    execution_payload: &'a ExecutionPayloadV3,
+                    blobs_bundle: &'a BlobsBundleV1,
+                    execution_requests: &'a ExecutionRequestsV4,
+                    signature: &'a BlsSignature,
+                }
+
+                SignedBidSubmissionV4Ref {
+                    message: &v4.message,
+                    execution_payload: &v4.execution_payload,
+                    blobs_bundle: &BlobsBundleV1::new([]), // override blobs bundle with empty one
+                    signature: &v4.signature,
+                    execution_requests: &v4.execution_requests,
+                }
+                .serialize(serializer)
+            }
+            AlloySubmitBlockRequest::Fulu(v5) => {
+                #[derive(serde::Serialize)]
+                struct SignedBidSubmissionV5Ref<'a> {
+                    message: &'a BidTrace,
+                    #[serde(with = "alloy_rpc_types_beacon::payload::beacon_payload_v3")]
+                    execution_payload: &'a ExecutionPayloadV3,
+                    blobs_bundle: &'a BlobsBundleV2,
+                    execution_requests: &'a ExecutionRequestsV4,
+                    signature: &'a BlsSignature,
+                }
+
+                SignedBidSubmissionV5Ref {
+                    message: &v5.message,
+                    execution_payload: &v5.execution_payload,
+                    blobs_bundle: &BlobsBundleV2::new([]), // override blobs bundle with empty one
+                    signature: &v5.signature,
+                    execution_requests: &v5.execution_requests,
+                }
+                .serialize(serializer)
+            }
         }
-        if let Ok(result) = ElectraSubmitBlockRequest::from_ssz_bytes(bytes) {
-            return Ok(Self::electra(result));
-        }
-        if let Ok(result) = DenebSubmitBlockRequest::from_ssz_bytes(bytes) {
-            return Ok(Self::deneb(result));
-        }
-
-        let result = CapellaSubmitBlockRequest::from_ssz_bytes(bytes)?;
-        Ok(Self::capella(result))
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Deref)]
-pub struct FuluSubmitBlockRequest {
-    #[deref]
-    #[serde(flatten)]
-    pub submission: SignedBidSubmissionV5,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub adjustment_data: Option<BidAdjustmentDataV1>,
-}
-
-impl FuluSubmitBlockRequest {
-    pub fn new(
-        submission: SignedBidSubmissionV5,
-        adjustment_data: Option<BidAdjustmentDataV1>,
-    ) -> Self {
-        Self {
-            submission,
-            adjustment_data,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Deref)]
-pub struct ElectraSubmitBlockRequest {
-    /// Inner bid submission.
-    #[deref]
-    #[serde(flatten)]
-    pub submission: SignedBidSubmissionV4,
-    /// Bid adjustment data if present.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub adjustment_data: Option<BidAdjustmentDataV1>,
-}
-
-impl ElectraSubmitBlockRequest {
-    /// Create new Electra submit block request.
-    pub fn new(
-        submission: SignedBidSubmissionV4,
-        adjustment_data: Option<BidAdjustmentDataV1>,
-    ) -> Self {
-        Self {
-            submission,
-            adjustment_data,
-        }
-    }
-}
-
-impl ssz::Encode for FuluSubmitBlockRequest {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let mut offset = <BidTrace as ssz::Encode>::ssz_fixed_len()
-            + <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
-            + <BlobsBundleV2 as ssz::Encode>::ssz_fixed_len()
-            + <ExecutionRequestsV4 as ssz::Encode>::ssz_fixed_len()
-            + <BlsSignature as ssz::Encode>::ssz_fixed_len();
-        if self.adjustment_data.is_some() {
-            offset += <BidAdjustmentDataV1 as ssz::Encode>::ssz_fixed_len();
-        }
-
-        let mut encoder = ssz::SszEncoder::container(buf, offset);
-
-        encoder.append(&self.message);
-        encoder.append(&self.execution_payload);
-        encoder.append(&self.blobs_bundle);
-        encoder.append(&self.execution_requests);
-        encoder.append(&self.signature);
-        if let Some(adjustment) = &self.adjustment_data {
-            encoder.append(&adjustment);
-        }
-
-        encoder.finalize();
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        let mut len = <BidTrace as ssz::Encode>::ssz_bytes_len(&self.message)
-            + <ExecutionPayloadV3 as ssz::Encode>::ssz_bytes_len(&self.execution_payload)
-            + <BlobsBundleV2 as ssz::Encode>::ssz_bytes_len(&self.blobs_bundle)
-            + <ExecutionRequestsV4 as ssz::Encode>::ssz_bytes_len(&self.execution_requests)
-            + <BlsSignature as ssz::Encode>::ssz_bytes_len(&self.signature);
-        if let Some(adjustment) = &self.adjustment_data {
-            len += <BidAdjustmentDataV1 as ssz::Encode>::ssz_bytes_len(adjustment);
-        }
-        len
     }
 }
 
-impl ssz::Decode for FuluSubmitBlockRequest {
-    fn is_ssz_fixed_len() -> bool {
-        false
+mod ssz_helpers {
+    use super::*;
+
+    #[derive(ssz_derive::Decode)]
+    pub(crate) struct CapellaSubmitBlockRequestSszHelper {
+        message: BidTrace,
+        execution_payload: ExecutionPayloadV2,
+        signature: BlsSignature,
+        adjustment_data: BidAdjustmentDataV1,
     }
 
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        #[derive(ssz_derive::Decode)]
-        struct FuluSubmitBlockRequestSszHelper {
-            message: BidTrace,
-            execution_payload: ExecutionPayloadV3,
-            blobs_bundle: BlobsBundleV2,
-            execution_requests: ExecutionRequestsV4,
-            signature: BlsSignature,
-            adjustment_data: BidAdjustmentDataV1,
-        }
-
-        if let Ok(request) = FuluSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
-            let FuluSubmitBlockRequestSszHelper {
+    impl From<CapellaSubmitBlockRequestSszHelper> for SubmitBlockRequest {
+        fn from(value: CapellaSubmitBlockRequestSszHelper) -> Self {
+            let CapellaSubmitBlockRequestSszHelper {
                 message,
                 execution_payload,
-                blobs_bundle,
-                execution_requests,
                 signature,
                 adjustment_data,
-            } = request;
-            let submission = SignedBidSubmissionV5 {
+            } = value;
+            Self {
+                request: Arc::new(AlloySubmitBlockRequest::Capella(SignedBidSubmissionV2 {
+                    message,
+                    execution_payload,
+                    signature,
+                })),
+                adjustment_data: Some(adjustment_data),
+            }
+        }
+    }
+
+    #[derive(ssz_derive::Decode)]
+    pub(crate) struct DenebSubmitBlockRequestSszHelper {
+        message: BidTrace,
+        execution_payload: ExecutionPayloadV3,
+        blobs_bundle: BlobsBundleV1,
+        signature: BlsSignature,
+        adjustment_data: BidAdjustmentDataV1,
+    }
+
+    impl From<DenebSubmitBlockRequestSszHelper> for SubmitBlockRequest {
+        fn from(value: DenebSubmitBlockRequestSszHelper) -> Self {
+            let DenebSubmitBlockRequestSszHelper {
                 message,
                 execution_payload,
                 blobs_bundle,
-                execution_requests,
                 signature,
-            };
-            Ok(Self::new(submission, Some(adjustment_data)))
-        } else {
-            let submission = SignedBidSubmissionV5::from_ssz_bytes(bytes)?;
-            Ok(Self::new(submission, None))
+                adjustment_data,
+            } = value;
+            Self {
+                request: Arc::new(AlloySubmitBlockRequest::Deneb(SignedBidSubmissionV3 {
+                    message,
+                    execution_payload,
+                    blobs_bundle,
+                    signature,
+                })),
+                adjustment_data: Some(adjustment_data),
+            }
         }
     }
-}
 
-impl ssz::Encode for ElectraSubmitBlockRequest {
-    fn is_ssz_fixed_len() -> bool {
-        false
+    #[derive(ssz_derive::Decode)]
+    pub(crate) struct ElectraSubmitBlockRequestSszHelper {
+        message: BidTrace,
+        execution_payload: ExecutionPayloadV3,
+        blobs_bundle: BlobsBundleV1,
+        execution_requests: ExecutionRequestsV4,
+        signature: BlsSignature,
+        adjustment_data: BidAdjustmentDataV1,
     }
 
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let mut offset = <BidTrace as ssz::Encode>::ssz_fixed_len()
-            + <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
-            + <BlobsBundleV1 as ssz::Encode>::ssz_fixed_len()
-            + <ExecutionRequestsV4 as ssz::Encode>::ssz_fixed_len()
-            + <BlsSignature as ssz::Encode>::ssz_fixed_len();
-        if self.adjustment_data.is_some() {
-            offset += <BidAdjustmentDataV1 as ssz::Encode>::ssz_fixed_len();
-        }
-
-        let mut encoder = ssz::SszEncoder::container(buf, offset);
-
-        encoder.append(&self.message);
-        encoder.append(&self.execution_payload);
-        encoder.append(&self.blobs_bundle);
-        encoder.append(&self.execution_requests);
-        encoder.append(&self.signature);
-        if let Some(adjustment) = &self.adjustment_data {
-            encoder.append(&adjustment);
-        }
-
-        encoder.finalize();
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        let mut len = <BidTrace as ssz::Encode>::ssz_bytes_len(&self.message)
-            + <ExecutionPayloadV3 as ssz::Encode>::ssz_bytes_len(&self.execution_payload)
-            + <BlobsBundleV1 as ssz::Encode>::ssz_bytes_len(&self.blobs_bundle)
-            + <ExecutionRequestsV4 as ssz::Encode>::ssz_bytes_len(&self.execution_requests)
-            + <BlsSignature as ssz::Encode>::ssz_bytes_len(&self.signature);
-        if let Some(adjustment) = &self.adjustment_data {
-            len += <BidAdjustmentDataV1 as ssz::Encode>::ssz_bytes_len(adjustment);
-        }
-        len
-    }
-}
-
-impl ssz::Decode for ElectraSubmitBlockRequest {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        #[derive(ssz_derive::Decode)]
-        struct ElectraSubmitBlockRequestSszHelper {
-            message: BidTrace,
-            execution_payload: ExecutionPayloadV3,
-            blobs_bundle: BlobsBundleV1,
-            execution_requests: ExecutionRequestsV4,
-            signature: BlsSignature,
-            adjustment_data: BidAdjustmentDataV1,
-        }
-
-        if let Ok(request) = ElectraSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
+    impl From<ElectraSubmitBlockRequestSszHelper> for SubmitBlockRequest {
+        fn from(value: ElectraSubmitBlockRequestSszHelper) -> Self {
             let ElectraSubmitBlockRequestSszHelper {
                 message,
                 execution_payload,
@@ -349,211 +362,50 @@ impl ssz::Decode for ElectraSubmitBlockRequest {
                 execution_requests,
                 signature,
                 adjustment_data,
-            } = request;
-            let submission = SignedBidSubmissionV4 {
+            } = value;
+            Self {
+                request: Arc::new(AlloySubmitBlockRequest::Electra(SignedBidSubmissionV4 {
+                    message,
+                    execution_payload,
+                    blobs_bundle,
+                    execution_requests,
+                    signature,
+                })),
+                adjustment_data: Some(adjustment_data),
+            }
+        }
+    }
+
+    #[derive(ssz_derive::Decode)]
+    pub(crate) struct FuluSubmitBlockRequestSszHelper {
+        message: BidTrace,
+        execution_payload: ExecutionPayloadV3,
+        blobs_bundle: BlobsBundleV2,
+        execution_requests: ExecutionRequestsV4,
+        signature: BlsSignature,
+        adjustment_data: BidAdjustmentDataV1,
+    }
+
+    impl From<FuluSubmitBlockRequestSszHelper> for SubmitBlockRequest {
+        fn from(value: FuluSubmitBlockRequestSszHelper) -> Self {
+            let FuluSubmitBlockRequestSszHelper {
                 message,
                 execution_payload,
                 blobs_bundle,
                 execution_requests,
                 signature,
-            };
-            Ok(Self::new(submission, Some(adjustment_data)))
-        } else {
-            let submission = SignedBidSubmissionV4::from_ssz_bytes(bytes)?;
-            Ok(Self::new(submission, None))
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Deref)]
-pub struct DenebSubmitBlockRequest {
-    /// Inner bid submission.
-    #[deref]
-    #[serde(flatten)]
-    pub submission: SignedBidSubmissionV3,
-    /// Bid adjustment data if present.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub adjustment_data: Option<BidAdjustmentDataV1>,
-}
-
-impl DenebSubmitBlockRequest {
-    /// Create new Deneb submit block request.
-    pub fn new(
-        submission: SignedBidSubmissionV3,
-        adjustment_data: Option<BidAdjustmentDataV1>,
-    ) -> Self {
-        Self {
-            submission,
-            adjustment_data,
-        }
-    }
-}
-
-impl ssz::Encode for DenebSubmitBlockRequest {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let mut offset = <BidTrace as ssz::Encode>::ssz_fixed_len()
-            + <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
-            + <BlobsBundleV1 as ssz::Encode>::ssz_fixed_len()
-            + <BlsSignature as ssz::Encode>::ssz_fixed_len();
-        if self.adjustment_data.is_some() {
-            offset += <BidAdjustmentDataV1 as ssz::Encode>::ssz_fixed_len();
-        }
-
-        let mut encoder = ssz::SszEncoder::container(buf, offset);
-
-        encoder.append(&self.message);
-        encoder.append(&self.execution_payload);
-        encoder.append(&self.blobs_bundle);
-        encoder.append(&self.signature);
-        if let Some(adjustment) = &self.adjustment_data {
-            encoder.append(&adjustment);
-        }
-
-        encoder.finalize();
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        let mut len = <BidTrace as ssz::Encode>::ssz_bytes_len(&self.message)
-            + <ExecutionPayloadV3 as ssz::Encode>::ssz_bytes_len(&self.execution_payload)
-            + <BlobsBundleV1 as ssz::Encode>::ssz_bytes_len(&self.blobs_bundle)
-            + <BlsSignature as ssz::Encode>::ssz_bytes_len(&self.signature);
-        if let Some(adjustment) = &self.adjustment_data {
-            len += <BidAdjustmentDataV1 as ssz::Encode>::ssz_bytes_len(adjustment);
-        }
-        len
-    }
-}
-
-impl ssz::Decode for DenebSubmitBlockRequest {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        #[derive(ssz_derive::Decode)]
-        struct DenebSubmitBlockRequestSszHelper {
-            message: BidTrace,
-            execution_payload: ExecutionPayloadV3,
-            blobs_bundle: BlobsBundleV1,
-            signature: BlsSignature,
-            adjustment_data: BidAdjustmentDataV1,
-        }
-
-        if let Ok(request) = DenebSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
-            let DenebSubmitBlockRequestSszHelper {
-                message,
-                execution_payload,
-                blobs_bundle,
-                signature,
                 adjustment_data,
-            } = request;
-            let submission = SignedBidSubmissionV3 {
-                message,
-                execution_payload,
-                blobs_bundle,
-                signature,
-            };
-            Ok(Self::new(submission, Some(adjustment_data)))
-        } else {
-            let submission = SignedBidSubmissionV3::from_ssz_bytes(bytes)?;
-            Ok(Self::new(submission, None))
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Deref)]
-pub struct CapellaSubmitBlockRequest {
-    /// Inner bid submission.
-    #[deref]
-    #[serde(flatten)]
-    pub submission: SignedBidSubmissionV2,
-    /// Bid adjustment data if present.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub adjustment_data: Option<BidAdjustmentDataV1>,
-}
-
-impl CapellaSubmitBlockRequest {
-    /// Create new Capella submit block request.
-    pub fn new(
-        submission: SignedBidSubmissionV2,
-        adjustment_data: Option<BidAdjustmentDataV1>,
-    ) -> Self {
-        Self {
-            submission,
-            adjustment_data,
-        }
-    }
-}
-
-impl ssz::Encode for CapellaSubmitBlockRequest {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let mut offset = <BidTrace as ssz::Encode>::ssz_fixed_len()
-            + <ExecutionPayloadV2 as ssz::Encode>::ssz_fixed_len()
-            + <BlsSignature as ssz::Encode>::ssz_fixed_len();
-        if self.adjustment_data.is_some() {
-            offset += <BidAdjustmentDataV1 as ssz::Encode>::ssz_fixed_len();
-        }
-
-        let mut encoder = ssz::SszEncoder::container(buf, offset);
-        encoder.append(&self.message);
-        encoder.append(&self.execution_payload);
-        encoder.append(&self.signature);
-        if let Some(adjustment) = &self.adjustment_data {
-            encoder.append(&adjustment);
-        }
-
-        encoder.finalize();
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        let mut len = <BidTrace as ssz::Encode>::ssz_bytes_len(&self.message)
-            + <ExecutionPayloadV2 as ssz::Encode>::ssz_bytes_len(&self.execution_payload)
-            + <BlsSignature as ssz::Encode>::ssz_bytes_len(&self.signature);
-        if let Some(adjustment) = &self.adjustment_data {
-            len += <BidAdjustmentDataV1 as ssz::Encode>::ssz_bytes_len(adjustment);
-        }
-        len
-    }
-}
-
-impl ssz::Decode for CapellaSubmitBlockRequest {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        #[derive(ssz_derive::Decode)]
-        struct CapellaSubmitBlockRequestSszHelper {
-            message: BidTrace,
-            execution_payload: ExecutionPayloadV2,
-            signature: BlsSignature,
-            adjustment_data: BidAdjustmentDataV1,
-        }
-
-        if let Ok(request) = CapellaSubmitBlockRequestSszHelper::from_ssz_bytes(bytes) {
-            let CapellaSubmitBlockRequestSszHelper {
-                message,
-                execution_payload,
-                signature,
-                adjustment_data,
-            } = request;
-            let submission = SignedBidSubmissionV2 {
-                message,
-                execution_payload,
-                signature,
-            };
-            Ok(Self::new(submission, Some(adjustment_data)))
-        } else {
-            let submission = SignedBidSubmissionV2::from_ssz_bytes(bytes)?;
-            Ok(Self::new(submission, None))
+            } = value;
+            Self {
+                request: Arc::new(AlloySubmitBlockRequest::Fulu(SignedBidSubmissionV5 {
+                    message,
+                    execution_payload,
+                    blobs_bundle,
+                    execution_requests,
+                    signature,
+                })),
+                adjustment_data: Some(adjustment_data),
+            }
         }
     }
 }

--- a/crates/rbuilder-primitives/src/mev_boost/submit_block.rs
+++ b/crates/rbuilder-primitives/src/mev_boost/submit_block.rs
@@ -31,13 +31,35 @@ impl ssz::Encode for SubmitBlockRequest {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let mut offset = <AlloySubmitBlockRequest as ssz::Encode>::ssz_fixed_len();
+        // Every request contains bid trace and signature.
+        let mut offset = <BidTrace as ssz::Encode>::ssz_fixed_len()
+            + <BlsSignature as ssz::Encode>::ssz_fixed_len();
+        // Amend offset with fork specific fields.
+        offset += match &self.request.as_ref() {
+            AlloySubmitBlockRequest::Fulu(_) => {
+                <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
+                    + <BlobsBundleV2 as ssz::Encode>::ssz_fixed_len()
+                    + <ExecutionRequestsV4 as ssz::Encode>::ssz_fixed_len()
+            }
+            AlloySubmitBlockRequest::Electra(_) => {
+                <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
+                    + <BlobsBundleV1 as ssz::Encode>::ssz_fixed_len()
+                    + <ExecutionRequestsV4 as ssz::Encode>::ssz_fixed_len()
+            }
+            AlloySubmitBlockRequest::Deneb(_) => {
+                <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
+                    + <BlobsBundleV1 as ssz::Encode>::ssz_fixed_len()
+            }
+            AlloySubmitBlockRequest::Capella(_) => {
+                <ExecutionPayloadV2 as ssz::Encode>::ssz_fixed_len()
+            }
+        };
+        // Add adjustment data offset if present.
         if self.adjustment_data.is_some() {
             offset += <BidAdjustmentDataV1 as ssz::Encode>::ssz_fixed_len();
         }
 
         let mut encoder = ssz::SszEncoder::container(buf, offset);
-
         match self.request.as_ref() {
             AlloySubmitBlockRequest::Fulu(request) => {
                 let SignedBidSubmissionV5 {

--- a/crates/rbuilder/benches/benchmarks/mev_boost.rs
+++ b/crates/rbuilder/benches/benchmarks/mev_boost.rs
@@ -1,16 +1,16 @@
 use alloy_consensus::{Block, Header};
 use alloy_eips::{eip4844::BlobTransactionSidecar, eip7594::BlobTransactionSidecarVariant};
 use alloy_primitives::U256;
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use alloy_rpc_types_beacon::BlsPublicKey;
 use criterion::{criterion_group, Criterion};
 use rbuilder::mev_boost::{rpc::TestDataGenerator, sign_block_for_relay, BLSBlockSigner};
-use rbuilder_primitives::mev_boost::DenebSubmitBlockRequest;
 use reth::primitives::SealedBlock;
 use reth_primitives::kzg::Blob;
 use ssz::Encode;
 use std::{fs, path::PathBuf, sync::Arc};
 
-fn mev_boost_serialize_submit_block(data: DenebSubmitBlockRequest) {
+fn mev_boost_serialize_submit_block(data: AlloySubmitBlockRequest) {
     data.as_ssz_bytes();
 }
 

--- a/crates/rbuilder/src/bin/debug-bench-machine.rs
+++ b/crates/rbuilder/src/bin/debug-bench-machine.rs
@@ -5,6 +5,7 @@ use alloy_consensus::TxEnvelope;
 use alloy_eips::Decodable2718;
 use alloy_primitives::address;
 use alloy_provider::Provider;
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use clap::Parser;
 use eyre::Context;
 use itertools::Itertools;
@@ -180,11 +181,11 @@ async fn main() -> eyre::Result<()> {
 fn read_execution_payload_from_json(path: PathBuf) -> eyre::Result<alloy_rpc_types::Block> {
     let req = std::fs::read_to_string(&path)?;
     let req: SubmitBlockRequest = serde_json::from_str(&req)?;
-    let block_raw = match req {
-        SubmitBlockRequest::Capella(req) => req.execution_payload.clone().into_block_raw()?,
-        SubmitBlockRequest::Fulu(req) => req.execution_payload.clone().into_block_raw()?,
-        SubmitBlockRequest::Deneb(req) => req.execution_payload.clone().into_block_raw()?,
-        SubmitBlockRequest::Electra(req) => req.execution_payload.clone().into_block_raw()?,
+    let block_raw = match req.request.as_ref() {
+        AlloySubmitBlockRequest::Capella(req) => req.execution_payload.clone().into_block_raw()?,
+        AlloySubmitBlockRequest::Fulu(req) => req.execution_payload.clone().into_block_raw()?,
+        AlloySubmitBlockRequest::Deneb(req) => req.execution_payload.clone().into_block_raw()?,
+        AlloySubmitBlockRequest::Electra(req) => req.execution_payload.clone().into_block_raw()?,
     };
     let rpc_block = alloy_rpc_types::Block::from_consensus(block_raw, None);
     let rpc_block = rpc_block.try_map_transactions(|bytes| -> eyre::Result<_> {

--- a/crates/rbuilder/src/live_builder/block_output/bidding_service_interface.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding_service_interface.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use alloy_primitives::{BlockHash, BlockNumber, I256, U256};
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use bid_scraper::{
     bid_sender::{BidSender, BidSenderError},
     types::ScrapedRelayBlockBid,
 };
 use derivative::Derivative;
 use mockall::automock;
-use rbuilder_primitives::mev_boost::SubmitBlockRequest;
 use time::OffsetDateTime;
 use tokio_util::sync::CancellationToken;
 
@@ -27,7 +27,7 @@ pub trait BidObserver: std::fmt::Debug {
     fn block_submitted(
         &self,
         slot_data: &MevBoostSlotData,
-        submit_block_request: &SubmitBlockRequest,
+        submit_block_request: &AlloySubmitBlockRequest,
         built_block_trace: &BuiltBlockTrace,
         builder_name: String,
         best_bid_value: U256,
@@ -41,7 +41,7 @@ impl BidObserver for NullBidObserver {
     fn block_submitted(
         &self,
         _slot_data: &MevBoostSlotData,
-        _submit_block_request: &SubmitBlockRequest,
+        _submit_block_request: &AlloySubmitBlockRequest,
         _built_block_trace: &BuiltBlockTrace,
         _builder_name: String,
         _best_bid_value: U256,

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use ahash::HashMap;
 use alloy_primitives::{utils::format_ether, Address, U256};
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use alloy_rpc_types_engine::ExecutionPayload;
 use futures::FutureExt as _;
 use mockall::automock;
@@ -114,7 +115,7 @@ pub struct OptimisticV3Config {
     /// The URL where the relay can call to retrieve the block.
     pub builder_url: Vec<u8>,
     /// Sender for Optimistic V3 blocks.
-    pub block_sender: broadcast::Sender<Arc<SubmitBlockRequest>>,
+    pub block_sender: broadcast::Sender<Arc<AlloySubmitBlockRequest>>,
 }
 
 /// Values from [`BuiltBlockTrace`]
@@ -147,7 +148,7 @@ async fn run_submit_to_relays_job(
     'submit: loop {
         tokio::select! {
             _ = cancel.cancelled() => {
-                info!( block = slot_data.block(), "run_submit_to_relays_job cancelled");
+                info!(block = slot_data.block(), "run_submit_to_relays_job cancelled");
                 break 'submit res;
             },
             _ = pending_bid.wait_for_change() => {}
@@ -289,7 +290,7 @@ async fn run_submit_to_relays_job(
         mark_submission_start_time(block.trace.orders_sealed_at);
         if let Some(request) = &regular_request {
             submit_block_to_relays(
-                request,
+                request.clone(),
                 &bid_metadata,
                 &block.bid_adjustments,
                 &regular_relays,
@@ -307,7 +308,7 @@ async fn run_submit_to_relays_job(
             .or(regular_request.map(|req| (req, false)));
         if let Some((request, optimistic)) = optimistic_request {
             submit_block_to_relays(
-                &request,
+                request.clone(),
                 &bid_metadata,
                 &block.bid_adjustments,
                 &optimistic_relays,
@@ -339,7 +340,7 @@ fn create_submit_block_request(
     slot_data: &MevBoostSlotData,
     block: &Block,
     execution_payload: &ExecutionPayload,
-) -> eyre::Result<SubmitBlockRequest> {
+) -> eyre::Result<Arc<AlloySubmitBlockRequest>> {
     let (message, signature) = sign_block_for_relay(
         signer,
         &block.sealed_block,
@@ -355,11 +356,12 @@ fn create_submit_block_request(
         execution_requests: block.execution_requests.clone(),
     }
     .into_request(chain_spec)
+    .map(Arc::new)
 }
 
 fn create_optimistic_v3_request(
     builder_url: &[u8],
-    request: &SubmitBlockRequest,
+    request: &AlloySubmitBlockRequest,
     maybe_adjustment_data: Option<&BidAdjustmentData>,
     adjustment_data_required: bool,
 ) -> eyre::Result<HeaderSubmissionOptimisticV3> {
@@ -368,44 +370,62 @@ fn create_optimistic_v3_request(
         eyre::bail!("adjustment data is required")
     }
 
-    let header_submission = match request {
-        SubmitBlockRequest::Electra(request) => {
-            let header = ExecutionPayloadHeaderElectra::from(&request.execution_payload);
-            HeaderSubmission::Electra(HeaderSubmissionElectra {
-                bid_trace: request.message.clone(),
-                execution_payload_header: header,
-                execution_requests: request.execution_requests.clone(),
-                commitments: request.blobs_bundle.commitments.clone(),
-                adjustment_data: maybe_adjustment_data_v2,
-            })
+    let (submission, tx_count) = match &request {
+        AlloySubmitBlockRequest::Electra(request) => {
+            let tx_count = request
+                .execution_payload
+                .payload_inner
+                .payload_inner
+                .transactions
+                .len();
+            let submission = SignedHeaderSubmission {
+                message: HeaderSubmission::Electra(HeaderSubmissionElectra {
+                    bid_trace: request.message.clone(),
+                    execution_payload_header: ExecutionPayloadHeaderElectra::from(
+                        &request.execution_payload,
+                    ),
+                    execution_requests: request.execution_requests.clone(),
+                    commitments: request.blobs_bundle.commitments.clone(),
+                    adjustment_data: maybe_adjustment_data_v2,
+                }),
+                signature: request.signature,
+            };
+            (submission, tx_count)
         }
-        SubmitBlockRequest::Fulu(request) => {
-            let header = ExecutionPayloadHeaderElectra::from(&request.execution_payload);
-            HeaderSubmission::Fulu(HeaderSubmissionElectra {
-                bid_trace: request.message.clone(),
-                execution_payload_header: header,
-                execution_requests: request.execution_requests.clone(),
-                commitments: request.blobs_bundle.commitments.clone(),
-                adjustment_data: maybe_adjustment_data_v2,
-            })
+        AlloySubmitBlockRequest::Fulu(request) => {
+            let tx_count = request
+                .execution_payload
+                .payload_inner
+                .payload_inner
+                .transactions
+                .len();
+            let submission = SignedHeaderSubmission {
+                message: HeaderSubmission::Fulu(HeaderSubmissionElectra {
+                    bid_trace: request.message.clone(),
+                    execution_payload_header: ExecutionPayloadHeaderElectra::from(
+                        &request.execution_payload,
+                    ),
+                    execution_requests: request.execution_requests.clone(),
+                    commitments: request.blobs_bundle.commitments.clone(),
+                    adjustment_data: maybe_adjustment_data_v2,
+                }),
+                signature: request.signature,
+            };
+            (submission, tx_count)
         }
         _ => eyre::bail!("optimistic v3 submission is not supported for this fork"),
     };
 
-    let tx_count = request.execution_payload_v1().transactions.len();
     Ok(HeaderSubmissionOptimisticV3 {
         url: builder_url.to_vec(),
         tx_count: tx_count as u32,
-        submission: SignedHeaderSubmission {
-            message: header_submission,
-            signature: request.signature(),
-        },
+        submission,
     })
 }
 
 #[allow(clippy::too_many_arguments)]
 fn submit_block_to_relays(
-    request: &SubmitBlockRequest,
+    request: Arc<AlloySubmitBlockRequest>,
     bid_metadata: &BidMetadata,
     bid_adjustments: &std::collections::HashMap<Address, BidAdjustmentData>,
     relays: &Vec<MevBoostRelayBidSubmitter>,
@@ -440,7 +460,7 @@ fn submit_block_to_relays(
             if let Some(config) = optimistic_v3_config {
                 optimistic_v3 = create_optimistic_v3_request(
                     &config.builder_url,
-                    request,
+                    request.as_ref(),
                     maybe_adjustment_data,
                     relay.optimistic_v3_bid_adjustment_required(),
                 )
@@ -452,16 +472,15 @@ fn submit_block_to_relays(
             }
         }
 
-        let mut request = request.clone();
-
-        // We only set adjustment data on non optimistic v3 submissions.
-        // For optimistic v3, it is already included in the header submission.
-        if let Some(adjustment_data) = maybe_adjustment_data.filter(|_| optimistic_v3.is_none()) {
-            request.set_adjustment_data(adjustment_data.clone().into_v1());
-        }
-
         let submission = SubmitBlockRequestWithMetadata {
-            submission: Arc::new(request),
+            submission: SubmitBlockRequest {
+                request: request.clone(),
+                // We only set adjustment data on non optimistic v3 submissions.
+                // For optimistic v3, it is already included in the header submission.
+                adjustment_data: maybe_adjustment_data
+                    .filter(|_| optimistic_v3.is_none())
+                    .map(|adjustment_data| adjustment_data.clone().into_v1()),
+            },
             metadata: bid_metadata.clone(),
         };
 
@@ -505,7 +524,7 @@ async fn submit_bid_to_the_relay(
         // Send the block to be saved in cache
         let _ = config
             .block_sender
-            .send(submit_block_request.submission.clone());
+            .send(submit_block_request.submission.request.clone());
         relay
             .submit_optimistic_v3(request, registration)
             .left_future()

--- a/crates/rbuilder/src/mev_boost/bloxroute_grpc.rs
+++ b/crates/rbuilder/src/mev_boost/bloxroute_grpc.rs
@@ -5,15 +5,12 @@ use alloy_eips::{
 use alloy_rpc_types_beacon::{
     relay::{
         BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4,
-        SignedBidSubmissionV5,
+        SignedBidSubmissionV5, SubmitBlockRequest as AlloySubmitBlockRequest,
     },
     requests::ExecutionRequestsV4,
 };
 use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
-use rbuilder_primitives::mev_boost::{
-    CapellaSubmitBlockRequest, DenebSubmitBlockRequest, ElectraSubmitBlockRequest,
-    FuluSubmitBlockRequest, SubmitBlockRequest,
-};
+use rbuilder_primitives::mev_boost::SubmitBlockRequest;
 use std::sync::Arc;
 
 /// Bloxroute gRPC types.
@@ -43,131 +40,98 @@ pub type GrpcRelayClient =
 
 impl From<&SubmitBlockRequest> for types::SubmitBlockRequest {
     fn from(value: &SubmitBlockRequest) -> Self {
-        let (
-            version,
-            execution_payload,
-            bid_trace,
-            signature,
-            blobs_bundle,
-            execution_requests,
-            adjustment_data,
-        ) = match value {
-            SubmitBlockRequest::Capella(request) => {
-                let CapellaSubmitBlockRequest {
-                    submission:
-                        SignedBidSubmissionV2 {
-                            execution_payload,
-                            message,
-                            signature,
-                        },
-                    adjustment_data,
-                } = request;
+        let (version, execution_payload, bid_trace, signature, blobs_bundle, execution_requests) =
+            match value.request.as_ref() {
+                AlloySubmitBlockRequest::Capella(request) => {
+                    let SignedBidSubmissionV2 {
+                        execution_payload,
+                        message,
+                        signature,
+                    } = request;
 
-                let version = DataVersion::Capella;
-                let execution_payload = types::ExecutionPayload::from_v2(execution_payload);
-                let bid_trace = types::BidTrace::new(message, None, None);
-                (
-                    version,
-                    execution_payload,
-                    bid_trace,
-                    signature,
-                    None,
-                    None,
-                    adjustment_data,
-                )
-            }
-            SubmitBlockRequest::Deneb(request) => {
-                let DenebSubmitBlockRequest {
-                    submission:
-                        SignedBidSubmissionV3 {
-                            execution_payload,
-                            message,
-                            signature,
-                            blobs_bundle,
-                        },
-                    adjustment_data,
-                } = request;
+                    let version = DataVersion::Capella;
+                    let execution_payload = types::ExecutionPayload::from_v2(execution_payload);
+                    let bid_trace = types::BidTrace::new(message, None, None);
+                    (version, execution_payload, bid_trace, signature, None, None)
+                }
+                AlloySubmitBlockRequest::Deneb(request) => {
+                    let SignedBidSubmissionV3 {
+                        execution_payload,
+                        message,
+                        signature,
+                        blobs_bundle,
+                    } = request;
 
-                let version = DataVersion::Deneb;
-                let execution_payload = types::ExecutionPayload::from_v3(execution_payload);
-                let bid_trace = types::BidTrace::new(
-                    message,
-                    Some(execution_payload.blob_gas_used),
-                    Some(execution_payload.excess_blob_gas),
-                );
-                (
-                    version,
-                    execution_payload,
-                    bid_trace,
-                    signature,
-                    Some(types::BlobsBundle::from(blobs_bundle)),
-                    None,
-                    adjustment_data,
-                )
-            }
-            SubmitBlockRequest::Electra(request) => {
-                let ElectraSubmitBlockRequest {
-                    submission:
-                        SignedBidSubmissionV4 {
-                            execution_payload,
-                            message,
-                            signature,
-                            blobs_bundle,
-                            execution_requests,
-                        },
-                    adjustment_data,
-                } = request;
+                    let version = DataVersion::Deneb;
+                    let execution_payload = types::ExecutionPayload::from_v3(execution_payload);
+                    let bid_trace = types::BidTrace::new(
+                        message,
+                        Some(execution_payload.blob_gas_used),
+                        Some(execution_payload.excess_blob_gas),
+                    );
+                    (
+                        version,
+                        execution_payload,
+                        bid_trace,
+                        signature,
+                        Some(types::BlobsBundle::from(blobs_bundle)),
+                        None,
+                    )
+                }
+                AlloySubmitBlockRequest::Electra(request) => {
+                    let SignedBidSubmissionV4 {
+                        execution_payload,
+                        message,
+                        signature,
+                        blobs_bundle,
+                        execution_requests,
+                    } = request;
 
-                let version = DataVersion::Electra;
-                let execution_payload = types::ExecutionPayload::from_v3(execution_payload);
-                let bid_trace = types::BidTrace::new(
-                    message,
-                    Some(execution_payload.blob_gas_used),
-                    Some(execution_payload.excess_blob_gas),
-                );
-                (
-                    version,
-                    execution_payload,
-                    bid_trace,
-                    signature,
-                    Some(types::BlobsBundle::from(blobs_bundle)),
-                    Some(execution_requests),
-                    adjustment_data,
-                )
-            }
-            SubmitBlockRequest::Fulu(request) => {
-                let FuluSubmitBlockRequest {
-                    submission:
-                        SignedBidSubmissionV5 {
-                            execution_payload,
-                            message,
-                            signature,
-                            blobs_bundle,
-                            execution_requests,
-                        },
-                    adjustment_data,
-                } = request;
+                    let version = DataVersion::Electra;
+                    let execution_payload = types::ExecutionPayload::from_v3(execution_payload);
+                    let bid_trace = types::BidTrace::new(
+                        message,
+                        Some(execution_payload.blob_gas_used),
+                        Some(execution_payload.excess_blob_gas),
+                    );
+                    (
+                        version,
+                        execution_payload,
+                        bid_trace,
+                        signature,
+                        Some(types::BlobsBundle::from(blobs_bundle)),
+                        Some(execution_requests),
+                    )
+                }
+                AlloySubmitBlockRequest::Fulu(request) => {
+                    let SignedBidSubmissionV5 {
+                        execution_payload,
+                        message,
+                        signature,
+                        blobs_bundle,
+                        execution_requests,
+                    } = request;
 
-                let version = DataVersion::Electra;
-                let execution_payload = types::ExecutionPayload::from_v3(execution_payload);
-                let bid_trace = types::BidTrace::new(
-                    message,
-                    Some(execution_payload.blob_gas_used),
-                    Some(execution_payload.excess_blob_gas),
-                );
-                (
-                    version,
-                    execution_payload,
-                    bid_trace,
-                    signature,
-                    Some(types::BlobsBundle::from(blobs_bundle)),
-                    Some(execution_requests),
-                    adjustment_data,
-                )
-            }
-        };
+                    let version = DataVersion::Electra;
+                    let execution_payload = types::ExecutionPayload::from_v3(execution_payload);
+                    let bid_trace = types::BidTrace::new(
+                        message,
+                        Some(execution_payload.blob_gas_used),
+                        Some(execution_payload.excess_blob_gas),
+                    );
+                    (
+                        version,
+                        execution_payload,
+                        bid_trace,
+                        signature,
+                        Some(types::BlobsBundle::from(blobs_bundle)),
+                        Some(execution_requests),
+                    )
+                }
+            };
         let execution_requests = execution_requests.map(types::ExecutionRequests::from);
-        let adjustment_data = adjustment_data
+        let adjustment_data = value
+            .adjustment_data
             .as_ref()
             .map(ssz::Encode::as_ssz_bytes)
             .unwrap_or_default();

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -798,7 +798,7 @@ impl RelayClient {
         submission: &SubmitBlockRequestWithMetadata,
     ) -> Result<bloxroute_grpc::types::SubmitBlockResponse, SubmitBlockErr> {
         let mut request = tonic::Request::new(bloxroute_grpc::types::SubmitBlockRequest::from(
-            submission.submission.as_ref(),
+            &submission.submission,
         ));
         request.set_timeout(Duration::from_secs(2));
         request.metadata_mut().insert(
@@ -1256,9 +1256,10 @@ mod tests {
         let relay_url = Url::from_str(&srv.endpoint()).unwrap();
         let relay =
             RelayClient::from_url(relay_url, None, None, None, false, Vec::new(), false, false);
-        let submission = Arc::new(SubmitBlockRequest::Deneb(
-            generator.create_deneb_submit_block_request(),
-        ));
+        let submission = Arc::new(SubmitBlockRequest {
+            request: generator.create_deneb_submit_block_request(),
+            adjustment_data: None,
+        });
         let sub_relay = SubmitBlockRequestWithMetadata {
             submission,
             metadata: BidMetadata {

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -1256,10 +1256,10 @@ mod tests {
         let relay_url = Url::from_str(&srv.endpoint()).unwrap();
         let relay =
             RelayClient::from_url(relay_url, None, None, None, false, Vec::new(), false, false);
-        let submission = Arc::new(SubmitBlockRequest {
-            request: generator.create_deneb_submit_block_request(),
+        let submission = SubmitBlockRequest {
+            request: Arc::new(generator.create_deneb_submit_block_request()),
             adjustment_data: None,
-        });
+        };
         let sub_relay = SubmitBlockRequestWithMetadata {
             submission,
             metadata: BidMetadata {

--- a/crates/rbuilder/src/mev_boost/optimistic_v3.rs
+++ b/crates/rbuilder/src/mev_boost/optimistic_v3.rs
@@ -3,6 +3,7 @@ use crate::{
     utils,
 };
 use alloy_primitives::{bytes::Bytes, B256};
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use alloy_rpc_types_beacon::BlsPublicKey;
 use ctor::ctor;
 use futures::StreamExt as _;
@@ -10,9 +11,7 @@ use lazy_static::lazy_static;
 use metrics_macros::register_metrics;
 use parking_lot::Mutex;
 use prometheus::{HistogramOpts, HistogramVec, IntCounter};
-use rbuilder_primitives::mev_boost::{
-    verify_signed_relay_request, SignedGetPayloadV3, SubmitBlockRequest,
-};
+use rbuilder_primitives::mev_boost::{verify_signed_relay_request, SignedGetPayloadV3};
 use schnellru::{ByLength, LruMap};
 use ssz::{Decode as _, Encode};
 use std::{
@@ -65,7 +64,7 @@ pub fn spawn_server(
     address: impl Into<SocketAddr>,
     domain: B256,
     relay_pubkeys: HashSet<BlsPublicKey>,
-    bid_stream: BroadcastStream<Arc<SubmitBlockRequest>>,
+    bid_stream: BroadcastStream<Arc<AlloySubmitBlockRequest>>,
 ) -> eyre::Result<()> {
     let blocks = Arc::new(Mutex::new(LruMap::new(ByLength::new(
         OPTIMISTIC_V3_CACHE_SIZE_DEFAULT,
@@ -103,7 +102,7 @@ pub fn spawn_server(
 struct Handler {
     domain: B256,
     relay_pubkeys: HashSet<BlsPublicKey>,
-    blocks: Arc<Mutex<LruMap<B256, Arc<SubmitBlockRequest>>>>,
+    blocks: Arc<Mutex<LruMap<B256, Arc<AlloySubmitBlockRequest>>>>,
 }
 
 impl Handler {
@@ -199,8 +198,8 @@ impl Handler {
 }
 
 async fn maintain_block_cache(
-    mut bid_stream: BroadcastStream<Arc<SubmitBlockRequest>>,
-    blocks: Arc<Mutex<LruMap<B256, Arc<SubmitBlockRequest>>>>,
+    mut bid_stream: BroadcastStream<Arc<AlloySubmitBlockRequest>>,
+    blocks: Arc<Mutex<LruMap<B256, Arc<AlloySubmitBlockRequest>>>>,
 ) {
     loop {
         match bid_stream.next().await {

--- a/crates/rbuilder/src/mev_boost/rpc.rs
+++ b/crates/rbuilder/src/mev_boost/rpc.rs
@@ -1,5 +1,6 @@
 use alloy_consensus::{Blob, Bytes48};
 use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use alloy_rpc_types_beacon::{
     events::PayloadAttributesData,
     relay::{BidTrace, SignedBidSubmissionV3},
@@ -9,8 +10,8 @@ use alloy_rpc_types_engine::{
     BlobsBundleV1, ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3,
 };
 use alloy_rpc_types_eth::Withdrawal;
-use rbuilder_primitives::mev_boost::DenebSubmitBlockRequest;
 use reth::rpc::types::engine::PayloadAttributes;
+
 /// TestDataGenerator allows you to create unique test objects with unique content, it tries to use different numbers for every field it sets
 #[derive(Default)]
 pub struct TestDataGenerator {
@@ -18,16 +19,13 @@ pub struct TestDataGenerator {
 }
 
 impl TestDataGenerator {
-    pub fn create_deneb_submit_block_request(&mut self) -> DenebSubmitBlockRequest {
-        DenebSubmitBlockRequest {
-            submission: SignedBidSubmissionV3 {
-                message: self.create_bid_trace(),
-                execution_payload: self.create_deneb_payload(),
-                blobs_bundle: self.create_txs_blobs_sidecars(),
-                signature: self.create_signature(),
-            },
-            adjustment_data: None,
-        }
+    pub fn create_deneb_submit_block_request(&mut self) -> AlloySubmitBlockRequest {
+        AlloySubmitBlockRequest::Deneb(SignedBidSubmissionV3 {
+            message: self.create_bid_trace(),
+            execution_payload: self.create_deneb_payload(),
+            blobs_bundle: self.create_txs_blobs_sidecars(),
+            signature: self.create_signature(),
+        })
     }
 
     pub fn create_txs_blobs_sidecars(&mut self) -> BlobsBundleV1 {

--- a/crates/test-relay/Cargo.toml
+++ b/crates/test-relay/Cargo.toml
@@ -22,6 +22,7 @@ alloy-json-rpc.workspace = true
 alloy-primitives.workspace = true
 alloy-provider.workspace = true
 alloy-consensus.workspace = true
+alloy-rpc-types-beacon.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 serde_json.workspace = true

--- a/crates/test-relay/src/validation_api_client.rs
+++ b/crates/test-relay/src/validation_api_client.rs
@@ -1,12 +1,12 @@
 use alloy_json_rpc::{ErrorPayload, RpcError};
-use std::{fmt::Debug, sync::Arc};
-
 use alloy_primitives::B256;
 use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use rbuilder::utils::http_provider;
 use rbuilder_primitives::mev_boost::SubmitBlockRequest;
 use serde::Serialize;
 use serde_with::{serde_as, DisplayFromStr};
+use std::{fmt::Debug, sync::Arc};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info_span, warn};
@@ -69,11 +69,11 @@ impl ValidationAPIClient {
             return Err(ValidationError::NoValidationNodes);
         }
 
-        let method = match req {
-            SubmitBlockRequest::Capella(_) => "flashbots_validateBuilderSubmissionV2",
-            SubmitBlockRequest::Deneb(_) => "flashbots_validateBuilderSubmissionV3",
-            SubmitBlockRequest::Electra(_) => "flashbots_validateBuilderSubmissionV4",
-            SubmitBlockRequest::Fulu(_) => "flashbots_validateBuilderSubmissionV5",
+        let method = match req.request.as_ref() {
+            AlloySubmitBlockRequest::Capella(_) => "flashbots_validateBuilderSubmissionV2",
+            AlloySubmitBlockRequest::Deneb(_) => "flashbots_validateBuilderSubmissionV3",
+            AlloySubmitBlockRequest::Electra(_) => "flashbots_validateBuilderSubmissionV4",
+            AlloySubmitBlockRequest::Fulu(_) => "flashbots_validateBuilderSubmissionV5",
         };
         let request = ValidRequest {
             req: req.clone(),


### PR DESCRIPTION
## 📝 Summary

Refactor block submission types to put the main block data in an `Arc`. Get rid of the redundant deep cloning of block request in the hot relay submission loop here:

https://github.com/flashbots/rbuilder/blob/4ee212eedcc577479130d7123ee04ea84dfcb38c/crates/rbuilder/src/live_builder/block_output/relay_submit.rs#L454-L461

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
