### PR TITLE
perf: arc bid observer inputs

### DIFF
--- a/crates/rbuilder-operator/src/blocks_processor.rs
+++ b/crates/rbuilder-operator/src/blocks_processor.rs
@@ -356,15 +356,13 @@ impl<HttpClientType: ClientT + Clone + Send + Sync + std::fmt::Debug + 'static> 
     fn block_submitted(
         &self,
         _slot_data: &MevBoostSlotData,
-        submit_block_request: &AlloySubmitBlockRequest,
-        built_block_trace: &BuiltBlockTrace,
+        submit_block_request: Arc<AlloySubmitBlockRequest>,
+        built_block_trace: Arc<BuiltBlockTrace>,
         builder_name: String,
         best_bid_value: U256,
     ) {
         let client = self.client.clone();
         let parent_span = Span::current();
-        let submit_block_request = submit_block_request.clone();
-        let built_block_trace = built_block_trace.clone();
         tokio::spawn(async move {
             let block_processor_result = client
                 .submit_built_block(

--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -431,16 +431,16 @@ impl BidObserver for RbuilderOperatorBidObserver {
     fn block_submitted(
         &self,
         slot_data: &MevBoostSlotData,
-        submit_block_request: &AlloySubmitBlockRequest,
-        built_block_trace: &BuiltBlockTrace,
+        submit_block_request: Arc<AlloySubmitBlockRequest>,
+        built_block_trace: Arc<BuiltBlockTrace>,
         builder_name: String,
         best_bid_value: U256,
     ) {
         if let Some(p) = self.block_processor.as_ref() {
             p.block_submitted(
                 slot_data,
-                submit_block_request,
-                built_block_trace,
+                submit_block_request.clone(),
+                built_block_trace.clone(),
                 builder_name.clone(),
                 best_bid_value,
             )

--- a/crates/rbuilder-operator/src/true_block_value_push/best_true_value_observer.rs
+++ b/crates/rbuilder-operator/src/true_block_value_push/best_true_value_observer.rs
@@ -7,6 +7,7 @@ use rbuilder::{
     },
 };
 use redis::RedisError;
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use super::{
@@ -73,8 +74,8 @@ impl BidObserver for BestTrueValueObserver {
     fn block_submitted(
         &self,
         slot_data: &MevBoostSlotData,
-        _submit_block_request: &AlloySubmitBlockRequest,
-        built_block_trace: &BuiltBlockTrace,
+        _submit_block_request: Arc<AlloySubmitBlockRequest>,
+        built_block_trace: Arc<BuiltBlockTrace>,
         builder_name: String,
         _best_bid_value: alloy_primitives::U256,
     ) {

--- a/crates/rbuilder/src/live_builder/block_output/bidding_service_interface.rs
+++ b/crates/rbuilder/src/live_builder/block_output/bidding_service_interface.rs
@@ -27,8 +27,8 @@ pub trait BidObserver: std::fmt::Debug {
     fn block_submitted(
         &self,
         slot_data: &MevBoostSlotData,
-        submit_block_request: &AlloySubmitBlockRequest,
-        built_block_trace: &BuiltBlockTrace,
+        submit_block_request: Arc<AlloySubmitBlockRequest>,
+        built_block_trace: Arc<BuiltBlockTrace>,
         builder_name: String,
         best_bid_value: U256,
     );
@@ -41,8 +41,8 @@ impl BidObserver for NullBidObserver {
     fn block_submitted(
         &self,
         _slot_data: &MevBoostSlotData,
-        _submit_block_request: &AlloySubmitBlockRequest,
-        _built_block_trace: &BuiltBlockTrace,
+        _submit_block_request: Arc<AlloySubmitBlockRequest>,
+        _built_block_trace: Arc<BuiltBlockTrace>,
         _builder_name: String,
         _best_bid_value: U256,
     ) {

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -323,8 +323,8 @@ async fn run_submit_to_relays_job(
                 // NOTE: we only notify normal submission here because they have the same contents but different pubkeys
                 config.bid_observer.block_submitted(
                     &slot_data,
-                    &request,
-                    &block.trace,
+                    request,
+                    Arc::new(block.trace),
                     builder_name,
                     bid_metadata.value.top_competitor_bid.unwrap_or_default(),
                 );


### PR DESCRIPTION
## 📝 Summary

Put bid observer inputs in an arc to avoid unnecessary clones in `BlocksProcessorClientBidObserver`
https://github.com/flashbots/rbuilder/blob/61a796efbd979a0110ce2244e86b0ef117014af6/crates/rbuilder-operator/src/blocks_processor.rs#L355-L356

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
