### PR TITLE
Bidding service server part.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9566,6 +9566,7 @@ dependencies = [
 name = "rbuilder-operator"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "alloy-primitives 1.4.1",
  "alloy-rpc-types-beacon",
  "alloy-signer",
@@ -9601,6 +9602,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tonic 0.13.1",
  "tonic-build",

--- a/crates/rbuilder-operator/Cargo.toml
+++ b/crates/rbuilder-operator/Cargo.toml
@@ -82,6 +82,8 @@ clickhouse = { version = "0.14.0", features = ["time", "uuid", "native-tls"] }
 futures-util.workspace = true
 parking_lot.workspace = true
 lazy_static.workspace = true
+ahash.workspace = true
+tokio-stream = { version = "0.1", features = ["net"] }
 
 [build-dependencies]
 built = { version = "0.7.1", features = ["git2", "chrono"] }

--- a/crates/rbuilder-operator/src/bidding_service_wrapper/mod.rs
+++ b/crates/rbuilder-operator/src/bidding_service_wrapper/mod.rs
@@ -3,4 +3,5 @@ pub mod bidding_service;
 pub mod client;
 pub mod conversion;
 pub mod fast_streams;
+pub mod server;
 pub use bidding_service::*;

--- a/crates/rbuilder-operator/src/bidding_service_wrapper/server/bidding_service.rs
+++ b/crates/rbuilder-operator/src/bidding_service_wrapper/server/bidding_service.rs
@@ -1,0 +1,74 @@
+//! Main entry point for the bidding service.
+//! Just call run_bidding_service from main and it will create the server and run it.
+
+use std::path::Path;
+
+use crate::bidding_service_wrapper::{
+    bidding_service_server::BiddingServiceServer,
+    server::{
+        bidding_service_server_initializer::BiddingServiceServerInitializer,
+        bidding_service_with_reload::BiddingServiceFactory,
+    },
+    BidderVersionInfo,
+};
+
+use tokio::{
+    net::UnixListener,
+    select,
+    signal::{ctrl_c, unix::SignalKind},
+};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+pub async fn run_bidding_service(
+    ipc_path: String,
+    bidding_service_factory_factory: BiddingServiceFactory,
+    version_info: Option<BidderVersionInfo>,
+) -> eyre::Result<()> {
+    info!("Bidding service starting");
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+
+    tokio::spawn(async move {
+        select! {
+            _ = ctrl_c() => {
+            },
+            _ = term() => {
+            }
+        }
+        info!("Bidding service shutting down");
+        cancel_clone.cancel()
+    });
+    tokio::spawn(async move {
+        // Remove the socket file if it already exists
+        if Path::new(&ipc_path).exists() {
+            std::fs::remove_file(&ipc_path).unwrap();
+        }
+        let uds = UnixListener::bind(&ipc_path).unwrap();
+        let server = BiddingServiceServerInitializer::new(
+            Box::new(bidding_service_factory_factory),
+            cancel.clone(),
+            version_info,
+        );
+        tonic::transport::Server::builder()
+            .add_service(BiddingServiceServer::new(server))
+            .serve_with_incoming_shutdown(
+                tokio_stream::wrappers::UnixListenerStream::new(uds),
+                async {
+                    cancel.cancelled().await;
+                },
+            )
+            .await
+            .unwrap();
+    })
+    .await?;
+    Ok(())
+}
+
+/// Move this to some general place?
+async fn term() -> std::io::Result<()> {
+    tokio::signal::unix::signal(SignalKind::terminate())?
+        .recv()
+        .await;
+    Ok(())
+}

--- a/crates/rbuilder-operator/src/bidding_service_wrapper/server/bidding_service_server_adapter.rs
+++ b/crates/rbuilder-operator/src/bidding_service_wrapper/server/bidding_service_server_adapter.rs
@@ -1,0 +1,256 @@
+use std::{sync::Arc, thread};
+
+use crate::bidding_service_wrapper::{
+    conversion::rpc2real_landed_block_info,
+    fast_streams::{
+        helpers::{
+            create_blocks_service, create_got_scraped_bids_or_blocks_service, create_node_builder,
+            create_scraped_bids_service, LAST_ITEM_MAX_BUFFERS, SCRAPED_BIDS_MAX_BUFFERS,
+        },
+        subscriber_poller::SubscriberPoller,
+        types::{BuiltBlockDescriptorForSlotBidderRPC, ScrapedRelayBlockBidRPC},
+    },
+    CreateSlotBidderParams, DestroySlotBidderParams, Empty, LandedBlocksParams, MustWinBlockParams,
+};
+use iceoryx2::{port::listener::Listener, service::ipc};
+use parking_lot::Mutex;
+use rbuilder::utils::sync::{Watch, THREAD_BLOCKING_DURATION};
+
+use ahash::HashMap;
+use tokio_util::sync::CancellationToken;
+use tonic::{Request, Response, Status};
+use tracing::{error, info};
+
+use super::{
+    bidding_service_sync::BiddingServiceSync,
+    bidding_service_with_reload::BiddingServiceWithReload, slot_bidder_server::SlotBidderServer,
+};
+
+pub type SlotBidderId = u64;
+
+/// Server side implementation of bidding_service_server::BiddingService.
+/// Non bidding calls go directly to the BiddingService.
+/// Creates SlotBidderServer on create_slot_bidder and stores them on BiddingServiceServerInner::bidders and destroys them on destroy_slot_bidder.
+/// All bidding calls are handled by the associated SlotBidderServer.
+/// A thread is spawned to poll blocks and scraped bids (via iceoryx) from the builder and forwards them to the BiddingServiceServerInner.
+/// BiddingServiceServerInner will forward blocks to the associated SlotBidder and scraped bids to the BiddingService.
+pub struct BiddingServiceServerAdapter {
+    inner: Arc<Mutex<BiddingServiceServerInner>>,
+    cancellation_token: CancellationToken,
+}
+
+struct BiddingServiceServerInner {
+    service: Box<dyn BiddingServiceWithReload>,
+    bidders: HashMap<SlotBidderId, SlotBidderServer>,
+}
+
+impl BiddingServiceServerInner {
+    /// usage if the name of the calling func or the "reason" to get a bidder. Used to log on errors.
+    fn bidder(&self, slot_bidder_id: SlotBidderId, usage: &str) -> Option<&SlotBidderServer> {
+        if let Some(bidder) = self.bidders.get(&slot_bidder_id) {
+            Some(bidder)
+        } else {
+            error!(slot_bidder_id=?slot_bidder_id,usage,"No bidder found");
+            None
+        }
+    }
+
+    /// Forward to SlotBidderServer
+    pub fn new_block(&self, block_descriptor: BuiltBlockDescriptorForSlotBidderRPC) {
+        if let Some(bidder) = self.bidder(block_descriptor.session_id, "new_block") {
+            bidder.new_block(block_descriptor.into());
+        }
+    }
+
+    /// Forward to bidding_service
+    pub fn update_new_bid(&mut self, bid: ScrapedRelayBlockBidRPC) {
+        self.service
+            .bidding_service()
+            .observe_relay_bids(bid.into());
+    }
+}
+
+impl BiddingServiceServerAdapter {
+    pub fn new(
+        service: Box<dyn BiddingServiceWithReload>,
+        cancellation_token: CancellationToken,
+    ) -> Result<Self, crate::bidding_service_wrapper::fast_streams::helpers::Error> {
+        let cancellation_token = cancellation_token.child_token();
+        let inner = Arc::new(Mutex::new(BiddingServiceServerInner {
+            service,
+            bidders: Default::default(),
+        }));
+        spawn_scraped_bids_and_blocks_subscriber(inner.clone(), cancellation_token.clone())?;
+        Ok(Self {
+            inner,
+            cancellation_token,
+        })
+    }
+}
+
+impl Drop for BiddingServiceServerAdapter {
+    fn drop(&mut self) {
+        self.cancellation_token.cancel();
+    }
+}
+
+#[tonic::async_trait]
+impl BiddingServiceSync for BiddingServiceServerAdapter {
+    /// Creates a SlotBidderServer which will handle all bidding related calls (eg: new block, new competition bid) and will feed our bids into a channel.
+    /// Returns the callback stream containing the bids and any other state changes.
+    fn create_slot_bidder(
+        &self,
+        request: Request<CreateSlotBidderParams>,
+    ) -> Result<Response<Empty>, Status> {
+        let params = request.into_inner();
+        let mut inner = self.inner.lock();
+        match SlotBidderServer::new(inner.service.as_mut().bidding_service(), &params) {
+            Ok(slot_bidder_server) => {
+                let slot_bidder_id = params.session_id;
+                if inner
+                    .bidders
+                    .insert(slot_bidder_id, slot_bidder_server)
+                    .is_some()
+                {
+                    error!(slot_bidder_id = ?slot_bidder_id,"create_slot_bidder with already created bidder")
+                } else {
+                    info!(
+                        slot_bidder_id = ?slot_bidder_id,
+                        "SlotBidder created!"
+                    );
+                }
+            }
+            Err(err) => {
+                error!(err=?err,"create_slot_bidder SlotBidderServer::new err");
+                return Err(Status::invalid_argument(""));
+            }
+        }
+        Ok(Response::new(Empty {}))
+    }
+
+    fn destroy_slot_bidder(
+        &self,
+        request: Request<DestroySlotBidderParams>,
+    ) -> Result<Response<Empty>, Status> {
+        let params = request.into_inner();
+        let mut inner = self.inner.lock();
+        let slot_bidder_id = params.session_id;
+        if inner.bidders.remove(&slot_bidder_id).is_none() {
+            error!(slot_bidder_id = ?slot_bidder_id,"destroy_slot_bidder failed to remove")
+        } else {
+            info!(
+                slot_bidder_id = ?slot_bidder_id,
+                "SlotBidder destroyed"
+            );
+        }
+        Ok(Response::new(Empty {}))
+    }
+
+    /// Direct forwarding
+    fn must_win_block(
+        &self,
+        _request: Request<MustWinBlockParams>,
+    ) -> Result<Response<Empty>, Status> {
+        // this was removed because only NullWinControl was used here before
+        Ok(Response::new(Empty {}))
+    }
+
+    /// Direct forwarding
+    fn update_new_landed_blocks_detected(
+        &self,
+        request: Request<LandedBlocksParams>,
+    ) -> Result<Response<Empty>, Status> {
+        let params = request.into_inner();
+        let block_info: Result<Vec<_>, _> = params
+            .landed_block_info
+            .iter()
+            .map(rpc2real_landed_block_info)
+            .collect();
+        let block_info = block_info?;
+        self.inner
+            .lock()
+            .service
+            .bidding_service()
+            .update_new_landed_blocks_detected(&block_info);
+        Ok(Response::new(Empty {}))
+    }
+
+    /// Direct forwarding
+    fn update_failed_reading_new_landed_blocks(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<Empty>, Status> {
+        self.inner
+            .lock()
+            .service
+            .bidding_service()
+            .update_failed_reading_new_landed_blocks();
+        Ok(Response::new(Empty {}))
+    }
+
+    fn reload(&self) {
+        self.inner.lock().service.reload();
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn init_scraped_bids_and_blocks_subscriber() -> Result<
+    (
+        Listener<ipc::Service>,
+        SubscriberPoller<ScrapedRelayBlockBidRPC>,
+        SubscriberPoller<BuiltBlockDescriptorForSlotBidderRPC>,
+    ),
+    crate::bidding_service_wrapper::fast_streams::helpers::Error,
+> {
+    let node = create_node_builder()?;
+    let scraped_bids_service = create_scraped_bids_service(&node)?;
+    let scraped_bids_subscriber = SubscriberPoller::new(
+        scraped_bids_service,
+        SCRAPED_BIDS_MAX_BUFFERS,
+        "scraped_bids",
+    )?;
+    let blocks_service = create_blocks_service(&node)?;
+    let blocks_subscriber = SubscriberPoller::new(blocks_service, LAST_ITEM_MAX_BUFFERS, "blocks")?;
+    let got_scraped_bids_or_blocks = create_got_scraped_bids_or_blocks_service(&node)?;
+    let listener = got_scraped_bids_or_blocks.listener_builder().create()?;
+    Ok((listener, scraped_bids_subscriber, blocks_subscriber))
+}
+
+/// Spawns a thread that subscribes to the scraped bids and new blocks and forwards them to rpc_service.
+fn spawn_scraped_bids_and_blocks_subscriber(
+    inner: Arc<Mutex<BiddingServiceServerInner>>,
+    cancellation_token: CancellationToken,
+) -> Result<(), crate::bidding_service_wrapper::fast_streams::helpers::Error> {
+    let init_done = Arc::new(Watch::<
+        Result<(), crate::bidding_service_wrapper::fast_streams::helpers::Error>,
+    >::new());
+    let init_done_clone = init_done.clone();
+    thread::spawn(move || {
+        info!("Subscriber thread starting");
+        let (listener, mut scraped_bids_subscriber, mut blocks_subscriber) =
+            match init_scraped_bids_and_blocks_subscriber() {
+                Ok(res) => res,
+                Err(err) => {
+                    init_done.set(Err(err));
+                    return;
+                }
+            };
+        init_done.set(Ok(()));
+        while !cancellation_token.is_cancelled() {
+            if let Ok(Some(_event_id)) = listener.timed_wait_one(THREAD_BLOCKING_DURATION) {
+                if let Err(err) = scraped_bids_subscriber.poll(|sample| {
+                    inner.lock().update_new_bid(sample);
+                }) {
+                    error!(err=?err, "scraped_bids_subscriber poll failed.");
+                }
+                if let Err(err) = blocks_subscriber.poll(|sample| {
+                    inner.lock().new_block(sample);
+                }) {
+                    error!(err=?err, "blocks_subscriber poll failed.");
+                }
+            }
+        }
+        info!("Subscriber thread shutting down");
+    });
+    init_done_clone.wait_for_ever()
+}

--- a/crates/rbuilder-operator/src/bidding_service_wrapper/server/bidding_service_server_initializer.rs
+++ b/crates/rbuilder-operator/src/bidding_service_wrapper/server/bidding_service_server_initializer.rs
@@ -1,0 +1,183 @@
+use crate::bidding_service_wrapper::{
+    conversion::{real2rpc_relay_set, rpc2real_relay_set},
+    server::bidding_service_with_reload::BiddingServiceFactory,
+    BidderVersionInfo, InitParams, InitReturn,
+};
+use parking_lot::Mutex;
+use std::sync::Arc;
+use tokio::signal::unix::SignalKind;
+use tokio_util::sync::CancellationToken;
+use tonic::{Request, Response, Status};
+use tracing::{error, info};
+
+use super::{
+    bidding_service_server_adapter::BiddingServiceServerAdapter,
+    bidding_service_sync::BiddingServiceSync,
+    uninitialized_bidding_service::UninitializedBiddingService,
+};
+use crate::bidding_service_wrapper::{
+    bidding_service_server::BiddingService as RPCBiddingService,
+    conversion::rpc2real_landed_block_info, CreateSlotBidderParams, DestroySlotBidderParams, Empty,
+    LandedBlocksParams, MustWinBlockParams,
+};
+
+/// @Pending Consider more errors if they don't leak info.
+#[derive(thiserror::Error, Debug)]
+pub enum BiddingServiceFactoryError {
+    #[error("Unable create BiddingService")]
+    UnableToCreateBiddingService,
+    #[error("Error opening/parsing config file")]
+    UnableToParseConfigFile,
+    #[error("Error parsing best competition bid selector cfg")]
+    UnableToParseBestCompetitionBidSelectorCfg,
+}
+
+/// Handles initialization allowing reconnection.
+/// Removes async from the calls.
+/// Forwards to another RPCBiddingService.
+/// On creation the default RPCBiddingService is UninitializedBiddingService that justs traces errors since any call before initialize is unexpected.
+/// On initialize creates a new BiddingServiceServerAdapter via a factory stepping on the previous one.
+pub struct BiddingServiceServerInitializer {
+    rpc_service: Arc<Mutex<Arc<dyn BiddingServiceSync + Send + Sync>>>,
+    /// Option only to allow not having it on testing :(
+    factory: Option<BiddingServiceFactory>,
+    cancellation_token: CancellationToken,
+    version_info: Option<BidderVersionInfo>,
+}
+
+impl BiddingServiceServerInitializer {
+    pub fn new(
+        factory: BiddingServiceFactory,
+        cancellation_token: CancellationToken,
+        version_info: Option<BidderVersionInfo>,
+    ) -> Self {
+        let rpc_service: Arc<Mutex<Arc<dyn BiddingServiceSync + Send + Sync>>> =
+            Arc::new(Mutex::new(Arc::new(UninitializedBiddingService {})));
+        let rpc_service_clone = rpc_service.clone();
+        if let Ok(mut hangup) = tokio::signal::unix::signal(SignalKind::hangup()) {
+            tokio::spawn(async move {
+                info!("SIGHUP handler started");
+                loop {
+                    hangup.recv().await;
+                    rpc_service_clone.lock().reload();
+                }
+            });
+        } else {
+            error!("Failed to init SIGHUP handler, reload disabled");
+        };
+        Self {
+            cancellation_token,
+            rpc_service,
+            factory: Some(factory),
+            version_info,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_initialized(
+        service: Box<
+            dyn rbuilder::live_builder::block_output::bidding_service_interface::BiddingService,
+        >,
+    ) -> Self {
+        use crate::bidding_service_wrapper::server::bidding_service_with_reload::NotReloadingBiddingServiceWithReload;
+
+        Self {
+            rpc_service: Arc::new(Mutex::new(Arc::new(
+                BiddingServiceServerAdapter::new(
+                    Box::new(NotReloadingBiddingServiceWithReload::new(service)),
+                    CancellationToken::new(),
+                )
+                .unwrap(),
+            ))),
+            factory: None,
+            cancellation_token: CancellationToken::new(),
+            version_info: None,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl RPCBiddingService for BiddingServiceServerInitializer {
+    /// Call after connection before calling anything. This will really create the BiddingService on the server side.
+    async fn initialize(
+        &self,
+        request: tonic::Request<InitParams>,
+    ) -> Result<tonic::Response<InitReturn>, tonic::Status> {
+        let params = request.into_inner();
+        let landed_block_info = params
+            .landed_block_info
+            .iter()
+            .map(rpc2real_landed_block_info)
+            .collect::<Result<Vec<_>, tonic::Status>>()?;
+        let all_relay_ids = rpc2real_relay_set(
+            params
+                .all_relay_ids
+                .as_ref()
+                .ok_or(Status::invalid_argument("all_relay_ids is required"))?,
+        );
+        let mut relay_sets = vec![];
+        if let Some(factory) = &self.factory {
+            match factory(landed_block_info, all_relay_ids.relays()) {
+                Ok(mut new_bidding_service) => {
+                    relay_sets = new_bidding_service.bidding_service().relay_sets();
+                    let new_adapter = match BiddingServiceServerAdapter::new(
+                        new_bidding_service,
+                        self.cancellation_token.clone(),
+                    ) {
+                        Ok(new_adapter) => new_adapter,
+                        Err(err) => {
+                            return Err(Status::internal(err.to_string()));
+                        }
+                    };
+                    *self.rpc_service.lock() = Arc::new(new_adapter);
+                }
+                Err(err) => {
+                    return Err(Status::invalid_argument(err.to_string()));
+                }
+            }
+        }
+        Ok(Response::new(InitReturn {
+            bidder_version: self.version_info.clone(),
+            relay_sets: relay_sets.iter().map(real2rpc_relay_set).collect(),
+        }))
+    }
+
+    async fn create_slot_bidder(
+        &self,
+        request: Request<CreateSlotBidderParams>,
+    ) -> Result<Response<Empty>, Status> {
+        self.rpc_service.lock().create_slot_bidder(request)
+    }
+
+    async fn destroy_slot_bidder(
+        &self,
+        request: Request<DestroySlotBidderParams>,
+    ) -> Result<Response<Empty>, Status> {
+        self.rpc_service.lock().destroy_slot_bidder(request)
+    }
+
+    async fn must_win_block(
+        &self,
+        request: Request<MustWinBlockParams>,
+    ) -> Result<Response<Empty>, Status> {
+        self.rpc_service.lock().must_win_block(request)
+    }
+
+    async fn update_new_landed_blocks_detected(
+        &self,
+        request: Request<LandedBlocksParams>,
+    ) -> Result<Response<Empty>, Status> {
+        self.rpc_service
+            .lock()
+            .update_new_landed_blocks_detected(request)
+    }
+
+    async fn update_failed_reading_new_landed_blocks(
+        &self,
+        request: Request<Empty>,
+    ) -> Result<Response<Empty>, Status> {
+        self.rpc_service
+            .lock()
+            .update_failed_reading_new_landed_blocks(request)
+    }
+}

--- a/crates/rbuilder-operator/src/bidding_service_wrapper/server/bidding_service_sync.rs
+++ b/crates/rbuilder-operator/src/bidding_service_wrapper/server/bidding_service_sync.rs
@@ -1,0 +1,39 @@
+use tonic::{Request, Response, Status};
+
+use crate::bidding_service_wrapper::{
+    CreateSlotBidderParams, DestroySlotBidderParams, Empty, LandedBlocksParams, MustWinBlockParams,
+};
+
+/// Sync version of BiddingService to simplify things since our bidding is sync.
+/// As an extra it adds reload() to forward it to BiddingServiceWithReload::reload
+/// New blocks and new bids are not here since they are not transferred with gRPC calls.
+pub trait BiddingServiceSync: Send + Sync + 'static {
+    /// BiddingService
+    #[allow(clippy::result_large_err)]
+    fn create_slot_bidder(
+        &self,
+        request: Request<CreateSlotBidderParams>,
+    ) -> Result<Response<Empty>, Status>;
+    #[allow(clippy::result_large_err)]
+    fn destroy_slot_bidder(
+        &self,
+        request: Request<DestroySlotBidderParams>,
+    ) -> Result<Response<Empty>, Status>;
+    #[allow(clippy::result_large_err)]
+    fn must_win_block(
+        &self,
+        request: Request<MustWinBlockParams>,
+    ) -> Result<Response<Empty>, Status>;
+    #[allow(clippy::result_large_err)]
+    fn update_new_landed_blocks_detected(
+        &self,
+        request: Request<LandedBlocksParams>,
+    ) -> Result<Response<Empty>, Status>;
+    #[allow(clippy::result_large_err)]
+    fn update_failed_reading_new_landed_blocks(
+        &self,
+        request: Request<Empty>,
+    ) -> Result<Response<Empty>, Status>;
+
+    fn reload(&self);
+}

--- a/crates/rbuilder-operator/src/bidding_service_wrapper/server/bidding_service_with_reload.rs
+++ b/crates/rbuilder-operator/src/bidding_service_wrapper/server/bidding_service_with_reload.rs
@@ -1,0 +1,42 @@
+use rbuilder::live_builder::block_output::bidding_service_interface::{
+    BiddingService, LandedBlockInfo,
+};
+use rbuilder_primitives::mev_boost::MevBoostRelayID;
+
+use crate::bidding_service_wrapper::server::bidding_service_server_initializer::BiddingServiceFactoryError;
+
+/// Trait that encapsulates the ownership of a BiddingService + the ability to
+/// reload the cfg somehow.
+pub trait BiddingServiceWithReload: Send + Sync {
+    fn bidding_service(&mut self) -> &mut dyn BiddingService;
+    fn reload(&mut self);
+}
+
+/// Dummy implementation of BiddingServiceWithReload when reload is not available.
+pub struct NotReloadingBiddingServiceWithReload {
+    bidding_service: Box<dyn BiddingService>,
+}
+
+/// Dummy implementation of BiddingServiceWithReload when reload is not available.
+impl NotReloadingBiddingServiceWithReload {
+    pub fn new(bidding_service: Box<dyn BiddingService>) -> Self {
+        Self { bidding_service }
+    }
+}
+
+impl BiddingServiceWithReload for NotReloadingBiddingServiceWithReload {
+    fn bidding_service(&mut self) -> &mut dyn BiddingService {
+        self.bidding_service.as_mut()
+    }
+
+    fn reload(&mut self) {}
+}
+
+pub type BiddingServiceFactory = Box<
+    dyn Fn(
+            Vec<LandedBlockInfo>,
+            &[MevBoostRelayID],
+        ) -> Result<Box<dyn BiddingServiceWithReload>, BiddingServiceFactoryError>
+        + Send
+        + Sync,
+>;

--- a/crates/rbuilder-operator/src/bidding_service_wrapper/server/mod.rs
+++ b/crates/rbuilder-operator/src/bidding_service_wrapper/server/mod.rs
@@ -1,0 +1,7 @@
+pub mod bidding_service;
+pub mod bidding_service_server_adapter;
+pub mod bidding_service_server_initializer;
+mod bidding_service_sync;
+pub mod bidding_service_with_reload;
+pub mod slot_bidder_server;
+mod uninitialized_bidding_service;

--- a/crates/rbuilder-operator/src/bidding_service_wrapper/server/slot_bidder_server.rs
+++ b/crates/rbuilder-operator/src/bidding_service_wrapper/server/slot_bidder_server.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use rbuilder::live_builder::block_output::bidding_service_interface::{
+    BiddingService, BlockSealInterfaceForSlotBidder, BuiltBlockDescriptorForSlotBidder, SlotBidder,
+    SlotBidderSealBidCommand, SlotBlockId,
+};
+use tokio_util::sync::CancellationToken;
+use tonic::Status;
+
+use crate::bidding_service_wrapper::{
+    conversion::rpc2real_block_hash,
+    fast_streams::helpers::{
+        create_slot_bidder_seal_bid_command_publisher, SlotBidderSealBidCommandPublisher,
+    },
+    CreateSlotBidderParams,
+};
+
+/// Handler for calls for a specific SlotBidder.
+/// To handle bids generated from the SlotBidder we create a SlotBidderSealBidCommandPublisher that streams the bids via iceoryx.
+/// The SlotBidder gets as [BlockSealInterfaceForSlotBidder] a [BlockSealInterfaceForSlotBidderToPublisher] that forwards the bids to the publisher.
+pub struct SlotBidderServer {
+    bidder: Arc<dyn SlotBidder>,
+    cancel: CancellationToken,
+}
+
+#[derive(Debug)]
+struct BlockSealInterfaceForSlotBidderToPublisher {
+    session_id: u64,
+    publisher: SlotBidderSealBidCommandPublisher,
+}
+
+impl BlockSealInterfaceForSlotBidder for BlockSealInterfaceForSlotBidderToPublisher {
+    fn seal_bid(&self, bid: SlotBidderSealBidCommand) {
+        self.publisher.send((bid, self.session_id));
+    }
+}
+
+impl SlotBidderServer {
+    #[allow(clippy::result_large_err)]
+    pub fn new(
+        bidding_service: &mut dyn BiddingService,
+        params: &CreateSlotBidderParams,
+    ) -> Result<Self, Status> {
+        let slot_timestamp = time::OffsetDateTime::from_unix_timestamp(params.slot_timestamp)
+            .map_err(|_| Status::invalid_argument("slot_timestamp"))?;
+        let parent_block_hash = rpc2real_block_hash(&params.parent_hash)
+            .map_err(|_| Status::invalid_argument("parent_block_hash"))?;
+        let cancel = CancellationToken::new();
+        let publisher = match create_slot_bidder_seal_bid_command_publisher(
+            &bidding_service.relay_sets(),
+            cancel.clone(),
+        ) {
+            Ok(publisher) => publisher,
+            Err(err) => {
+                return Err(Status::internal(err.to_string()));
+            }
+        };
+        let bid_maker = Box::new(BlockSealInterfaceForSlotBidderToPublisher {
+            session_id: params.session_id,
+            publisher,
+        });
+        let bidder = bidding_service.create_slot_bidder(
+            SlotBlockId::new(params.slot, params.block, parent_block_hash),
+            slot_timestamp,
+            bid_maker,
+            cancel.clone(),
+        );
+        let res = Self { bidder, cancel };
+        Ok(res)
+    }
+
+    pub fn new_block(&self, block_descriptor: BuiltBlockDescriptorForSlotBidder) {
+        self.bidder.notify_new_built_block(block_descriptor);
+    }
+}
+
+impl Drop for SlotBidderServer {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}

--- a/crates/rbuilder-operator/src/bidding_service_wrapper/server/uninitialized_bidding_service.rs
+++ b/crates/rbuilder-operator/src/bidding_service_wrapper/server/uninitialized_bidding_service.rs
@@ -1,0 +1,70 @@
+use tonic::{Request, Response, Status};
+use tracing::{error, warn};
+
+use crate::bidding_service_wrapper::{
+    CreateSlotBidderParams, DestroySlotBidderParams, Empty, LandedBlocksParams, MustWinBlockParams,
+};
+
+use super::bidding_service_sync::BiddingServiceSync;
+
+/// Handler for all RPC calls made before calling init.
+/// It logs errors for every call.
+pub struct UninitializedBiddingService {}
+
+impl UninitializedBiddingService {
+    fn status_err() -> Status {
+        Status::aborted("initialize not called")
+    }
+    #[allow(clippy::result_large_err)]
+    fn trace_and_error(func_name: &str) -> Result<Response<Empty>, Status> {
+        Self::trace(func_name);
+        Err(Self::status_err())
+    }
+    fn trace(func_name: &str) {
+        error!(func_name, "Unexpected call before initialize");
+    }
+}
+
+#[tonic::async_trait]
+impl BiddingServiceSync for UninitializedBiddingService {
+    /// BiddingService
+    fn create_slot_bidder(
+        &self,
+        _request: Request<CreateSlotBidderParams>,
+    ) -> Result<Response<Empty>, Status> {
+        Self::trace("create_slot_bidder");
+        Err(Self::status_err())
+    }
+
+    fn destroy_slot_bidder(
+        &self,
+        _request: Request<DestroySlotBidderParams>,
+    ) -> Result<Response<Empty>, Status> {
+        Self::trace_and_error("destroy_slot_bidder")
+    }
+
+    fn must_win_block(
+        &self,
+        _request: Request<MustWinBlockParams>,
+    ) -> Result<Response<Empty>, Status> {
+        Self::trace_and_error("must_win_block")
+    }
+
+    fn update_new_landed_blocks_detected(
+        &self,
+        _request: Request<LandedBlocksParams>,
+    ) -> Result<Response<Empty>, tonic::Status> {
+        Self::trace_and_error("update_new_landed_blocks_detected")
+    }
+
+    fn update_failed_reading_new_landed_blocks(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<Empty>, Status> {
+        Self::trace_and_error("update_failed_reading_new_landed_blocks")
+    }
+
+    fn reload(&self) {
+        warn!("reload called with no builder connected");
+    }
+}

--- a/crates/rbuilder-operator/src/bin/tbv-bidding-service.rs
+++ b/crates/rbuilder-operator/src/bin/tbv-bidding-service.rs
@@ -1,0 +1,93 @@
+//!Simple bidding service using NewTrueBlockValueBiddingService.
+
+use std::env;
+
+use rbuilder::live_builder::{
+    block_output::{
+        bidding_service_interface::{LandedBlockInfo, RelaySet},
+        true_value_bidding_service::NewTrueBlockValueBiddingService,
+    },
+    config::{
+        parse_true_block_value_bidding_service_config, TrueBlockValueBiddingServiceConfigToml,
+    },
+};
+
+use rbuilder_config::{load_toml_config, EnvOrValue, LoggerConfig};
+use rbuilder_operator::{
+    bidding_service_wrapper::server::{
+        bidding_service::run_bidding_service,
+        bidding_service_server_initializer::BiddingServiceFactoryError,
+        bidding_service_with_reload::NotReloadingBiddingServiceWithReload,
+    },
+    build_info::rbuilder_version,
+};
+
+use rbuilder_primitives::mev_boost::MevBoostRelayID;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    pub ipc_path: String,
+    pub log_json: bool,
+    pub log_level: EnvOrValue<String>,
+    pub log_color: bool,
+    #[serde(flatten)]
+    pub true_block_value_bidding_service_config: TrueBlockValueBiddingServiceConfigToml,
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        println!("Man, it's not that hard. It's a single parameter: the config file name. Something like:\n{} /home/cool_user_name/some_dir_to_keep_things_nice/some_other_dir_since_im_OCD/another_one/why_are_you_stil_reading_this_question_mark/stop_reading_and_fix_your_command_line/config_file.toml",args[0]);
+        return Ok(());
+    }
+    let config = load_toml_config::<Config>(args[1].clone())?;
+
+    let log_config = LoggerConfig {
+        env_filter: config.log_level.value()?,
+        log_json: config.log_json,
+        log_color: config.log_color,
+    };
+    log_config.init_tracing()?;
+
+    let parsed_config = parse_true_block_value_bidding_service_config(
+        &config.true_block_value_bidding_service_config,
+    )?;
+    let bidding_service_factory_factory = move |_landed_block_info: Vec<LandedBlockInfo>,all_relays: &[MevBoostRelayID]|
+              -> Result<
+            Box<dyn rbuilder_operator::bidding_service_wrapper::server::bidding_service_with_reload::BiddingServiceWithReload>,
+            BiddingServiceFactoryError,
+        > {
+            let bidding_service = NewTrueBlockValueBiddingService::new(&parsed_config, RelaySet::new(all_relays.to_vec())).
+                map_err(|_| BiddingServiceFactoryError::UnableToCreateBiddingService)?;
+            Ok(Box::new(NotReloadingBiddingServiceWithReload::new(Box::new(bidding_service))))
+        };
+    let version = rbuilder_version();
+    let version_info = rbuilder_operator::bidding_service_wrapper::BidderVersionInfo {
+        git_commit: version.git_commit,
+        git_ref: version.git_ref,
+        build_time_utc: version.build_time_utc,
+    };
+    run_bidding_service(
+        config.ipc_path.clone(),
+        Box::new(bidding_service_factory_factory),
+        Some(version_info),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod test {
+    use crate::Config;
+    use rbuilder_config::load_toml_config;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_parse_config() {
+        let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        p.push("../../examples/config/rbuilder/config-tbv-bidding-service.toml");
+        let _ = load_toml_config::<Config>(p).expect("Config load");
+    }
+}

--- a/crates/rbuilder/src/live_builder/block_output/true_value_bidding_service.rs
+++ b/crates/rbuilder/src/live_builder/block_output/true_value_bidding_service.rs
@@ -7,6 +7,17 @@ use tokio_util::sync::CancellationToken;
 
 use super::bidding_service_interface::*;
 
+/// Parsed configuration for TrueBlockValueBiddingService.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TrueBlockValueBiddingServiceConfig {
+    /// Default subsidy value.
+    pub subsidy: U256,
+    /// Per-relay subsidy overrides.
+    pub subsidy_overrides: HashMap<MevBoostRelayID, U256>,
+    /// When the sample bidder will start bidding.
+    pub slot_delta_to_start_bidding: time::Duration,
+}
+
 /// Bidding service that bids the true block value + subsidy to all relays.
 pub struct NewTrueBlockValueBiddingService {
     slot_delta_to_start_bidding: time::Duration,
@@ -15,29 +26,28 @@ pub struct NewTrueBlockValueBiddingService {
 
 impl NewTrueBlockValueBiddingService {
     pub fn new(
-        subsidy: U256,
-        subsidy_overrides: HashMap<MevBoostRelayID, U256>,
-        slot_delta_to_start_bidding: time::Duration,
+        config: &TrueBlockValueBiddingServiceConfig,
         all_relays: RelaySet,
-    ) -> Self {
+    ) -> eyre::Result<Self> {
         let mut default_relay_set: HashSet<MevBoostRelayID> =
             all_relays.relays().iter().cloned().collect();
         let mut relay_sets_subsidies = HashMap::default();
-        for (relay, subsidy) in subsidy_overrides {
+
+        for (relay, subsidy) in config.subsidy_overrides.clone() {
             default_relay_set.remove(&relay);
             relay_sets_subsidies.insert(RelaySet::new(vec![relay]), subsidy);
         }
         if !default_relay_set.is_empty() {
             relay_sets_subsidies.insert(
                 RelaySet::new(default_relay_set.into_iter().collect()),
-                subsidy,
+                config.subsidy,
             );
         }
 
-        Self {
-            slot_delta_to_start_bidding,
+        Ok(Self {
+            slot_delta_to_start_bidding: config.slot_delta_to_start_bidding,
             relay_sets_subsidies,
-        }
+        })
     }
 }
 

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -115,6 +115,20 @@ pub struct SubsidyConfig {
     pub value: String,
 }
 
+/// TOML configuration for TrueBlockValueBiddingService (deserializable from config files).
+#[derive(Debug, Clone, Deserialize, PartialEq, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct TrueBlockValueBiddingServiceConfigToml {
+    /// When the sample bidder (see TrueBlockValueBiddingService) will start bidding.
+    /// Usually a negative number.
+    pub slot_delta_to_start_bidding_ms: Option<i64>,
+    /// Value added to the bids (see TrueBlockValueBiddingService).
+    pub subsidy: Option<String>,
+    /// Overrides subsidy.
+    #[serde(default)]
+    pub subsidy_overrides: Vec<SubsidyConfig>,
+}
+
 #[serde_as]
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(default, deny_unknown_fields)]
@@ -128,17 +142,46 @@ pub struct Config {
     /// selected builder configurations
     pub builders: Vec<BuilderConfig>,
 
-    /// When the sample bidder (see TrueBlockValueBiddingService) will start bidding.
-    /// Usually a negative number.
-    pub slot_delta_to_start_bidding_ms: Option<i64>,
-    /// Value added to the bids (see TrueBlockValueBiddingService).
-    pub subsidy: Option<String>,
-    /// Overrides subsidy.
-    #[serde(default)]
-    pub subsidy_overrides: Vec<SubsidyConfig>,
+    #[serde(flatten)]
+    pub true_block_value_bidding_service_config: TrueBlockValueBiddingServiceConfigToml,
 }
 
 const DEFAULT_SLOT_DELTA_TO_START_BIDDING_MS: i64 = -8000;
+
+/// Parse TrueBlockValueBiddingServiceConfigToml into TrueBlockValueBiddingServiceConfig.
+/// This function converts the TOML config fields (Option<String> subsidy, Vec<SubsidyConfig>, Option<i64>)
+/// into the parsed types (U256, HashMap<MevBoostRelayID, U256>, Duration).
+pub fn parse_true_block_value_bidding_service_config(
+    config: &TrueBlockValueBiddingServiceConfigToml,
+) -> eyre::Result<super::block_output::true_value_bidding_service::TrueBlockValueBiddingServiceConfig>
+{
+    use super::block_output::true_value_bidding_service::TrueBlockValueBiddingServiceConfig;
+    let slot_delta_to_start_bidding = time::Duration::milliseconds(
+        config
+            .slot_delta_to_start_bidding_ms
+            .unwrap_or(DEFAULT_SLOT_DELTA_TO_START_BIDDING_MS),
+    );
+
+    let mut subsidy_overrides = HashMap::default();
+    for subsidy_override in config.subsidy_overrides.iter() {
+        subsidy_overrides.insert(
+            subsidy_override.relay.clone(),
+            parse_ether(&subsidy_override.value)?,
+        );
+    }
+
+    let subsidy = config
+        .subsidy
+        .as_ref()
+        .map(|s| parse_ether(s))
+        .unwrap_or(Ok(U256::ZERO))?;
+
+    Ok(TrueBlockValueBiddingServiceConfig {
+        subsidy,
+        subsidy_overrides,
+        slot_delta_to_start_bidding,
+    })
+}
 const DEFAULT_REGISTRATION_UPDATE_INTERVAL_MS: u64 = 5_000;
 const DEFAULT_ASK_FOR_FILTERING_VALIDATORS: bool = false;
 const DEFAULT_CAN_IGNORE_GAS_LIMIT: bool = false;
@@ -455,29 +498,14 @@ impl LiveBuilderConfig for Config {
     where
         P: StateProviderFactory + Clone + 'static,
     {
-        let subsidy = self.subsidy.clone();
-        let slot_delta_to_start_bidding_ms = time::Duration::milliseconds(
-            self.slot_delta_to_start_bidding_ms
-                .unwrap_or(DEFAULT_SLOT_DELTA_TO_START_BIDDING_MS),
-        );
-
+        let parsed_config = parse_true_block_value_bidding_service_config(
+            &self.true_block_value_bidding_service_config,
+        )?;
         let all_relays_set = self.l1_config.relays_ids();
-        let mut subsidy_overrides = HashMap::default();
-        for subsidy_override in self.subsidy_overrides.iter() {
-            subsidy_overrides.insert(
-                subsidy_override.relay.clone(),
-                parse_ether(&subsidy_override.value)?,
-            );
-        }
         let bidding_service = Arc::new(NewTrueBlockValueBiddingService::new(
-            subsidy
-                .as_ref()
-                .map(|s| parse_ether(s))
-                .unwrap_or(Ok(U256::ZERO))?,
-            subsidy_overrides,
-            slot_delta_to_start_bidding_ms,
+            &parsed_config,
             all_relays_set.clone(),
-        ));
+        )?);
 
         let (wallet_balance_watcher, _) =
             create_wallet_balance_watcher(provider.clone(), &self.base_config).await?;
@@ -695,9 +723,8 @@ impl Default for Config {
                     }),
                 },
             ],
-            slot_delta_to_start_bidding_ms: None,
-            subsidy: None,
-            subsidy_overrides: Vec::new(),
+            true_block_value_bidding_service_config:
+                TrueBlockValueBiddingServiceConfigToml::default(),
         }
     }
 }

--- a/examples/config/rbuilder/config-tbv-bidding-service.toml
+++ b/examples/config/rbuilder/config-tbv-bidding-service.toml
@@ -1,0 +1,10 @@
+ipc_path = "/tmp/rpc_bidding_server.sock"
+log_json = true
+log_level = "info"
+log_color = false
+slot_delta_to_start_bidding_ms = -1000
+subsidy  = "0.01"
+
+[[subsidy_overrides]]
+relay = "flashbots" 
+value = "0.05"


### PR DESCRIPTION
## 📝 Summary

So far we only had published the client part of the protocol to handle remote bidding, now we have also the server side.
A sample bidding service (crates/rbuilder-operator/src/bin/tbv-bidding-service.rs) is provided using the TBV bidder.


## 💡 Motivation and Context

This will allow better Buildernet testing.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
