### PR TITLE
chore: remove separate optimistic signer

### DIFF
--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -279,7 +279,6 @@ async fn run_submit_to_relays_job(
         );
 
         submission_span.in_scope(|| {
-            // NOTE: we only notify normal submission here because they have the same contents but different pubkeys
             config.bid_observer.block_submitted(
                 &slot_data,
                 request,

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -107,17 +107,8 @@ pub trait BlockBuildingSink: std::fmt::Debug + Send + Sync {
 pub struct SubmissionConfig {
     pub chain_spec: Arc<ChainSpec>,
     pub signer: BLSBlockSigner,
-
-    pub optimistic_config: Option<OptimisticConfig>,
     pub optimistic_v3_config: Option<OptimisticV3Config>,
     pub bid_observer: Box<dyn BidObserver + Send + Sync>,
-}
-
-/// Configuration for optimistic block submission to relays.
-#[derive(Debug, Clone)]
-pub struct OptimisticConfig {
-    pub signer: BLSBlockSigner,
-    pub max_bid_value: U256,
 }
 
 /// Configuration for optimistic V3.
@@ -160,19 +151,6 @@ async fn run_submit_to_relays_job(
             .collect::<Vec<_>>(),
     );
 
-    let (regular_relays, optimistic_relays) = relays
-        .into_iter()
-        .partition::<Vec<_>, _>(|relay| !relay.optimistic());
-
-    let regular_relays_ids = regular_relays
-        .iter()
-        .map(|relay| relay.id())
-        .collect::<Vec<_>>();
-    let optimistic_relays_ids = optimistic_relays
-        .iter()
-        .map(|relay| relay.id())
-        .collect::<Vec<_>>();
-
     let mut last_bid_hash = None;
     'submit: loop {
         tokio::select! {
@@ -210,18 +188,6 @@ async fn run_submit_to_relays_job(
             .filter(|o| !o.order.is_tx())
             .count();
 
-        // Only enable the optimistic config for this block if the bid value is below the max bid value
-        let optimistic_config = config
-            .optimistic_config
-            .as_ref()
-            .and_then(|optimistic_config| {
-                if block.trace.bid_value < optimistic_config.max_bid_value {
-                    Some(optimistic_config)
-                } else {
-                    None
-                }
-            });
-
         // SAFETY: UNIX timestamp in nanos won't exceed u64::MAX until year 2554
         let sequence = OffsetDateTime::now_utc().unix_timestamp_nanos() as u64;
         let executed_orders = block
@@ -254,8 +220,7 @@ async fn run_submit_to_relays_job(
             gas = block.sealed_block.gas_used,
             block_id = block.trace.build_block_id.0,
             builder_name = block.builder_name,
-            regular_relays_ids = ?regular_relays_ids,
-            optimistic_relays_ids = ?optimistic_relays_ids,
+            ?relay_set
         );
         info!(
             parent: &submission_span,
@@ -280,99 +245,50 @@ async fn run_submit_to_relays_job(
             latency_ms = latency.whole_milliseconds(),
             "Submitting bid",
         );
-        inc_initiated_submissions(optimistic_config.is_some());
+        inc_initiated_submissions(true);
 
         let execution_payload = block_to_execution_payload(
             &config.chain_spec,
             &slot_data.payload_attributes_event.data,
             &block.sealed_block,
         );
-        let (regular_request, optimistic_request) = {
-            let mut regular = None;
-            if optimistic_config.is_none() || !regular_relays.is_empty() {
-                regular = create_submit_block_request(
-                    &config.signer,
-                    &config.chain_spec,
-                    &slot_data,
-                    &block,
-                    &execution_payload,
-                )
-                .inspect_err(|error| {
-                    error!(parent: &submission_span, ?error, "Error creating regular submit block request");
-                })
-                .ok();
+        let request = match create_submit_block_request(
+            &config.signer,
+            &config.chain_spec,
+            &slot_data,
+            &block,
+            &execution_payload,
+        ) {
+            Ok(request) => request,
+            Err(error) => {
+                error!(parent: &submission_span, ?error, "Error creating submit block request");
+                continue 'submit;
             }
-
-            let mut optimistic = None;
-            if let Some(optimistic_config) =
-                optimistic_config.filter(|_| !optimistic_relays.is_empty())
-            {
-                optimistic = create_submit_block_request(
-                    &optimistic_config.signer,
-                    &config.chain_spec,
-                    &slot_data,
-                    &block,
-                    &execution_payload,
-                ).inspect_err(|error| {
-                    error!(parent: &submission_span, ?error, "Error creating optimistic submit block request");
-                })
-                .ok();
-            }
-
-            (regular, optimistic)
         };
 
-        if regular_request.is_none() && optimistic_request.is_none() {
-            let regular_relays_len = regular_relays.len();
-            let optimistic_relays_len = optimistic_relays.len();
-            error!(parent: &submission_span, regular_relays_len, optimistic_relays_len, "Unable to construct request from the built block");
-            continue 'submit;
-        }
-
         mark_submission_start_time(block.trace.orders_sealed_at);
-        if let Some(request) = &regular_request {
-            submit_block_to_relays(
-                request.clone(),
-                &bid_metadata,
-                &block.bid_adjustments,
-                &regular_relays,
-                &slot_data.relay_registrations,
-                false,
-                &config.optimistic_v3_config,
-                &submission_span,
-                &cancel,
-            )
-        }
+        submit_block_to_relays(
+            request.clone(),
+            &bid_metadata,
+            &block.bid_adjustments,
+            &relays,
+            &slot_data.relay_registrations,
+            &config.optimistic_v3_config,
+            &submission_span,
+            &cancel,
+        );
 
-        let optimistic_request = optimistic_request
-            .map(|req| (req, true))
-            // non-optimistic submission to optimistic relays
-            .or(regular_request.map(|req| (req, false)));
-        if let Some((request, optimistic)) = optimistic_request {
-            submit_block_to_relays(
-                request.clone(),
-                &bid_metadata,
-                &block.bid_adjustments,
-                &optimistic_relays,
-                &slot_data.relay_registrations,
-                optimistic,
-                &config.optimistic_v3_config,
-                &submission_span,
-                &cancel,
+        submission_span.in_scope(|| {
+            // NOTE: we only notify normal submission here because they have the same contents but different pubkeys
+            config.bid_observer.block_submitted(
+                &slot_data,
+                request,
+                Arc::new(block.trace),
+                builder_name,
+                bid_metadata.value.top_competitor_bid.unwrap_or_default(),
+                &relay_set,
             );
-
-            submission_span.in_scope(|| {
-                // NOTE: we only notify normal submission here because they have the same contents but different pubkeys
-                config.bid_observer.block_submitted(
-                    &slot_data,
-                    request,
-                    Arc::new(block.trace),
-                    builder_name,
-                    bid_metadata.value.top_competitor_bid.unwrap_or_default(),
-                    &relay_set,
-                );
-            })
-        }
+        });
     }
 }
 
@@ -473,7 +389,6 @@ fn submit_block_to_relays(
     bid_adjustments: &std::collections::HashMap<Address, BidAdjustmentData>,
     relays: &Vec<MevBoostRelayBidSubmitter>,
     registrations: &HashMap<MevBoostRelayID, RelaySlotData>,
-    optimistic: bool,
     optimistic_v3_config: &Option<OptimisticV3Config>,
     submission_span: &Span,
     cancel: &CancellationToken,
@@ -530,8 +445,7 @@ fn submit_block_to_relays(
             metadata: bid_metadata.clone(),
         };
 
-        let span =
-            info_span!(parent: submission_span, "relay_submit", relay = &relay.id(), optimistic);
+        let span = info_span!(parent: submission_span, "relay_submit", relay = &relay.id(), optimistic = true);
         let relay = relay.clone();
         let cancel = cancel.clone();
         tokio::spawn(
@@ -541,7 +455,6 @@ fn submit_block_to_relays(
                     submission,
                     optimistic_v3,
                     registration.registration,
-                    optimistic,
                     cancel,
                 )
                 .await;
@@ -556,7 +469,6 @@ async fn submit_bid_to_the_relay(
     submit_block_request: SubmitBlockRequestWithMetadata,
     optimistic_v3_request: Option<(OptimisticV3Config, SubmitHeaderRequestWithMetadata)>,
     registration: ValidatorSlotData,
-    optimistic: bool,
     cancel: CancellationToken,
 ) {
     let submit_start = Instant::now();
@@ -591,7 +503,7 @@ async fn submit_bid_to_the_relay(
         Ok(()) => {
             trace!("Block submitted to the relay successfully");
             add_relay_submit_time(relay.id(), submit_time);
-            inc_relay_accepted_submissions(relay.id(), optimistic);
+            inc_relay_accepted_submissions(relay.id(), true);
         }
         Err(SubmitBlockErr::PayloadDelivered | SubmitBlockErr::PastSlot) => {
             trace!("Block already delivered by the relay, cancelling");

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -245,7 +245,7 @@ async fn run_submit_to_relays_job(
             latency_ms = latency.whole_milliseconds(),
             "Submitting bid",
         );
-        inc_initiated_submissions(true);
+        inc_initiated_submissions();
 
         let execution_payload = block_to_execution_payload(
             &config.chain_spec,
@@ -445,7 +445,7 @@ fn submit_block_to_relays(
             metadata: bid_metadata.clone(),
         };
 
-        let span = info_span!(parent: submission_span, "relay_submit", relay = &relay.id(), optimistic = true);
+        let span = info_span!(parent: submission_span, "relay_submit", relay = &relay.id());
         let relay = relay.clone();
         let cancel = cancel.clone();
         tokio::spawn(
@@ -503,7 +503,7 @@ async fn submit_bid_to_the_relay(
         Ok(()) => {
             trace!("Block submitted to the relay successfully");
             add_relay_submit_time(relay.id(), submit_time);
-            inc_relay_accepted_submissions(relay.id(), true);
+            inc_relay_accepted_submissions(relay.id(), relay.optimistic());
         }
         Err(SubmitBlockErr::PayloadDelivered | SubmitBlockErr::PastSlot) => {
             trace!("Block already delivered by the relay, cancelling");

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -410,7 +410,7 @@ impl L1Config {
             optimistic_v3_config,
         )?;
         info!(
-            "Builder mev boost normal relay pubkey: {:?}",
+            "Builder mev boost relay pubkey: {:?}",
             submission_config.signer.pub_key()
         );
 

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -7,7 +7,7 @@ use super::{
         bidding_service_interface::{
             BidObserver, BiddingService, LandedBlockInfo, NullBidObserver,
         },
-        relay_submit::{OptimisticConfig, RelaySubmitSinkFactory, SubmissionConfig},
+        relay_submit::{RelaySubmitSinkFactory, SubmissionConfig},
         true_value_bidding_service::NewTrueBlockValueBiddingService,
         unfinished_block_processing::UnfinishedBuiltBlocksInputFactory,
     },
@@ -50,10 +50,7 @@ use crate::{
     utils::{build_info::rbuilder_version, ProviderFactoryReopener, Signer},
 };
 use alloy_chains::ChainKind;
-use alloy_primitives::{
-    utils::{format_ether, parse_ether},
-    Address, FixedBytes, B256, U256,
-};
+use alloy_primitives::{utils::parse_ether, Address, FixedBytes, B256, U256};
 use alloy_rpc_types_beacon::BlsPublicKey;
 use bid_scraper::config::NamedPublisherConfig;
 use ethereum_consensus::{
@@ -158,13 +155,6 @@ pub struct L1Config {
     pub registration_update_interval_ms: Option<u64>,
     /// Secret key that will be used to sign normal submissions to the relay.
     relay_secret_key: Option<EnvOrValue<String>>,
-    /// Secret key that will be used to sign optimistic submissions to the relay.
-    optimistic_relay_secret_key: EnvOrValue<String>,
-    /// When enabled builer will make optimistic submissions to optimistic relays
-    /// influenced by `optimistic_max_bid_value_eth`
-    pub optimistic_enabled: bool,
-    /// Bids above this value will always be submitted in non-optimistic mode.
-    pub optimistic_max_bid_value_eth: String,
 
     /// Name kept singular for backwards compatibility
     #[serde_as(deserialize_as = "OneOrMany<EnvOrValue<String>>")]
@@ -192,9 +182,6 @@ impl Default for L1Config {
             relays: vec![],
             enabled_relays: vec![],
             relay_secret_key: None,
-            optimistic_relay_secret_key: "".into(),
-            optimistic_enabled: false,
-            optimistic_max_bid_value_eth: "0.0".to_string(),
             cl_node_url: vec![EnvOrValue::from("http://127.0.0.1:3500")],
             genesis_fork_version: None,
             relay_bid_scrapers: Default::default(),
@@ -358,28 +345,9 @@ impl L1Config {
         let signer = BLSBlockSigner::new(relay_secret_key, signing_domain)
             .map_err(|e| eyre::eyre!("Failed to create normal signer: {:?}", e))?;
 
-        let optimistic_signer = if self.optimistic_enabled {
-            BLSBlockSigner::from_string(self.optimistic_relay_secret_key.value()?, signing_domain)
-                .map_err(|e| eyre::eyre!("Failed to create optimistic signer: {:?}", e))?
-        } else {
-            // Placeholder value since it is required for SubmissionConfig. But after https://github.com/flashbots/rbuilder/pull/323
-            // we can return None
-            signer.clone()
-        };
-
-        let optimistic_config = if self.optimistic_enabled {
-            Some(OptimisticConfig {
-                signer: optimistic_signer,
-                max_bid_value: parse_ether(&self.optimistic_max_bid_value_eth)?,
-            })
-        } else {
-            None
-        };
-
         Ok(SubmissionConfig {
             chain_spec,
             signer,
-            optimistic_config,
             optimistic_v3_config,
             bid_observer,
         })
@@ -445,14 +413,6 @@ impl L1Config {
             "Builder mev boost normal relay pubkey: {:?}",
             submission_config.signer.pub_key()
         );
-
-        if let Some(optimitic_config) = submission_config.optimistic_config.as_ref() {
-            info!(
-                "Optimistic mode enabled, relay pubkey {:?}, max_value: {}",
-                optimitic_config.signer.pub_key(),
-                format_ether(optimitic_config.max_bid_value),
-            );
-        };
 
         let (submitters, slot_info_providers) = self.create_relays()?;
         if slot_info_providers.is_empty() {

--- a/crates/rbuilder/src/live_builder/testdata/config_with_relay_override.toml
+++ b/crates/rbuilder/src/live_builder/testdata/config_with_relay_override.toml
@@ -10,7 +10,6 @@ reth_datadir = "/mnt/data/reth"
 
 coinbase_secret_key = "env:COINBASE_SECRET_KEY"
 relay_secret_key = "env:RELAY_SECRET_KEY"
-optimistic_relay_secret_key = "env:OPTIMISTIC_RELAY_SECRET_KEY"
 
 # cl_node_url can be a single value, array of values, or passed by an environment variables with values separated with a comma
 # cl_node_url = "http://localhost:3500"

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -209,15 +209,11 @@ register_metrics! {
         IntCounter::new("simulation_gas_used", "Simulation gas used").unwrap();
     pub static ACTIVE_SLOTS: IntCounter =
         IntCounter::new("active_slots", "Slots when builder was active").unwrap();
-    pub static INITIATED_SUBMISSIONS: IntCounterVec = IntCounterVec::new(
-        Opts::new(
+    pub static INITIATED_SUBMISSIONS: IntCounter = IntCounter::new(
             "initiated_submissions",
             "Number of initiated submissions to the relays"
-        ),
-        &["optimistic"],
     )
     .unwrap();
-
     pub static RELAY_SUBMIT_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new("relay_submit_time", "Time to send bid to the relay (ms)")
             .buckets(exponential_buckets_range(0.5, 3000.0, 50)),
@@ -567,10 +563,8 @@ pub fn inc_active_slots() {
     ACTIVE_SLOTS.inc();
 }
 
-pub fn inc_initiated_submissions(optimistic: bool) {
-    INITIATED_SUBMISSIONS
-        .with_label_values(&[&optimistic.to_string()])
-        .inc();
+pub fn inc_initiated_submissions() {
+    INITIATED_SUBMISSIONS.inc();
 }
 
 pub fn add_relay_submit_time(relay: &MevBoostRelayID, duration: Duration) {

--- a/examples/config/rbuilder/config-live-example.toml
+++ b/examples/config/rbuilder/config-live-example.toml
@@ -11,7 +11,6 @@ reth_datadir = "/mnt/data/reth"
 
 coinbase_secret_key = "env:COINBASE_SECRET_KEY"
 relay_secret_key = "env:RELAY_SECRET_KEY"
-optimistic_relay_secret_key = "env:OPTIMISTIC_RELAY_SECRET_KEY"
 
 # cl_node_url can be a single value, array of values, or passed by an environment variables with values separated with a comma
 # cl_node_url = "http://localhost:3500"


### PR DESCRIPTION
## 📝 Summary

Remove separate optimistic signer and configuration to allow builder to use only a single signing key for submissions and remove double signing from the hot path.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [ ] Added tests (if applicable)
