### PR TITLE
Stop submitting bids on clickhouse problems.

### DIFF
--- a/crates/rbuilder-operator/src/clickhouse.rs
+++ b/crates/rbuilder-operator/src/clickhouse.rs
@@ -8,7 +8,10 @@ use clickhouse::{Client, Row};
 use rbuilder::{
     building::BuiltBlockTrace,
     live_builder::{
-        block_output::bidding_service_interface::{BidObserver, RelaySet},
+        block_output::{
+            bidding_service_interface::{BidObserver, RelaySet},
+            relay_submit::{AlwaysSubmitPolicy, RelaySubmissionPolicy},
+        },
         payload_events::MevBoostSlotData,
         process_killer::RUN_SUBMIT_TO_RELAYS_JOB_CANCEL_TIME,
     },
@@ -30,7 +33,7 @@ use tracing::error;
 
 use crate::{
     flashbots_config::BuiltBlocksClickhouseConfig,
-    metrics::{set_disk_backup_max_size, ClickhouseMetrics},
+    metrics::{set_disk_backup_max_size, ClickhouseMetrics, CLICKHOUSE_DISK_BACKUP_SIZE_BYTES},
 };
 
 /// BlockRow to insert in clickhouse and also as entry type for the indexer since the BlockRow is made from a few &objects so it makes no sense to have a Block type and copy all the fields.
@@ -137,12 +140,49 @@ pub struct BuiltBlocksWriter {
     builder_name: String,
 }
 
+/// Policy to stop submitting blocks if the disk backup is too big.
+#[derive(Debug)]
+struct BackupNotTooBigRelaySubmissionPolicy {
+    disk_max_size_to_submit: u64,
+}
+
+impl BackupNotTooBigRelaySubmissionPolicy {
+    pub fn new(disk_max_size_to_submit: u64) -> Self {
+        Self {
+            disk_max_size_to_submit,
+        }
+    }
+}
+
+impl RelaySubmissionPolicy for BackupNotTooBigRelaySubmissionPolicy {
+    fn should_submit(&self) -> bool {
+        (CLICKHOUSE_DISK_BACKUP_SIZE_BYTES.get() as u64) < self.disk_max_size_to_submit
+    }
+}
+
 impl BuiltBlocksWriter {
+    /// Returns the writer and the submission policy what asks to stop submitting blocks if the disk backup is too big.
+    /// It's a little ugly/coupled  that we generate this here but it was easier than injecting a metric observer.
     pub fn new(
         config: BuiltBlocksClickhouseConfig,
         rbuilder_commit: String,
         cancellation_token: CancellationToken,
-    ) -> eyre::Result<Self> {
+    ) -> eyre::Result<(Self, Box<dyn RelaySubmissionPolicy + Send + Sync>)> {
+        let backup_max_size_bytes =
+            config.disk_max_size_mb.unwrap_or(DEFAULT_MAX_DISK_SIZE_MB) * MEGA;
+        let submission_policy: Box<dyn RelaySubmissionPolicy + Send + Sync> =
+            if let Some(disk_max_size_to_submit_mb) = config.disk_max_size_to_submit_mb {
+                let disk_max_size_to_submit = disk_max_size_to_submit_mb * MEGA;
+                if disk_max_size_to_submit > backup_max_size_bytes {
+                    eyre::bail!("disk_max_size_to_submit_mb must be less than disk_max_size_mb");
+                }
+                Box::new(BackupNotTooBigRelaySubmissionPolicy::new(
+                    disk_max_size_to_submit,
+                ))
+            } else {
+                Box::new(AlwaysSubmitPolicy {})
+            };
+
         let client = Client::default()
             .with_url(config.host)
             .with_database(config.database)
@@ -153,8 +193,6 @@ impl BuiltBlocksWriter {
         let task_manager = rbuilder_utils::tasks::TaskManager::current();
         let task_executor = task_manager.executor();
 
-        let backup_max_size_bytes =
-            config.disk_max_size_mb.unwrap_or(DEFAULT_MAX_DISK_SIZE_MB) * MEGA;
         set_disk_backup_max_size(backup_max_size_bytes);
 
         let (block_tx, block_rx) = mpsc::channel::<BlockRow>(BUILT_BLOCKS_CHANNEL_SIZE);
@@ -195,11 +233,14 @@ impl BuiltBlocksWriter {
             tokio::time::sleep(RUN_SUBMIT_TO_RELAYS_JOB_CANCEL_TIME).await;
             task_manager.graceful_shutdown_with_timeout(Duration::from_secs(5));
         });
-        Ok(Self {
-            blocks_tx: block_tx,
-            rbuilder_commit,
-            builder_name: config.builder_name,
-        })
+        Ok((
+            Self {
+                blocks_tx: block_tx,
+                rbuilder_commit,
+                builder_name: config.builder_name,
+            },
+            submission_policy,
+        ))
     }
 }
 

--- a/crates/rbuilder-operator/src/clickhouse.rs
+++ b/crates/rbuilder-operator/src/clickhouse.rs
@@ -33,7 +33,10 @@ use tracing::error;
 
 use crate::{
     flashbots_config::BuiltBlocksClickhouseConfig,
-    metrics::{set_disk_backup_max_size, ClickhouseMetrics, CLICKHOUSE_DISK_BACKUP_SIZE_BYTES},
+    metrics::{
+        set_disk_backup_max_size, set_disk_backup_max_size_to_submit_bids_to_relays,
+        ClickhouseMetrics, CLICKHOUSE_DISK_BACKUP_SIZE_BYTES,
+    },
 };
 
 /// BlockRow to insert in clickhouse and also as entry type for the indexer since the BlockRow is made from a few &objects so it makes no sense to have a Block type and copy all the fields.
@@ -171,13 +174,21 @@ impl BuiltBlocksWriter {
         let backup_max_size_bytes =
             config.disk_max_size_mb.unwrap_or(DEFAULT_MAX_DISK_SIZE_MB) * MEGA;
         let submission_policy: Box<dyn RelaySubmissionPolicy + Send + Sync> =
-            if let Some(disk_max_size_to_submit_mb) = config.disk_max_size_to_submit_mb {
-                let disk_max_size_to_submit = disk_max_size_to_submit_mb * MEGA;
-                if disk_max_size_to_submit > backup_max_size_bytes {
-                    eyre::bail!("disk_max_size_to_submit_mb must be less than disk_max_size_mb");
+            if let Some(disk_max_size_to_submit_bids_to_relays_mb) =
+                config.disk_max_size_to_submit_bids_to_relays_mb
+            {
+                let disk_max_size_to_submit_bids_to_relays =
+                    disk_max_size_to_submit_bids_to_relays_mb * MEGA;
+                if disk_max_size_to_submit_bids_to_relays > backup_max_size_bytes {
+                    eyre::bail!(
+                    "disk_max_size_to_submit_bids_to_relays_mb must be less than disk_max_size_mb"
+                );
                 }
+                set_disk_backup_max_size_to_submit_bids_to_relays(
+                    disk_max_size_to_submit_bids_to_relays,
+                );
                 Box::new(BackupNotTooBigRelaySubmissionPolicy::new(
-                    disk_max_size_to_submit,
+                    disk_max_size_to_submit_bids_to_relays,
                 ))
             } else {
                 Box::new(AlwaysSubmitPolicy {})

--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -85,7 +85,7 @@ pub struct BuiltBlocksClickhouseConfig {
     pub disk_database_path: PathBuf,
     /// If set must be < disk_max_size_mb.
     /// If the disk backup size is greater than this value, clickhouse will ask we stop submitting blocks.
-    pub disk_max_size_to_submit_mb: Option<u64>,
+    pub disk_max_size_to_submit_bids_to_relays_mb: Option<u64>,
     pub disk_max_size_mb: Option<u64>,
     pub memory_max_size_mb: Option<u64>,
     /// Clickhouse send timeout in milliseconds. Defaults to 2000ms if not set.

--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -15,8 +15,9 @@ use rbuilder::{
     },
     live_builder::{
         base_config::BaseConfig,
-        block_output::bidding_service_interface::{
-            BidObserver, BiddingService, LandedBlockInfo, RelaySet,
+        block_output::{
+            bidding_service_interface::{BidObserver, BiddingService, LandedBlockInfo, RelaySet},
+            relay_submit::{AlwaysSubmitPolicy, RelaySubmissionPolicy},
         },
         cli::LiveBuilderConfig,
         config::{
@@ -82,6 +83,9 @@ pub struct BuiltBlocksClickhouseConfig {
     pub builder_name: String,
     pub password: EnvOrValue<String>,
     pub disk_database_path: PathBuf,
+    /// If set must be < disk_max_size_mb.
+    /// If the disk backup size is greater than this value, clickhouse will ask we stop submitting blocks.
+    pub disk_max_size_to_submit_mb: Option<u64>,
     pub disk_max_size_mb: Option<u64>,
     pub memory_max_size_mb: Option<u64>,
     /// Clickhouse send timeout in milliseconds. Defaults to 2000ms if not set.
@@ -167,7 +171,9 @@ impl LiveBuilderConfig for FlashbotsConfig {
             )
             .await?;
 
-        let bid_observer = self.create_bid_observer(&cancellation_token).await?;
+        let (bid_observer, submission_policy) = self
+            .create_bid_observer_and_submission_policy(&cancellation_token)
+            .await?;
 
         let (sink_factory, slot_info_provider, adjustment_fee_payers) =
             create_sink_factory_and_relays(
@@ -176,6 +182,7 @@ impl LiveBuilderConfig for FlashbotsConfig {
                 bidding_service.relay_sets().to_vec(),
                 wallet_balance_watcher,
                 bid_observer,
+                submission_policy,
                 bidding_service.clone(),
                 cancellation_token.clone(),
             )
@@ -309,27 +316,30 @@ impl FlashbotsConfig {
     }
 
     /// Depending on the cfg may create:
-    /// - Dummy sink (no blocks_processor_url)
-    /// - Standard block processor client
-    /// - Secure block processor client (using block_processor_key to sign)
-    fn create_block_processor_client(
+    /// - Dummy sink (no built_blocks_clickhouse_config)
+    /// - BuiltBlocksWriter that writes to clickhouse
+    #[allow(clippy::type_complexity)]
+    fn create_clickhouse_writer_and_submission_policy(
         &self,
         cancellation_token: &CancellationToken,
         block_processor_key: Option<PrivateKeySigner>,
-    ) -> eyre::Result<Option<Box<dyn BidObserver + Send + Sync>>> {
+    ) -> eyre::Result<(
+        Option<Box<dyn BidObserver + Send + Sync>>,
+        Box<dyn RelaySubmissionPolicy + Send + Sync>,
+    )> {
         if let Some(built_blocks_clickhouse_config) = &self.built_blocks_clickhouse_config {
             let rbuilder_version = rbuilder_version();
-            let writer = BuiltBlocksWriter::new(
+            let (writer, submission_policy) = BuiltBlocksWriter::new(
                 built_blocks_clickhouse_config.clone(),
                 rbuilder_version.git_commit,
                 cancellation_token.clone(),
             )?;
-            Ok(Some(Box::new(writer)))
+            Ok((Some(Box::new(writer)), submission_policy))
         } else {
             if block_processor_key.is_some() {
                 return Self::bail_blocks_processor_url_not_set();
             }
-            Ok(None)
+            Ok((None, Box::new(AlwaysSubmitPolicy {})))
         }
     }
 
@@ -338,10 +348,13 @@ impl FlashbotsConfig {
     }
 
     /// Depending on the cfg add a BlocksProcessorClientBidObserver and/or a true value pusher.
-    async fn create_bid_observer(
+    async fn create_bid_observer_and_submission_policy(
         &self,
         cancellation_token: &CancellationToken,
-    ) -> eyre::Result<Box<dyn BidObserver + Send + Sync>> {
+    ) -> eyre::Result<(
+        Box<dyn BidObserver + Send + Sync>,
+        Box<dyn RelaySubmissionPolicy + Send + Sync>,
+    )> {
         let block_processor_key = if let Some(key_registration_url) = &self.key_registration_url {
             if self.blocks_processor_url.is_none() {
                 return Self::bail_blocks_processor_url_not_set();
@@ -351,12 +364,16 @@ impl FlashbotsConfig {
             None
         };
 
+        let (clickhouse_writer, submission_policy) = self
+            .create_clickhouse_writer_and_submission_policy(
+                cancellation_token,
+                block_processor_key.clone(),
+            )?;
         let bid_observer = RbuilderOperatorBidObserver {
-            block_processor: self
-                .create_block_processor_client(cancellation_token, block_processor_key.clone())?,
+            clickhouse_writer,
             tbv_pusher: self.create_tbv_pusher(block_processor_key, cancellation_token)?,
         };
-        Ok(Box::new(bid_observer))
+        Ok((Box::new(bid_observer), submission_policy))
     }
 
     fn create_tbv_pusher(
@@ -450,7 +467,7 @@ pub fn default_blocks_processor_max_request_size_bytes() -> u32 {
 
 #[derive(Debug)]
 struct RbuilderOperatorBidObserver {
-    block_processor: Option<Box<dyn BidObserver + Send + Sync>>,
+    clickhouse_writer: Option<Box<dyn BidObserver + Send + Sync>>,
     tbv_pusher: Option<Box<dyn BidObserver + Send + Sync>>,
 }
 
@@ -464,7 +481,7 @@ impl BidObserver for RbuilderOperatorBidObserver {
         relays: &RelaySet,
         sent_to_relay_at: OffsetDateTime,
     ) {
-        if let Some(p) = self.block_processor.as_ref() {
+        if let Some(p) = self.clickhouse_writer.as_ref() {
             p.block_submitted(
                 slot_data,
                 submit_block_request.clone(),

--- a/crates/rbuilder-operator/src/metrics.rs
+++ b/crates/rbuilder-operator/src/metrics.rs
@@ -63,7 +63,9 @@ register_metrics! {
         IntGauge::new("clickhouse_disk_backup_size_bytes", "Space used in bytes by the local DB for failed commit batches.").unwrap();
     pub static CLICKHOUSE_DISK_BACKUP_MAX_SIZE_BYTES: IntGauge =
         IntGauge::new("clickhouse_disk_backup_max_size_bytes", "Max space used in bytes by the local DB for failed commit batches. If clickhouse_disk_backup_size_bytes reaches this value we drop data").unwrap();
-
+    pub static CLICKHOUSE_DISK_BACKUP_MAX_SIZE_TO_SUBMIT_BIDS_TO_RELAYS_BYTES: IntGauge =
+        IntGauge::new("clickhouse_disk_backup_max_size_to_submit_bids_to_relays_bytes",
+        "While clickhouse_disk_backup_size_bytes is above this number we stop submitting bids to relays.").unwrap();
     pub static CLICKHOUSE_DISK_BACKUP_SIZE_BATCHES: IntGauge =
         IntGauge::new("clickhouse_disk_backup_size_batches", "Amount of batches in local DB for failed commit batches.").unwrap();
     pub static CLICKHOUSE_MEMORY_BACKUP_SIZE_BYTES: IntGauge =
@@ -103,6 +105,10 @@ pub(crate) struct ClickhouseMetrics {}
 
 pub(crate) fn set_disk_backup_max_size(max_size_bytes: u64) {
     CLICKHOUSE_DISK_BACKUP_MAX_SIZE_BYTES.set(max_size_bytes as i64);
+}
+
+pub(crate) fn set_disk_backup_max_size_to_submit_bids_to_relays(max_size_bytes: u64) {
+    CLICKHOUSE_DISK_BACKUP_MAX_SIZE_TO_SUBMIT_BIDS_TO_RELAYS_BYTES.set(max_size_bytes as i64);
 }
 
 impl rbuilder_utils::clickhouse::backup::metrics::Metrics for ClickhouseMetrics {

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -647,7 +647,7 @@ impl RelaySubmitSinkFactory {
     ) -> Box<dyn MultiRelayBlockBuildingSink> {
         // If submission is disabled, return a sink that throws away the blocks.
         if !self.submission_policy.should_submit() {
-            warn!("Submission is disabled by submission_policy, throwing away the blocks");
+            error!("Submission is disabled by submission_policy, throwing away the blocks");
             return Box::new(NullMultiRelayBlockBuildingSink {});
         }
         // Collect all relays to submit to.

--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -93,6 +93,16 @@ pub trait MultiRelayBlockBuildingSink: std::fmt::Debug + Send + Sync {
     fn new_block(&self, relay_set: RelaySet, block: Block);
 }
 
+/// MultiRelayBlockBuildingSink throwing away the blocks.
+#[derive(Debug)]
+struct NullMultiRelayBlockBuildingSink {}
+
+impl MultiRelayBlockBuildingSink for NullMultiRelayBlockBuildingSink {
+    fn new_block(&self, _relay_set: RelaySet, _block: Block) {
+        // noop
+    }
+}
+
 /// Final destination of blocks (eg: submit to the relays).
 /// The destination of the blocks is abstracted, can be a single relay or a set of relays.
 #[automock]
@@ -587,6 +597,22 @@ async fn submit_bid_to_the_relay(
     }
 }
 
+/// "Switch" to decide if we should submit the block to the relay or not.
+/// Used to cancel block submissions (but keep everything else running).
+/// Eg: Save to clickhouse observer is failing so we should NOT build blocks.
+pub trait RelaySubmissionPolicy: std::fmt::Debug + Send + Sync {
+    fn should_submit(&self) -> bool;
+}
+
+#[derive(Debug)]
+pub struct AlwaysSubmitPolicy {}
+
+impl RelaySubmissionPolicy for AlwaysSubmitPolicy {
+    fn should_submit(&self) -> bool {
+        true
+    }
+}
+
 /// Real life MultiRelayBlockBuildingSink that send the blocks to the Relays
 #[derive(Debug)]
 pub struct RelaySubmitSinkFactory {
@@ -594,6 +620,7 @@ pub struct RelaySubmitSinkFactory {
     relays: Vec<MevBoostRelayBidSubmitter>,
     /// We expect to get bids only for this specific relay sets.
     relay_sets: Vec<RelaySet>,
+    submission_policy: Box<dyn RelaySubmissionPolicy>,
 }
 
 impl RelaySubmitSinkFactory {
@@ -601,11 +628,13 @@ impl RelaySubmitSinkFactory {
         submission_config: SubmissionConfig,
         relays: Vec<MevBoostRelayBidSubmitter>,
         relay_sets: Vec<RelaySet>,
+        submission_policy: Box<dyn RelaySubmissionPolicy>,
     ) -> Self {
         Self {
             submission_config: Arc::new(submission_config),
             relays,
             relay_sets,
+            submission_policy,
         }
     }
 
@@ -616,6 +645,11 @@ impl RelaySubmitSinkFactory {
         slot_data: MevBoostSlotData,
         cancel: CancellationToken,
     ) -> Box<dyn MultiRelayBlockBuildingSink> {
+        // If submission is disabled, return a sink that throws away the blocks.
+        if !self.submission_policy.should_submit() {
+            warn!("Submission is disabled by submission_policy, throwing away the blocks");
+            return Box::new(NullMultiRelayBlockBuildingSink {});
+        }
         // Collect all relays to submit to.
         let mut relays = Vec::new();
         for relay in &self.relays {

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -34,7 +34,7 @@ use crate::{
         base_config::default_ip,
         block_output::{
             bidding_service_interface::{BiddingService2BidSender, RelaySet},
-            relay_submit::OptimisticV3Config,
+            relay_submit::{AlwaysSubmitPolicy, OptimisticV3Config, RelaySubmissionPolicy},
         },
         cli::LiveBuilderConfig,
         payload_events::MevBoostSlotDataGenerator,
@@ -402,6 +402,7 @@ impl L1Config {
         chain_spec: Arc<ChainSpec>,
         relay_sets: Vec<RelaySet>,
         bid_observer: Box<dyn BidObserver + Send + Sync>,
+        submission_policy: Box<dyn RelaySubmissionPolicy + Send + Sync>,
         cancellation_token: CancellationToken,
     ) -> eyre::Result<(
         RelaySubmitSinkFactory,
@@ -462,8 +463,12 @@ impl L1Config {
             eyre::bail!("No slot info providers provided");
         }
 
-        let sink_factory =
-            RelaySubmitSinkFactory::new(submission_config, submitters.clone(), relay_sets);
+        let sink_factory = RelaySubmitSinkFactory::new(
+            submission_config,
+            submitters.clone(),
+            relay_sets,
+            submission_policy,
+        );
 
         let adjustment_fee_payers = self
             .relays
@@ -517,6 +522,7 @@ impl LiveBuilderConfig for Config {
                 bidding_service.relay_sets(),
                 wallet_balance_watcher,
                 Box::new(NullBidObserver {}),
+                Box::new(AlwaysSubmitPolicy {}),
                 bidding_service,
                 cancellation_token.clone(),
             )
@@ -1074,12 +1080,14 @@ where
     .await??)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn create_sink_factory_and_relays<P>(
     base_config: &BaseConfig,
     l1_config: &L1Config,
     relay_sets: Vec<RelaySet>,
     wallet_balance_watcher: WalletBalanceWatcher<P>,
     bid_observer: Box<dyn BidObserver + Send + Sync>,
+    submission_policy: Box<dyn RelaySubmissionPolicy + Send + Sync>,
     bidding_service: Arc<dyn BiddingService>,
     cancellation_token: CancellationToken,
 ) -> eyre::Result<(
@@ -1095,6 +1103,7 @@ where
             base_config.chain_spec()?,
             relay_sets.clone(),
             bid_observer,
+            submission_policy,
             cancellation_token.clone(),
         )?;
 


### PR DESCRIPTION
## 📝 Summary

This PR introduces a trait RelaySubmissionPolicy to stop submitting on any problem.
I decided to cut the flow at the very end of the chain (I know it's inefficient) to play it super safe just in case any module is expecting new slot/block info periodically (eg: bidding services, caching stuff).
A new field was added to BuiltBlocksClickhouseConfig:

/// If set must be < disk_max_size_mb.
/// If the disk backup size is greater than this value, clickhouse will ask we stop submitting blocks.
pub disk_max_size_to_submit_bids_to_relays_mb: Option<u64>,

New metric clickhouse_disk_backup_max_size_to_submit_bids_to_relays_bytes with this value.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
