### PR TITLE
Toolchain rust bump to 1.98

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
-version = "1.88.0"
+version = "1.89.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Read the title.
