### PR TITLE
feat(rbuilder): add more relay submission metrics, smol optimizations

### DIFF
--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -178,30 +178,33 @@ async fn run_submit_to_relays_job(
 
         let builder_name = block.builder_name.clone();
 
-        let bundles = block
-            .trace
-            .included_orders
-            .iter()
-            .filter(|o| !o.order.is_tx())
-            .count();
+        let mut bundles = 0;
+        let mut order_ids = Vec::with_capacity(block.trace.included_orders.len());
+        let mut bundle_hashes = Vec::with_capacity(block.trace.included_orders.len());
+
+        for exec_res in &block.trace.included_orders {
+            if !exec_res.order.is_tx() {
+                bundles += 1;
+            }
+
+            for order in exec_res.order.original_orders() {
+                order_ids.push(order.id());
+                if let Some(bundle_hash) = order.external_bundle_hash() {
+                    bundle_hashes.push(bundle_hash);
+                }
+            }
+        }
 
         // SAFETY: UNIX timestamp in nanos won't exceed u64::MAX until year 2554
         let sequence = OffsetDateTime::now_utc().unix_timestamp_nanos() as u64;
-        let executed_orders = block
-            .trace
-            .included_orders
-            .iter()
-            .flat_map(|exec_res| exec_res.order.original_orders());
         let bid_metadata = BidMetadata {
             sequence,
             value: BidValueMetadata {
                 coinbase_reward: block.trace.coinbase_reward,
                 top_competitor_bid: block.trace.seen_competition_bid,
             },
-            order_ids: executed_orders.clone().map(|o| o.id()).collect(),
-            bundle_hashes: executed_orders
-                .filter_map(|o| o.external_bundle_hash())
-                .collect(),
+            order_ids,
+            bundle_hashes,
         };
 
         let latency = block.trace.orders_sealed_at - block.trace.orders_closed_at;

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -1,3 +1,5 @@
+use crate::telemetry::{add_gzip_compression_time, add_ssz_encoding_time};
+
 use super::utils::u256decimal_serde_helper;
 use alloy_primitives::{utils::parse_ether, Address, BlockHash, U256};
 use alloy_rpc_types_beacon::BlsPublicKey;
@@ -729,7 +731,11 @@ impl RelayClient {
         let mut builder = self.client.post(url.clone());
         // SSZ vs JSON
         let (mut body_data, content_type) = if ssz {
-            (submission.as_ssz_bytes(), SSZ_CONTENT_TYPE)
+            let ssz_start = std::time::Instant::now();
+            let encoded = submission.as_ssz_bytes();
+
+            add_ssz_encoding_time(ssz_start.elapsed());
+            (encoded, SSZ_CONTENT_TYPE)
         } else {
             let json_result = if fake_relay {
                 // For the fake relay we remove the blobs
@@ -751,13 +757,19 @@ impl RelayClient {
                 CONTENT_ENCODING,
                 HeaderValue::from_static(GZIP_CONTENT_ENCODING),
             );
-            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            let gzip_start = std::time::Instant::now();
+            // NOTE: Pre-allocate the buffer to avoid reallocations during compression.
+            // This should be more efficient even if we over-allocate (uncompressed > compressed)
+            let mut encoder =
+                GzEncoder::new(Vec::with_capacity(body_data.len()), Compression::default());
             encoder
                 .write_all(&body_data)
                 .map_err(|e| SubmitBlockErr::RPCSerializationError(e.to_string()))?;
             body_data = encoder
                 .finish()
                 .map_err(|e| SubmitBlockErr::RPCSerializationError(e.to_string()))?;
+
+            add_gzip_compression_time(gzip_start.elapsed());
         }
 
         // Set bloxroute specific headers.
@@ -1106,9 +1118,11 @@ mod tests {
         mode = 'slot_info'
         ";
 
-        std::env::set_var("XXX", "AAA");
-        std::env::set_var("YYY", "BBB");
-        std::env::set_var("ZZZ", "CCC");
+        unsafe {
+            std::env::set_var("XXX", "AAA");
+            std::env::set_var("YYY", "BBB");
+            std::env::set_var("ZZZ", "CCC");
+        }
 
         let config: RelayConfig = toml::from_str(example).unwrap();
         assert_eq!(config.name, "relay1");

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -234,14 +234,14 @@ register_metrics! {
     .unwrap();
 
     pub static SSZ_ENCODING_TIME: Histogram = Histogram::with_opts(
-        HistogramOpts::new("ssz_encoding_time", "Time to encode the block in SSZ (ms)")
+        HistogramOpts::new("payload_ssz_encoding_time", "Time to encode a full payload in SSZ (ms)")
             // Range: 100us - 100ms
             .buckets(exponential_buckets_range(0.1, 100.0, 20)),
     )
     .unwrap();
 
     pub static GZIP_COMPRESSION_TIME: Histogram = Histogram::with_opts(
-        HistogramOpts::new("gzip_compression_time", "Time to compress the block in GZIP (ms)")
+        HistogramOpts::new("payload_gzip_compression_time", "Time to compress a full payload in GZIP (ms)")
             // Range: 100us - 200ms
             .buckets(exponential_buckets_range(0.1, 200.0, 50)),
     )

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -21,8 +21,8 @@ use metrics_macros::register_metrics;
 use parking_lot::Mutex;
 use prometheus::{
     core::{Atomic, AtomicF64, AtomicI64, GenericGauge},
-    Counter, Gauge, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
-    Opts, Registry,
+    Counter, Gauge, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, Opts, Registry,
 };
 use rbuilder_primitives::mev_boost::MevBoostRelayID;
 use std::time::Duration;
@@ -230,6 +230,20 @@ register_metrics! {
         HistogramOpts::new("relay_submit_time", "Time to send bid to the relay (ms)")
             .buckets(exponential_buckets_range(0.5, 3000.0, 50)),
         &["relay"],
+    )
+    .unwrap();
+
+    pub static SSZ_ENCODING_TIME: Histogram = Histogram::with_opts(
+        HistogramOpts::new("ssz_encoding_time", "Time to encode the block in SSZ (ms)")
+            // Range: 100us - 100ms
+            .buckets(exponential_buckets_range(0.1, 100.0, 20)),
+    )
+    .unwrap();
+
+    pub static GZIP_COMPRESSION_TIME: Histogram = Histogram::with_opts(
+        HistogramOpts::new("gzip_compression_time", "Time to compress the block in GZIP (ms)")
+            // Range: 100us - 200ms
+            .buckets(exponential_buckets_range(0.1, 200.0, 50)),
     )
     .unwrap();
 
@@ -580,6 +594,14 @@ pub fn add_relay_submit_time(relay: &MevBoostRelayID, duration: Duration) {
     RELAY_SUBMIT_TIME
         .with_label_values(&[relay.as_str()])
         .observe(duration_ms(duration));
+}
+
+pub fn add_ssz_encoding_time(duration: Duration) {
+    SSZ_ENCODING_TIME.observe(duration_ms(duration));
+}
+
+pub fn add_gzip_compression_time(duration: Duration) {
+    GZIP_COMPRESSION_TIME.observe(duration_ms(duration));
 }
 
 const BIG_RPC_DATA_THRESHOLD: usize = 50000;


### PR DESCRIPTION
## 📝 Summary

- Adds histograms for SSZ encoding and GZIP compression times, for normal (non optimistic V3) payloads
- Some small optimizations:
    - Consolidate loops in hot path
    - Pre-allocate GZIP compression buffer

## 💡 Motivation and Context

We would like to understand how long these things take, and specifically if it wouldn't be better to disable gzip compression.

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
