### PR TITLE
distinguish non critical_sim_error

### DIFF
--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -466,15 +466,6 @@ fn submit_block_to_relays(
     }
 }
 
-/// This means we probably have a bug/problem.
-/// Move to table if this grows to more errors.
-fn is_critical_sim_error(error_text: &str) -> bool {
-    // We are not MEV Protect compatible yet
-    // Full example error: "Simulation Error: simulation failed: proposer MEV Protect is enabled for this slot duty but the block is invalid: expected ≥ 0.0072 ETH (ratio 90), got 0.0072 ETH (ratio 89): simulation failed: proposer MEV Protect is enabled for this slot duty but the block is invalid: expected ≥ 0.0072 ETH (ratio 90), got 0.0072 ETH (ratio 89). This block was accepted but may be rejected in the future. Please contact bloXroute to learn more about supporting MEV Protect feature."
-    !error_text
-        .contains("proposer MEV Protect is enabled for this slot duty but the block is invalid")
-}
-
 async fn submit_bid_to_the_relay(
     relay: &MevBoostRelayBidSubmitter,
     submit_block_request: SubmitBlockRequestWithMetadata,
@@ -526,10 +517,13 @@ async fn submit_bid_to_the_relay(
                 "Block not accepted by the relay"
             );
         }
-        Err(SubmitBlockErr::SimError(_)) => {
+        Err(SubmitBlockErr::SimError {
+            text: _,
+            is_critical,
+        }) => {
             let error_text = relay_result.as_ref().unwrap_err().to_string();
             // Avoid rasing alarms or errors logs for non critical errors.
-            if is_critical_sim_error(&error_text) {
+            if is_critical {
                 inc_failed_block_simulations();
                 store_error_event(
                     SIM_ERROR_CATEGORY,

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -466,6 +466,15 @@ fn submit_block_to_relays(
     }
 }
 
+/// This means we probably have a bug/problem.
+/// Move to table if this grows to more errors.
+fn is_critical_sim_error(error_text: &str) -> bool {
+    // We are not MEV Protect compatible yet
+    // Full example error: "Simulation Error: simulation failed: proposer MEV Protect is enabled for this slot duty but the block is invalid: expected ≥ 0.0072 ETH (ratio 90), got 0.0072 ETH (ratio 89): simulation failed: proposer MEV Protect is enabled for this slot duty but the block is invalid: expected ≥ 0.0072 ETH (ratio 90), got 0.0072 ETH (ratio 89). This block was accepted but may be rejected in the future. Please contact bloXroute to learn more about supporting MEV Protect feature."
+    !error_text
+        .contains("proposer MEV Protect is enabled for this slot duty but the block is invalid")
+}
+
 async fn submit_bid_to_the_relay(
     relay: &MevBoostRelayBidSubmitter,
     submit_block_request: SubmitBlockRequestWithMetadata,
@@ -518,16 +527,25 @@ async fn submit_bid_to_the_relay(
             );
         }
         Err(SubmitBlockErr::SimError(_)) => {
-            inc_failed_block_simulations();
-            store_error_event(
-                SIM_ERROR_CATEGORY,
-                relay_result.as_ref().unwrap_err().to_string().as_str(),
-                &submit_block_request.submission,
-            );
-            error!(
-                err = ?relay_result.unwrap_err(),
-                "Error block simulation fail, cancelling"
-            );
+            let error_text = relay_result.as_ref().unwrap_err().to_string();
+            // Avoid rasing alarms or errors logs for non critical errors.
+            if is_critical_sim_error(&error_text) {
+                inc_failed_block_simulations();
+                store_error_event(
+                    SIM_ERROR_CATEGORY,
+                    &error_text,
+                    &submit_block_request.submission,
+                );
+                error!(
+                    err = ?relay_result.unwrap_err(),
+                    "Error block simulation fail, cancelling"
+                );
+            } else {
+                warn!(
+                    err = ?relay_result.unwrap_err(),
+                    "Non critical block simulation failure, cancelling"
+                );
+            }
             cancel.cancel();
         }
         Err(SubmitBlockErr::RelayError(RelayError::TooManyRequests)) => {

--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -516,9 +516,18 @@ pub enum SubmitBlockErr {
     PayloadDelivered,
     #[error("Bid below floor")]
     BidBelowFloor,
-    #[cfg_attr(not(feature = "redact-sensitive"), error("Simulation Error: {0}"))]
-    #[cfg_attr(feature = "redact-sensitive", error("Simulation Error: [REDACTED]"))]
-    SimError(String),
+    // Simulation failed. We should stop block building.
+    // If the error is critical, we should raise an alarm.
+    // Example of non critical error: MEV Protect block. We know we don't comply so we should not continue building.
+    #[cfg_attr(
+        not(feature = "redact-sensitive"),
+        error("Simulation Error: {text} {is_critical}")
+    )]
+    #[cfg_attr(
+        feature = "redact-sensitive",
+        error("Simulation Error: [REDACTED] {is_critical}")
+    )]
+    SimError { text: String, is_critical: bool },
     #[error("RPC conversion Error")]
     /// RPC validates the submissions (eg: limit of txs) much more that our model.
     RPCConversionError(Error),
@@ -1048,6 +1057,15 @@ async fn map_response(response: Response) -> Result<(), SubmitBlockErr> {
     }
 }
 
+/// This means we probably have a bug/problem.
+/// Move to table if this grows to more errors.
+fn is_critical_sim_error(error_text: &str) -> bool {
+    // We are not MEV Protect compatible yet
+    // Full example error: "Simulation Error: simulation failed: proposer MEV Protect is enabled for this slot duty but the block is invalid: expected ≥ 0.0072 ETH (ratio 90), got 0.0072 ETH (ratio 89): simulation failed: proposer MEV Protect is enabled for this slot duty but the block is invalid: expected ≥ 0.0072 ETH (ratio 90), got 0.0072 ETH (ratio 89). This block was accepted but may be rejected in the future. Please contact bloXroute to learn more about supporting MEV Protect feature."
+    !error_text
+        .contains("proposer MEV Protect is enabled for this slot duty but the block is invalid")
+}
+
 fn map_relay_error_message(msg: &str, code: Option<u64>) -> SubmitBlockErr {
     match msg {
         "payload attributes not (yet) known" => SubmitBlockErr::PayloadAttributesNotKnown,
@@ -1063,7 +1081,10 @@ fn map_relay_error_message(msg: &str, code: Option<u64>) -> SubmitBlockErr {
             {
                 RelayError::InternalError.into()
             } else {
-                SubmitBlockErr::SimError(msg.to_string())
+                SubmitBlockErr::SimError {
+                    text: msg.to_string(),
+                    is_critical: is_critical_sim_error(msg),
+                }
             }
         }
         _ if msg.contains("request timeout hit") => RelayError::ConnectionError.into(),


### PR DESCRIPTION
## 📝 Summary

This PR avoids generating ERRORs and triggering alarms on MEV Protect errors.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
* [X] Cooked new year's eve dinner (anybody with more than 10 approved PRs is invited for dinner)
