### PR TITLE
New tool to monitor reth DB

### DIFF
--- a/crates/rbuilder/src/bin/reth-db-monitor.rs
+++ b/crates/rbuilder/src/bin/reth-db-monitor.rs
@@ -1,0 +1,184 @@
+//! `reth-db-monitor` - Monitor reth database for block changes
+//!
+//! This tool connects to a reth database and periodically checks for new blocks,
+//! logging changes when they occur.
+//!
+//! Usage:
+//!   `cargo run --bin reth-db-monitor -- --config <path-to-rbuilder-config>`
+//!   `cargo run --bin reth-db-monitor -- --reth-path <path-to-reth-datadir> --chain mainnet`
+
+use alloy_primitives::BlockHash;
+use clap::Parser;
+use eyre::Context;
+use rbuilder::{
+    live_builder::{
+        base_config::{create_provider_factory, BaseConfig},
+        get_last_blocks,
+    },
+    provider::StateProviderFactory,
+    utils::ProviderFactoryReopener,
+};
+use reth::chainspec::chain_value_parser;
+use reth_db::DatabaseEnv;
+use reth_node_api::NodeTypesWithDBAdapter;
+use reth_node_ethereum::EthereumNode;
+use serde::Deserialize;
+use std::{fs, path::PathBuf, sync::Arc, time::Duration};
+use tokio::time;
+use tracing::info;
+
+#[derive(Debug, Clone, Parser)]
+#[clap(
+    name = "reth-db-monitor",
+    about = "Monitor reth database for block changes",
+    long_about = "Monitor reth database for block changes.\n\n\
+                  Usage modes:\n  \
+                  1. Using rbuilder config: --config <path>\n  \
+                  2. Using reth data dir:   --reth-path <path> [--chain <chain>]"
+)]
+struct Cli {
+    /// Path to the rbuilder config file
+    #[arg(long, conflicts_with_all = ["reth_path", "chain"])]
+    config: Option<PathBuf>,
+
+    /// Path to reth's data directory
+    #[arg(long)]
+    reth_path: Option<PathBuf>,
+
+    /// Chain name (e.g., mainnet, sepolia, holesky)
+    #[arg(long, default_value = "mainnet")]
+    chain: String,
+
+    /// Polling interval in milliseconds
+    #[arg(long, default_value = "500")]
+    interval_ms: u64,
+}
+
+impl Cli {
+    fn validate(&self) -> eyre::Result<()> {
+        if self.config.is_none() && self.reth_path.is_none() {
+            eyre::bail!(
+                "Either --config or --reth-path must be provided.\n\n\
+                 Usage modes:\n  \
+                 1. Using rbuilder config: --config <path>\n  \
+                 2. Using reth data dir:   --reth-path <path> [--chain <chain>]\n\n\
+                 Run with --help for more information."
+            );
+        }
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    let cli = Cli::parse();
+
+    // Validate CLI arguments
+    cli.validate()?;
+
+    // Setup basic logging
+    setup_logging();
+
+    info!(interval_ms = cli.interval_ms, "Starting reth-db-monitor");
+
+    // Create provider based on CLI arguments
+    let provider = if let Some(config_path) = &cli.config {
+        info!(?config_path, "Loading rbuilder config");
+        create_provider_from_config(config_path.clone()).await?
+    } else {
+        // Validation ensures reth_path is present
+        let reth_path = cli.reth_path.as_ref().unwrap();
+        info!(?reth_path, chain = cli.chain, "Opening reth database");
+        create_provider_from_reth_path(reth_path.clone(), &cli.chain)?
+    };
+
+    info!("Database connection established");
+
+    // Start monitoring loop
+    monitor_blocks(provider, Duration::from_millis(cli.interval_ms)).await?;
+
+    Ok(())
+}
+
+/// Setup basic logging to stdout
+fn setup_logging() {
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(env_filter)
+        .init();
+}
+
+/// Dummy cfg containing only the base config.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ConfigWithBaseConfig {
+    #[serde(flatten)]
+    pub base_config: BaseConfig,
+}
+
+/// Create provider from any config file that contains BaseConfig fields
+/// Works with rbuilder, rbuilder-operator, or any config with flattened BaseConfig
+async fn create_provider_from_config(
+    config_path: PathBuf,
+) -> eyre::Result<ProviderFactoryReopener<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>> {
+    // Read and parse the config file as BaseConfig
+    // This works because BaseConfig uses #[serde(flatten)] in the parent configs
+    let config_str = fs::read_to_string(&config_path)
+        .with_context(|| format!("Failed to read config file: {:?}", config_path))?;
+
+    let config: ConfigWithBaseConfig = toml::from_str(&config_str).with_context(|| {
+        format!(
+            "Failed to parse config file as BaseConfig: {:?}",
+            config_path
+        )
+    })?;
+
+    // We don't need root hash computation for monitoring, so we pass true to skip it
+    let provider = config
+        .base_config
+        .create_reth_provider_factory(true) // skip_root_hash = true
+        .context("Failed to create provider from config")?;
+
+    Ok(provider)
+}
+
+/// Create provider from reth path and chain name
+fn create_provider_from_reth_path(
+    reth_path: PathBuf,
+    chain: &str,
+) -> eyre::Result<ProviderFactoryReopener<NodeTypesWithDBAdapter<EthereumNode, Arc<DatabaseEnv>>>> {
+    let chain_spec = chain_value_parser(chain).context("Failed to parse chain name")?;
+
+    // We don't need root hash computation for monitoring, so we pass None
+    let provider = create_provider_factory(
+        Some(&reth_path),
+        None,
+        None,
+        chain_spec,
+        false, // read-only
+        None,  // no root hash
+    )
+    .context("Failed to create provider from reth path")?;
+
+    Ok(provider)
+}
+
+/// Monitor blocks and log when they change
+async fn monitor_blocks(
+    provider: impl StateProviderFactory,
+    interval: Duration,
+) -> eyre::Result<()> {
+    let mut last_blocks: Vec<(u64, Option<BlockHash>)> = Vec::new();
+    let mut interval_ticker = time::interval(interval);
+
+    loop {
+        interval_ticker.tick().await;
+        let current_blocks = get_last_blocks(&provider).await;
+        // Only log if blocks have changed
+        if current_blocks != last_blocks {
+            info!(?current_blocks, "New blocks");
+            last_blocks = current_blocks;
+        }
+    }
+}

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     },
 };
 use alloy_consensus::Header;
-use alloy_primitives::B256;
+use alloy_primitives::{BlockHash, B256};
 use block_list_provider::BlockListProvider;
 use block_output::unfinished_block_processing::UnfinishedBuiltBlocksInputFactory;
 use building::BlockBuildingPool;
@@ -288,7 +288,10 @@ where
                 {
                     Ok(header) => header,
                     Err(err) => {
-                        warn!(payload_id = payload.payload_id, parent_hash = ?payload.parent_block_hash(), ?err, "Failed to get parent header for new slot");
+                        let last_blocks = get_last_blocks(&self.provider).await;
+                        let blocks_count_behind =
+                            payload.block() - last_blocks.first().unwrap_or(&(0, None)).0;
+                        warn!(payload_id = payload.payload_id, parent_hash = ?payload.parent_block_hash(), ?last_blocks, blocks_count_behind, ?err, "Failed to get parent header for new slot");
                         continue;
                     }
                 }
@@ -400,6 +403,42 @@ where
             TimingsConfig::ethereum()
         }
     }
+}
+
+/// We bring 10 blocks since that's more than enough to see the evolution of the chain.
+/// We could probably be ok even with only the last block.
+const LAST_BLOCKS_COUNT: usize = 10;
+/// Get the last blocks in decreasing order for debugging purposes.
+/// Returns a vector of tuples (block_number, header_hash) for available blocks.
+/// On error returns empty.
+pub async fn get_last_blocks<P>(provider: &P) -> Vec<(u64, Option<BlockHash>)>
+where
+    P: StateProviderFactory,
+{
+    let mut result = Vec::new();
+
+    // Get the last block number
+    let last_block_num = match provider.last_block_number() {
+        Ok(num) => num,
+        Err(err) => {
+            warn!(?err, "Failed to get last block number");
+            return result;
+        }
+    };
+
+    // Get the last headers going backwards from the last block
+    for i in 0..LAST_BLOCKS_COUNT {
+        let block_num = last_block_num.saturating_sub(i as u64);
+        let header_hash = provider
+            .header_by_number(block_num)
+            .ok()
+            .flatten()
+            .map(|h| h.hash_slow());
+
+        result.push((block_num, header_hash));
+    }
+
+    result
 }
 
 /// May fail if we wait too much (see [BLOCK_HEADER_DEAD_LINE_DELTA])


### PR DESCRIPTION
## 📝 Summary

This PR addes a new tool reth-db-monitor that allows to monitor the evolution of reth's DB last blocks.
Now rbuilder logs the last blocks when it can't find the parent needed to make a new block as instructed by the CL.

## 💡 Motivation and Context

It's common to have this kind of problems where you don't know if rbuilder is failing or reth DB is not up to date.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
