### PR TITLE
feat: update both optimistic submission methods to use adjustment data v3

### DIFF
--- a/crates/rbuilder-primitives/src/mev_boost/adjustment.rs
+++ b/crates/rbuilder-primitives/src/mev_boost/adjustment.rs
@@ -1,46 +1,5 @@
 use alloy_primitives::{Address, Bloom, Bytes, B256};
 
-/// The type representing UltraSound bid adjustments.
-#[derive(
-    PartialEq,
-    Eq,
-    Clone,
-    Debug,
-    serde::Serialize,
-    serde::Deserialize,
-    ssz_derive::Encode,
-    ssz_derive::Decode,
-)]
-pub struct BidAdjustmentDataV1 {
-    /// State root of the payload.
-    pub state_root: B256,
-    /// Transactions root of the payload.
-    pub transactions_root: B256,
-    /// Receipts root of the payload.
-    pub receipts_root: B256,
-    /// The usual builder address that pays the proposer in the last transaction of the block.
-    /// When we adjust a bid, this transaction is overwritten by a transaction from the collateral
-    /// account `fee_payer_address`. If we don't adjust the bid, `builder_address` pays the
-    /// proposer as per usual.
-    pub builder_address: Address,
-    /// The state proof for the builder account.
-    pub builder_proof: Vec<Bytes>,
-    /// The proposer's fee recipient.
-    pub fee_recipient_address: Address,
-    /// The state proof for the fee recipient account.
-    pub fee_recipient_proof: Vec<Bytes>,
-    /// The fee payer address that is custodied by the relay.
-    pub fee_payer_address: Address,
-    /// The state proof for the fee payer account.
-    pub fee_payer_proof: Vec<Bytes>,
-    /// The merkle proof for the last transaction in the block, which will be overwritten with a
-    /// payment from `fee_payer` to `fee_recipient` if we adjust the bid.
-    pub placeholder_transaction_proof: Vec<Bytes>,
-    /// The merkle proof for the receipt of the placeholder transaction. It's required for
-    /// adjusting payments to contract addresses.
-    pub placeholder_receipt_proof: Vec<Bytes>,
-}
-
 /// The type for bid adjustments in optimistic v3.
 /// Ref: <https://github.com/ultrasoundmoney/docs/blob/main/optimistic-v3.md#optimistic-v3>
 #[derive(
@@ -76,81 +35,16 @@ pub struct BidAdjustmentDataV3 {
     /// The merkle proof for the last transaction in the block, which will be overwritten with a
     /// payment from `fee_payer` to `fee_recipient` if we adjust the bid.
     pub el_placeholder_transaction_proof: Vec<Bytes>,
-    /// New in V2: SSZ merkle proof for last transaction
+    /// SSZ merkle proof for last transaction
     pub cl_placeholder_transaction_proof: Vec<B256>,
     /// The merkle proof for the receipt of the placeholder transaction. It's required for
     /// adjusting payments to contract addresses.
     pub el_placeholder_receipt_proof: Vec<Bytes>,
-    /// New in V2: Logs bloom accrued until but not including the last (payment) transaction.
+    /// Logs bloom accrued until but not including the last (payment) transaction.
     pub pre_payment_logs_bloom: Bloom,
     /// Gas used by the placeholder (payout) transaction. Required for V3 to relax the
     /// gas_limit == gas_used requirement.
     pub placeholder_gas_used: u64,
-}
-
-/// Common bid adjustment information that can be used for creating bid adjustment data.
-#[derive(Clone, Debug)]
-pub struct BidAdjustmentData {
-    /// State root of the payload.
-    pub state_root: B256,
-    /// Transactions root of the payload.
-    pub el_transactions_root: B256,
-    /// Withdrawals root of the payload.
-    pub el_withdrawals_root: B256,
-    /// Receipts root of the payload.
-    pub receipts_root: B256,
-    /// The merkle proof for the last transaction in the block, which will be overwritten with a
-    /// payment from `fee_payer` to `fee_recipient` if we adjust the bid.
-    pub el_placeholder_transaction_proof: Vec<Bytes>,
-    /// New in V2: SSZ merkle proof for last transaction
-    pub cl_placeholder_transaction_proof: Vec<B256>,
-    /// The merkle proof for the receipt of the placeholder transaction. It's required for
-    /// adjusting payments to contract addresses.
-    pub placeholder_receipt_proof: Vec<Bytes>,
-    /// New in V2: Logs bloom accrued until but not including the last (payment) transaction.
-    pub pre_payment_logs_bloom: Bloom,
-    /// Gas used by the placeholder (payout) transaction.
-    pub placeholder_gas_used: u64,
-    /// State proofs.
-    pub state_proofs: BidAdjustmentStateProofs,
-}
-
-impl BidAdjustmentData {
-    /// Convert bid adjustment data into [`BidAdjustmentDataV1`].
-    pub fn into_v1(self) -> BidAdjustmentDataV1 {
-        BidAdjustmentDataV1 {
-            state_root: self.state_root,
-            transactions_root: self.el_transactions_root,
-            receipts_root: self.receipts_root,
-            builder_address: self.state_proofs.builder_address,
-            builder_proof: self.state_proofs.builder_proof,
-            fee_recipient_address: self.state_proofs.fee_recipient_address,
-            fee_recipient_proof: self.state_proofs.fee_recipient_proof,
-            fee_payer_address: self.state_proofs.fee_payer_address,
-            fee_payer_proof: self.state_proofs.fee_payer_proof,
-            placeholder_transaction_proof: self.el_placeholder_transaction_proof,
-            placeholder_receipt_proof: self.placeholder_receipt_proof,
-        }
-    }
-
-    /// Convert bid adjustment data into [`BidAdjustmentDataV3`].
-    pub fn into_v3(self) -> BidAdjustmentDataV3 {
-        BidAdjustmentDataV3 {
-            el_transactions_root: self.el_transactions_root,
-            el_withdrawals_root: self.el_withdrawals_root,
-            builder_address: self.state_proofs.builder_address,
-            builder_proof: self.state_proofs.builder_proof,
-            fee_recipient_address: self.state_proofs.fee_recipient_address,
-            fee_recipient_proof: self.state_proofs.fee_recipient_proof,
-            fee_payer_address: self.state_proofs.fee_payer_address,
-            fee_payer_proof: self.state_proofs.fee_payer_proof,
-            el_placeholder_transaction_proof: self.el_placeholder_transaction_proof,
-            cl_placeholder_transaction_proof: self.cl_placeholder_transaction_proof,
-            el_placeholder_receipt_proof: self.placeholder_receipt_proof,
-            pre_payment_logs_bloom: self.pre_payment_logs_bloom,
-            placeholder_gas_used: self.placeholder_gas_used,
-        }
-    }
 }
 
 /// Bid adjustment state proofs.

--- a/crates/rbuilder-primitives/src/mev_boost/adjustment.rs
+++ b/crates/rbuilder-primitives/src/mev_boost/adjustment.rs
@@ -53,7 +53,7 @@ pub struct BidAdjustmentDataV1 {
     ssz_derive::Encode,
     ssz_derive::Decode,
 )]
-pub struct BidAdjustmentDataV2 {
+pub struct BidAdjustmentDataV3 {
     /// Transactions root of the payload.
     pub el_transactions_root: B256,
     /// Withdrawals root of the payload.
@@ -80,9 +80,12 @@ pub struct BidAdjustmentDataV2 {
     pub cl_placeholder_transaction_proof: Vec<B256>,
     /// The merkle proof for the receipt of the placeholder transaction. It's required for
     /// adjusting payments to contract addresses.
-    pub placeholder_receipt_proof: Vec<Bytes>,
+    pub el_placeholder_receipt_proof: Vec<Bytes>,
     /// New in V2: Logs bloom accrued until but not including the last (payment) transaction.
     pub pre_payment_logs_bloom: Bloom,
+    /// Gas used by the placeholder (payout) transaction. Required for V3 to relax the
+    /// gas_limit == gas_used requirement.
+    pub placeholder_gas_used: u64,
 }
 
 /// Common bid adjustment information that can be used for creating bid adjustment data.
@@ -106,6 +109,8 @@ pub struct BidAdjustmentData {
     pub placeholder_receipt_proof: Vec<Bytes>,
     /// New in V2: Logs bloom accrued until but not including the last (payment) transaction.
     pub pre_payment_logs_bloom: Bloom,
+    /// Gas used by the placeholder (payout) transaction.
+    pub placeholder_gas_used: u64,
     /// State proofs.
     pub state_proofs: BidAdjustmentStateProofs,
 }
@@ -128,9 +133,9 @@ impl BidAdjustmentData {
         }
     }
 
-    /// Convert bid adjustment data into [`BidAdjustmentDataV2`].
-    pub fn into_v2(self) -> BidAdjustmentDataV2 {
-        BidAdjustmentDataV2 {
+    /// Convert bid adjustment data into [`BidAdjustmentDataV3`].
+    pub fn into_v3(self) -> BidAdjustmentDataV3 {
+        BidAdjustmentDataV3 {
             el_transactions_root: self.el_transactions_root,
             el_withdrawals_root: self.el_withdrawals_root,
             builder_address: self.state_proofs.builder_address,
@@ -141,8 +146,9 @@ impl BidAdjustmentData {
             fee_payer_proof: self.state_proofs.fee_payer_proof,
             el_placeholder_transaction_proof: self.el_placeholder_transaction_proof,
             cl_placeholder_transaction_proof: self.cl_placeholder_transaction_proof,
-            placeholder_receipt_proof: self.placeholder_receipt_proof,
+            el_placeholder_receipt_proof: self.placeholder_receipt_proof,
             pre_payment_logs_bloom: self.pre_payment_logs_bloom,
+            placeholder_gas_used: self.placeholder_gas_used,
         }
     }
 }

--- a/crates/rbuilder-primitives/src/mev_boost/submit_block.rs
+++ b/crates/rbuilder-primitives/src/mev_boost/submit_block.rs
@@ -1,4 +1,4 @@
-use crate::mev_boost::BidAdjustmentDataV1;
+use crate::mev_boost::BidAdjustmentDataV3;
 use alloy_rpc_types_beacon::{
     relay::{
         BidTrace, SignedBidSubmissionV2, SignedBidSubmissionV3, SignedBidSubmissionV4,
@@ -22,7 +22,7 @@ pub struct SubmitBlockRequest {
     pub request: Arc<AlloySubmitBlockRequest>,
     /// Bid adjustment data if present.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub adjustment_data: Option<BidAdjustmentDataV1>,
+    pub adjustment_data: Option<BidAdjustmentDataV3>,
 }
 
 impl ssz::Encode for SubmitBlockRequest {
@@ -56,7 +56,7 @@ impl ssz::Encode for SubmitBlockRequest {
         };
         // Add adjustment data offset if present.
         if self.adjustment_data.is_some() {
-            offset += <BidAdjustmentDataV1 as ssz::Encode>::ssz_fixed_len();
+            offset += <BidAdjustmentDataV3 as ssz::Encode>::ssz_fixed_len();
         }
 
         let mut encoder = ssz::SszEncoder::container(buf, offset);
@@ -122,7 +122,7 @@ impl ssz::Encode for SubmitBlockRequest {
     fn ssz_bytes_len(&self) -> usize {
         let mut len = <AlloySubmitBlockRequest as ssz::Encode>::ssz_bytes_len(&self.request);
         if let Some(adjustment) = &self.adjustment_data {
-            len += <BidAdjustmentDataV1 as ssz::Encode>::ssz_bytes_len(adjustment);
+            len += <BidAdjustmentDataV3 as ssz::Encode>::ssz_bytes_len(adjustment);
         }
         len
     }
@@ -216,7 +216,7 @@ impl SubmitBlockRequest {
     }
 
     /// Set the bid adjustment data on the request.
-    pub fn set_adjustment_data(&mut self, data: BidAdjustmentDataV1) {
+    pub fn set_adjustment_data(&mut self, data: BidAdjustmentDataV3) {
         self.adjustment_data = Some(data);
     }
 
@@ -313,7 +313,7 @@ mod ssz_helpers {
         message: BidTrace,
         execution_payload: ExecutionPayloadV2,
         signature: BlsSignature,
-        adjustment_data: BidAdjustmentDataV1,
+        adjustment_data: BidAdjustmentDataV3,
     }
 
     impl From<CapellaSubmitBlockRequestSszHelper> for SubmitBlockRequest {
@@ -341,7 +341,7 @@ mod ssz_helpers {
         execution_payload: ExecutionPayloadV3,
         blobs_bundle: BlobsBundleV1,
         signature: BlsSignature,
-        adjustment_data: BidAdjustmentDataV1,
+        adjustment_data: BidAdjustmentDataV3,
     }
 
     impl From<DenebSubmitBlockRequestSszHelper> for SubmitBlockRequest {
@@ -372,7 +372,7 @@ mod ssz_helpers {
         blobs_bundle: BlobsBundleV1,
         execution_requests: ExecutionRequestsV4,
         signature: BlsSignature,
-        adjustment_data: BidAdjustmentDataV1,
+        adjustment_data: BidAdjustmentDataV3,
     }
 
     impl From<ElectraSubmitBlockRequestSszHelper> for SubmitBlockRequest {
@@ -405,7 +405,7 @@ mod ssz_helpers {
         blobs_bundle: BlobsBundleV2,
         execution_requests: ExecutionRequestsV4,
         signature: BlsSignature,
-        adjustment_data: BidAdjustmentDataV1,
+        adjustment_data: BidAdjustmentDataV3,
     }
 
     impl From<FuluSubmitBlockRequestSszHelper> for SubmitBlockRequest {

--- a/crates/rbuilder-primitives/src/mev_boost/submit_header.rs
+++ b/crates/rbuilder-primitives/src/mev_boost/submit_header.rs
@@ -35,7 +35,7 @@ pub struct SubmitHeaderRequest {
     /// The number of transactions in the block.
     pub tx_count: u32,
     /// The signed header data. This is the same structure used by
-    /// the Optimistic V2 'SignedHeaderSubmission'.
+    /// the Optimistic V3 'SignedHeaderSubmission'.
     pub submission: SignedHeaderSubmission,
 }
 

--- a/crates/rbuilder-primitives/src/mev_boost/submit_header.rs
+++ b/crates/rbuilder-primitives/src/mev_boost/submit_header.rs
@@ -1,5 +1,5 @@
 use crate::mev_boost::{
-    adjustment::BidAdjustmentDataV2,
+    adjustment::BidAdjustmentDataV3,
     ssz_roots::{calculate_transactions_root_ssz, calculate_withdrawals_root_ssz},
     BidMetadata,
 };
@@ -84,8 +84,8 @@ pub struct HeaderSubmissionElectra {
     pub execution_requests: ExecutionRequestsV4,
     /// Blob KZG commitments.
     pub commitments: Vec<alloy_consensus::Bytes48>,
-    /// Bid adjustment data V2.
-    pub adjustment_data: Option<BidAdjustmentDataV2>,
+    /// Bid adjustment data V3.
+    pub adjustment_data: Option<BidAdjustmentDataV3>,
 }
 
 impl ssz::Encode for HeaderSubmissionElectra {
@@ -99,7 +99,7 @@ impl ssz::Encode for HeaderSubmissionElectra {
             + <ExecutionRequestsV4 as ssz::Encode>::ssz_fixed_len()
             + <Vec<alloy_consensus::Bytes48> as ssz::Encode>::ssz_fixed_len();
         if self.adjustment_data.is_some() {
-            offset += <BidAdjustmentDataV2 as ssz::Encode>::ssz_fixed_len();
+            offset += <BidAdjustmentDataV3 as ssz::Encode>::ssz_fixed_len();
         }
 
         let mut encoder = ssz::SszEncoder::container(buf, offset);
@@ -123,7 +123,7 @@ impl ssz::Encode for HeaderSubmissionElectra {
             + <ExecutionRequestsV4 as ssz::Encode>::ssz_bytes_len(&self.execution_requests)
             + <Vec<alloy_consensus::Bytes48> as ssz::Encode>::ssz_bytes_len(&self.commitments);
         if let Some(adjustment) = &self.adjustment_data {
-            len += <BidAdjustmentDataV2 as ssz::Encode>::ssz_bytes_len(adjustment);
+            len += <BidAdjustmentDataV3 as ssz::Encode>::ssz_bytes_len(adjustment);
         }
         len
     }
@@ -141,7 +141,7 @@ impl ssz::Decode for HeaderSubmissionElectra {
             execution_payload_header: ExecutionPayloadHeaderElectra,
             execution_requests: ExecutionRequestsV4,
             commitments: Vec<alloy_consensus::Bytes48>,
-            adjustment_data: BidAdjustmentDataV2,
+            adjustment_data: BidAdjustmentDataV3,
         }
 
         #[derive(ssz_derive::Decode)]

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -18,7 +18,7 @@ use crate::{
 use ahash::HashSet;
 use alloy_eips::eip7594::BlobTransactionSidecarVariant;
 use alloy_primitives::{Address, Bytes};
-use rbuilder_primitives::{mev_boost::BidAdjustmentData, AccountNonce, OrderId, SimulatedOrder};
+use rbuilder_primitives::{mev_boost::BidAdjustmentDataV3, AccountNonce, OrderId, SimulatedOrder};
 use reth::primitives::SealedBlock;
 use std::{
     collections::HashMap,
@@ -49,7 +49,7 @@ pub struct Block {
     /// The Pectra execution requests for this bid.
     pub execution_requests: Vec<Bytes>,
     /// Bid adjustment data by fee payer address.
-    pub bid_adjustments: HashMap<Address, BidAdjustmentData>,
+    pub bid_adjustments: HashMap<Address, BidAdjustmentDataV3>,
 }
 
 /// Id to uniquely identify every block built (unique even among different algorithms).

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -39,7 +39,7 @@ use evm::EthCachedEvmFactory;
 use jsonrpsee::core::Serialize;
 use parking_lot::Mutex;
 use rbuilder_primitives::{
-    mev_boost::BidAdjustmentData, BlockSpace, Order, SimValue, SimulatedOrder,
+    mev_boost::BidAdjustmentDataV3, BlockSpace, Order, SimValue, SimulatedOrder,
     TransactionSignedEcRecoveredWithBlobs,
 };
 use reth::{
@@ -613,7 +613,7 @@ pub struct FinalizeResult {
     /// The Pectra execution requests for this bid.
     pub execution_requests: Vec<Bytes>,
     /// Bid adjustment data.
-    pub bid_adjustments: HashMap<Address, BidAdjustmentData>,
+    pub bid_adjustments: HashMap<Address, BidAdjustmentDataV3>,
     /// Duration of root hash calculation.
     pub root_hash_time: Duration,
 }
@@ -1151,17 +1151,20 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
             .map(|(fee_payer, state_proofs)| {
                 (
                     fee_payer,
-                    BidAdjustmentData {
-                        state_root: block.header.state_root,
+                    BidAdjustmentDataV3 {
                         el_transactions_root: block.header.transactions_root,
                         el_withdrawals_root: block.header.withdrawals_root.unwrap_or_default(),
-                        receipts_root: block.header.receipts_root,
+                        builder_address: state_proofs.builder_address,
+                        builder_proof: state_proofs.builder_proof,
+                        fee_recipient_address: state_proofs.fee_recipient_address,
+                        fee_recipient_proof: state_proofs.fee_recipient_proof,
+                        fee_payer_address: state_proofs.fee_payer_address,
+                        fee_payer_proof: state_proofs.fee_payer_proof,
                         el_placeholder_transaction_proof: el_placeholder_transaction_proof.clone(),
                         cl_placeholder_transaction_proof: cl_placeholder_transaction_proof.clone(),
-                        placeholder_receipt_proof: placeholder_receipt_proof.clone(),
+                        el_placeholder_receipt_proof: placeholder_receipt_proof.clone(),
                         pre_payment_logs_bloom,
                         placeholder_gas_used,
-                        state_proofs,
                     },
                 )
             })

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -1141,6 +1141,11 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
                 &local_ctx.tx_ssz_leaf_root_cache,
             )
         });
+        let placeholder_gas_used = self
+            .executed_tx_infos
+            .last()
+            .map(|tx_info| tx_info.space_used.gas)
+            .expect("payout transaction must exist");
         let bid_adjustments = bid_adjustment_state_proofs
             .into_iter()
             .map(|(fee_payer, state_proofs)| {
@@ -1155,6 +1160,7 @@ impl<Tracer: SimulationTracer, PartialBlockExecutionTracerType: PartialBlockExec
                         cl_placeholder_transaction_proof: cl_placeholder_transaction_proof.clone(),
                         placeholder_receipt_proof: placeholder_receipt_proof.clone(),
                         pre_payment_logs_bloom,
+                        placeholder_gas_used,
                         state_proofs,
                     },
                 )

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -326,8 +326,8 @@ fn create_optimistic_v3_request(
     maybe_adjustment_data: Option<&BidAdjustmentData>,
     adjustment_data_required: bool,
 ) -> eyre::Result<SubmitHeaderRequest> {
-    let maybe_adjustment_data_v2 = maybe_adjustment_data.map(|d| d.clone().into_v2());
-    if maybe_adjustment_data_v2.is_none() && adjustment_data_required {
+    let maybe_adjustment_data_v3 = maybe_adjustment_data.map(|d| d.clone().into_v3());
+    if maybe_adjustment_data_v3.is_none() && adjustment_data_required {
         eyre::bail!("adjustment data is required")
     }
 
@@ -347,7 +347,7 @@ fn create_optimistic_v3_request(
                     ),
                     execution_requests: request.execution_requests.clone(),
                     commitments: request.blobs_bundle.commitments.clone(),
-                    adjustment_data: maybe_adjustment_data_v2,
+                    adjustment_data: maybe_adjustment_data_v3,
                 }),
                 signature: request.signature,
             };
@@ -368,7 +368,7 @@ fn create_optimistic_v3_request(
                     ),
                     execution_requests: request.execution_requests.clone(),
                     commitments: request.blobs_bundle.commitments.clone(),
-                    adjustment_data: maybe_adjustment_data_v2,
+                    adjustment_data: maybe_adjustment_data_v3,
                 }),
                 signature: request.signature,
             };

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -25,7 +25,7 @@ use parking_lot::Mutex;
 use rbuilder_primitives::{
     built_block::{block_to_execution_payload, SignedBuiltBlock},
     mev_boost::{
-        BidAdjustmentData, BidMetadata, BidValueMetadata, ExecutionPayloadHeaderElectra,
+        BidAdjustmentDataV3, BidMetadata, BidValueMetadata, ExecutionPayloadHeaderElectra,
         HeaderSubmission, HeaderSubmissionElectra, MevBoostRelayID, SignedHeaderSubmission,
         SubmitBlockRequest, SubmitBlockRequestWithMetadata, SubmitHeaderRequest,
         SubmitHeaderRequestWithMetadata, ValidatorSlotData,
@@ -323,11 +323,10 @@ fn create_submit_block_request(
 fn create_optimistic_v3_request(
     builder_url: &[u8],
     request: &AlloySubmitBlockRequest,
-    maybe_adjustment_data: Option<&BidAdjustmentData>,
+    maybe_adjustment_data: Option<&BidAdjustmentDataV3>,
     adjustment_data_required: bool,
 ) -> eyre::Result<SubmitHeaderRequest> {
-    let maybe_adjustment_data_v3 = maybe_adjustment_data.map(|d| d.clone().into_v3());
-    if maybe_adjustment_data_v3.is_none() && adjustment_data_required {
+    if maybe_adjustment_data.is_none() && adjustment_data_required {
         eyre::bail!("adjustment data is required")
     }
 
@@ -347,7 +346,7 @@ fn create_optimistic_v3_request(
                     ),
                     execution_requests: request.execution_requests.clone(),
                     commitments: request.blobs_bundle.commitments.clone(),
-                    adjustment_data: maybe_adjustment_data_v3,
+                    adjustment_data: maybe_adjustment_data.cloned(),
                 }),
                 signature: request.signature,
             };
@@ -368,7 +367,7 @@ fn create_optimistic_v3_request(
                     ),
                     execution_requests: request.execution_requests.clone(),
                     commitments: request.blobs_bundle.commitments.clone(),
-                    adjustment_data: maybe_adjustment_data_v3,
+                    adjustment_data: maybe_adjustment_data.cloned(),
                 }),
                 signature: request.signature,
             };
@@ -388,7 +387,7 @@ fn create_optimistic_v3_request(
 fn submit_block_to_relays(
     request: Arc<AlloySubmitBlockRequest>,
     bid_metadata: &BidMetadata,
-    bid_adjustments: &std::collections::HashMap<Address, BidAdjustmentData>,
+    bid_adjustments: &std::collections::HashMap<Address, BidAdjustmentDataV3>,
     relays: &Vec<MevBoostRelayBidSubmitter>,
     registrations: &HashMap<MevBoostRelayID, RelaySlotData>,
     optimistic_v3_config: &Option<OptimisticV3Config>,
@@ -442,7 +441,7 @@ fn submit_block_to_relays(
                 // For optimistic v3, it is already included in the header submission.
                 adjustment_data: maybe_adjustment_data
                     .filter(|_| optimistic_v3.is_none())
-                    .map(|adjustment_data| adjustment_data.clone().into_v1()),
+                    .cloned(),
             },
             metadata: bid_metadata.clone(),
         };


### PR DESCRIPTION
## 📝 Summary

Unify optimistic v1 and v3 submissions to use BidAdjustmentDataV3 format, removing BidAdjustmentDataV1 and intermediate conversion methods.

## 💡 Motivation and Context

For payout transactions, gas_used may differ from gas_limit. BidAdjustmentDataV3(https://docs.ultrasound.money/builders/optimistic-v3) format relaxes the gas_limit == gas_used assumption by explicitly providing placeholder_gas_used, allowing the relay to use the actual gas consumed. 

In addition to optimistic v3 submissions, there already is a support for using the BidAdjustmentDataV3 with optimistic v1 submissions. Currently in rbuilder codebase, v1 submissions used BidAdjustmentDataV1 while v3 submissions used BidAdjustmentDataV2. Changing those submission types to use v3 data allows relays to use the actual gas consumed, preventing adjustment failures when gas_used differs from gas_limit, and will increase builder adjustment revenues.

Therefore we can simplify the codebase by:
- Removing BidAdjustmentDataV1 entirely
- Removing the intermediate BidAdjustmentData struct and conversion methods
- Using BidAdjustmentDataV3 directly for both optimistic submission methods

---

## ✅ I have completed the following steps:

* [✅ ] Run `make lint`
* [✅  ] Run `make test`
* [ ] Added tests (if applicable)
