### PR TITLE
fix(ci): enable automatic Docker image publishing on release tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,7 +181,7 @@ jobs:
           echo "${{ steps.create-release-draft.outputs.url }}" >> $GITHUB_STEP_SUMMARY
 
   build-docker:
-    if: ${{ github.event.inputs.build-docker == 'true' }}
+    if: ${{ github.event.inputs.build-docker == 'true' || github.event_name == 'push'}}
     name: Build and publish Docker image
     needs: extract-version
     runs-on: warp-ubuntu-2404-x64-16x


### PR DESCRIPTION
## Problem

The `build-docker` job in the release workflow is currently only triggered when manually invoked via `workflow_dispatch` with the `build-docker` input set to `true`. This means Docker images are not automatically published when release tags are pushed.

## Solution

This PR updates the `build-docker` job condition to match the `build-binary` job behavior:

```yaml
if: ${{ github.event.inputs.build-docker == 'true' || github.event_name == 'push'}}
```

Now Docker images will be automatically built and published to `ghcr.io/flashbots/rbuilder` when release tags (v*) are pushed.