### PR TITLE
Fixed finalize/roothash metrics

### DIFF
--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -304,6 +304,7 @@ impl<
         building_ctx: &BlockBuildingContext,
         built_block_trace: &BuiltBlockTrace,
         sim_gas_used: u64,
+        block_was_adjusted: bool,
     ) {
         let txs = finalized_block.sealed_block.body().transactions.len();
         let gas_used = finalized_block.sealed_block.gas_used;
@@ -317,6 +318,7 @@ impl<
             sim_gas_used,
             builder_name,
             building_ctx.timestamp(),
+            block_was_adjusted,
         );
 
         trace!(
@@ -468,6 +470,7 @@ impl<
             &self.building_ctx,
             &self.built_block_trace,
             sim_gas_used,
+            adjust_finalized_block,
         );
 
         self.finalize_adjustment_state = Some(finalize_adjustment_state);

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -32,6 +32,18 @@ use tracing::error;
 pub mod scope_meter;
 mod tracing_metrics;
 pub use tracing_metrics::*;
+
+const FINALIZE_MODE_ADJUSTED: &str = "adjusted";
+const FINALIZE_MODE_NORMAL: &str = "normal";
+
+fn finalize_mode_label(adjusted: bool) -> &'static str {
+    if adjusted {
+        FINALIZE_MODE_ADJUSTED
+    } else {
+        FINALIZE_MODE_NORMAL
+    }
+}
+
 const SUBSIDY_ATTEMPT: &str = "attempt";
 const SUBSIDY_LANDED: &str = "landed";
 
@@ -342,20 +354,14 @@ register_metrics! {
     .unwrap();
     pub static BLOCK_FINALIZE_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_finalize_time", "Block Finalize Times (ms)")
-            .buckets(exponential_buckets_range(0.01, 3000.0, 200)),
-        &[]
-    )
-    .unwrap();
-    pub static BLOCK_FINALIZE_ADJUST_TIME: HistogramVec = HistogramVec::new(
-        HistogramOpts::new("block_finalize_adjust_time", "Block Finalize Adjust Times (ms)")
-            .buckets(exponential_buckets_range(0.01, 300.0, 200)),
-        &[]
+            .buckets(exponential_buckets_range(0.01, 2000.0, 200)),
+        &["mode"]
     )
     .unwrap();
     pub static BLOCK_ROOT_HASH_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new("block_root_hash_time", "Block Root Hash Time (ms)")
             .buckets(exponential_buckets_range(0.01, 2000.0, 200)),
-        &[]
+        &["mode"]
     )
     .unwrap();
     pub static BLOCK_MULTI_BID_COPY_DURATION: HistogramVec = HistogramVec::new(
@@ -504,19 +510,22 @@ pub fn add_finalized_block_metrics(
     sim_gas_used: u64,
     builder_name: &str,
     block_timestamp: OffsetDateTime,
+    block_was_adjusted: bool,
 ) {
     if !is_now_close_to_slot_end(block_timestamp) {
         return;
     }
 
     BLOCK_FINALIZE_TIME
-        .with_label_values(&[])
-        .observe(duration_ms(built_block_trace.finalize_time));
-    BLOCK_FINALIZE_ADJUST_TIME
-        .with_label_values(&[])
-        .observe(duration_ms(built_block_trace.finalize_adjust_time));
+        .with_label_values(&[finalize_mode_label(block_was_adjusted)])
+        .observe(duration_ms(if block_was_adjusted {
+            built_block_trace.finalize_adjust_time
+        } else {
+            built_block_trace.finalize_time
+        }));
+
     BLOCK_ROOT_HASH_TIME
-        .with_label_values(&[])
+        .with_label_values(&[finalize_mode_label(block_was_adjusted)])
         .observe(duration_ms(built_block_trace.root_hash_time));
 
     BLOCK_BUILT_TXS


### PR DESCRIPTION
## 📝 Summary

Metrics were wrong since finalize_adjust_time and finalize_time were always updated no matter if it was the first finalize call or an update.
Not we differentiate the cases and combined the metrics in a single one with a label "mode".
Did the same differentiation for root hash times (label "mode") so we can tell the difference between the first root hash and an adjustment.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
