### PR TITLE
Better shutdown.

### DIFF
--- a/crates/rbuilder-operator/src/clickhouse.rs
+++ b/crates/rbuilder-operator/src/clickhouse.rs
@@ -13,7 +13,6 @@ use rbuilder::{
             relay_submit::{AlwaysSubmitPolicy, RelaySubmissionPolicy},
         },
         payload_events::MevBoostSlotData,
-        process_killer::RUN_SUBMIT_TO_RELAYS_JOB_CANCEL_TIME,
     },
 };
 use rbuilder_primitives::{Order, OrderId};
@@ -28,6 +27,7 @@ use rbuilder_utils::clickhouse::{
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
@@ -164,13 +164,20 @@ impl RelaySubmissionPolicy for BackupNotTooBigRelaySubmissionPolicy {
 }
 
 impl BuiltBlocksWriter {
-    /// Returns the writer and the submission policy what asks to stop submitting blocks if the disk backup is too big.
-    /// It's a little ugly/coupled  that we generate this here but it was easier than injecting a metric observer.
+    /// Returns the writer, the submission policy, and a JoinHandle for the clickhouse tasks.
+    /// The JoinHandle can be awaited to ensure clickhouse tasks have completed during shutdown.
+    /// It's a little ugly/coupled that we generate the submission policy here but it was easier than injecting a metric observer.
+    /// abort_token is a last resort cancellation token used to cancel clickhouse tasks if the BuiltBlocksWriter is not
+    /// released. It will tell clickhouse to stop listening for new blocks and flush the backup process.
     pub fn new(
         config: BuiltBlocksClickhouseConfig,
         rbuilder_commit: String,
-        cancellation_token: CancellationToken,
-    ) -> eyre::Result<(Self, Box<dyn RelaySubmissionPolicy + Send + Sync>)> {
+        abort_token: CancellationToken,
+    ) -> eyre::Result<(
+        Self,
+        Box<dyn RelaySubmissionPolicy + Send + Sync>,
+        JoinHandle<()>,
+    )> {
         let backup_max_size_bytes =
             config.disk_max_size_mb.unwrap_or(DEFAULT_MAX_DISK_SIZE_MB) * MEGA;
         let submission_policy: Box<dyn RelaySubmissionPolicy + Send + Sync> =
@@ -222,28 +229,29 @@ impl BuiltBlocksWriter {
         let end_timeout =
             Duration::from_millis(config.end_timeout_ms.unwrap_or(DEFAULT_END_TIMEOUT_MS));
 
-        spawn_clickhouse_inserter_and_backup::<BlockRow, BlockRow, ClickhouseMetrics>(
-            &client,
-            block_rx,
-            &task_executor,
-            BLOCKS_TABLE_NAME.to_string(),
-            "".to_string(), // No buildername used in blocks table.
-            disk_backup,
-            config
-                .memory_max_size_mb
-                .unwrap_or(DEFAULT_MAX_MEMORY_SIZE_MB)
-                * MEGA,
-            send_timeout,
-            end_timeout,
-            BLOCKS_TABLE_NAME,
-        );
-        // Task to forward the cancellation to the task_manager.
+        let clickhouse_shutdown_handle =
+            spawn_clickhouse_inserter_and_backup::<BlockRow, BlockRow, ClickhouseMetrics>(
+                &client,
+                block_rx,
+                &task_executor,
+                BLOCKS_TABLE_NAME.to_string(),
+                "".to_string(), // No buildername used in blocks table.
+                disk_backup,
+                config
+                    .memory_max_size_mb
+                    .unwrap_or(DEFAULT_MAX_MEMORY_SIZE_MB)
+                    * MEGA,
+                send_timeout,
+                end_timeout,
+                BLOCKS_TABLE_NAME,
+            );
+
+        // Task to forward the abort to the task_manager.
         tokio::spawn(async move {
-            cancellation_token.cancelled().await;
-            // @Pending: Needed to avoid losing blocks but we should try to avoid this.
-            tokio::time::sleep(RUN_SUBMIT_TO_RELAYS_JOB_CANCEL_TIME).await;
-            task_manager.graceful_shutdown_with_timeout(Duration::from_secs(5));
+            abort_token.cancelled().await;
+            task_manager.graceful_shutdown();
         });
+
         Ok((
             Self {
                 blocks_tx: block_tx,
@@ -251,6 +259,7 @@ impl BuiltBlocksWriter {
                 builder_name: config.builder_name,
             },
             submission_policy,
+            clickhouse_shutdown_handle,
         ))
     }
 }

--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -331,6 +331,7 @@ impl FlashbotsConfig {
     /// Depending on the cfg may create:
     /// - Dummy sink (no built_blocks_clickhouse_config)
     /// - BuiltBlocksWriter that writes to clickhouse
+    ///
     /// Returns (BidObserver, RelaySubmissionPolicy, Option<JoinHandle> for clickhouse shutdown)
     #[allow(clippy::type_complexity)]
     fn create_clickhouse_writer_and_submission_policy(

--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -48,6 +48,7 @@ use crate::{
 
 use clickhouse::Client;
 use std::{path::PathBuf, sync::Arc};
+use tokio::task::JoinHandle;
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
 pub struct ClickhouseConfig {
@@ -155,6 +156,7 @@ impl LiveBuilderConfig for FlashbotsConfig {
     where
         P: StateProviderFactory + Clone + 'static,
     {
+        let abort_token = CancellationToken::new();
         if self.l1_config.relay_bid_scrapers.is_empty() {
             eyre::bail!("relay_bid_scrapers is not set");
         }
@@ -171,8 +173,8 @@ impl LiveBuilderConfig for FlashbotsConfig {
             )
             .await?;
 
-        let (bid_observer, submission_policy) = self
-            .create_bid_observer_and_submission_policy(&cancellation_token)
+        let (bid_observer, submission_policy, clickhouse_shutdown_handle) = self
+            .create_bid_observer_and_submission_policy(&cancellation_token, &abort_token)
             .await?;
 
         let (sink_factory, slot_info_provider, adjustment_fee_payers) =
@@ -188,7 +190,7 @@ impl LiveBuilderConfig for FlashbotsConfig {
             )
             .await?;
 
-        let live_builder = create_builder_from_sink(
+        let mut live_builder = create_builder_from_sink(
             &self.base_config,
             &self.l1_config,
             provider,
@@ -196,8 +198,13 @@ impl LiveBuilderConfig for FlashbotsConfig {
             slot_info_provider,
             adjustment_fee_payers,
             cancellation_token,
+            abort_token,
         )
         .await?;
+
+        if let Some(handle) = clickhouse_shutdown_handle {
+            live_builder.add_critical_task(handle);
+        }
 
         let mut module = RpcModule::new(());
         module.register_async_method("bid_subsidiseBlock", move |params, _| {
@@ -318,28 +325,34 @@ impl FlashbotsConfig {
     /// Depending on the cfg may create:
     /// - Dummy sink (no built_blocks_clickhouse_config)
     /// - BuiltBlocksWriter that writes to clickhouse
+    /// Returns (BidObserver, RelaySubmissionPolicy, Option<JoinHandle> for clickhouse shutdown)
     #[allow(clippy::type_complexity)]
     fn create_clickhouse_writer_and_submission_policy(
         &self,
-        cancellation_token: &CancellationToken,
+        clickhouse_abort_token: &CancellationToken,
         block_processor_key: Option<PrivateKeySigner>,
     ) -> eyre::Result<(
         Option<Box<dyn BidObserver + Send + Sync>>,
         Box<dyn RelaySubmissionPolicy + Send + Sync>,
+        Option<JoinHandle<()>>,
     )> {
         if let Some(built_blocks_clickhouse_config) = &self.built_blocks_clickhouse_config {
             let rbuilder_version = rbuilder_version();
-            let (writer, submission_policy) = BuiltBlocksWriter::new(
+            let (writer, submission_policy, shutdown_handle) = BuiltBlocksWriter::new(
                 built_blocks_clickhouse_config.clone(),
                 rbuilder_version.git_commit,
-                cancellation_token.clone(),
+                clickhouse_abort_token.clone(),
             )?;
-            Ok((Some(Box::new(writer)), submission_policy))
+            Ok((
+                Some(Box::new(writer)),
+                submission_policy,
+                Some(shutdown_handle),
+            ))
         } else {
             if block_processor_key.is_some() {
                 return Self::bail_blocks_processor_url_not_set();
             }
-            Ok((None, Box::new(AlwaysSubmitPolicy {})))
+            Ok((None, Box::new(AlwaysSubmitPolicy {}), None))
         }
     }
 
@@ -348,12 +361,17 @@ impl FlashbotsConfig {
     }
 
     /// Depending on the cfg add a BlocksProcessorClientBidObserver and/or a true value pusher.
+    /// Returns (BidObserver, RelaySubmissionPolicy, Option<JoinHandle> for clickhouse shutdown)
+    /// cancellation_token: used to cancel tbv_pusher
+    /// clickhouse_abort_token: used to cancel clickhouse tasks if source is hanged.
     async fn create_bid_observer_and_submission_policy(
         &self,
         cancellation_token: &CancellationToken,
+        clickhouse_abort_token: &CancellationToken,
     ) -> eyre::Result<(
         Box<dyn BidObserver + Send + Sync>,
         Box<dyn RelaySubmissionPolicy + Send + Sync>,
+        Option<JoinHandle<()>>,
     )> {
         let block_processor_key = if let Some(key_registration_url) = &self.key_registration_url {
             if self.blocks_processor_url.is_none() {
@@ -364,16 +382,20 @@ impl FlashbotsConfig {
             None
         };
 
-        let (clickhouse_writer, submission_policy) = self
+        let (clickhouse_writer, submission_policy, clickhouse_shutdown_handle) = self
             .create_clickhouse_writer_and_submission_policy(
-                cancellation_token,
+                clickhouse_abort_token,
                 block_processor_key.clone(),
             )?;
         let bid_observer = RbuilderOperatorBidObserver {
             clickhouse_writer,
             tbv_pusher: self.create_tbv_pusher(block_processor_key, cancellation_token)?,
         };
-        Ok((Box::new(bid_observer), submission_policy))
+        Ok((
+            Box::new(bid_observer),
+            submission_policy,
+            clickhouse_shutdown_handle,
+        ))
     }
 
     fn create_tbv_pusher(

--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -177,18 +177,22 @@ impl LiveBuilderConfig for FlashbotsConfig {
             .create_bid_observer_and_submission_policy(&cancellation_token, &abort_token)
             .await?;
 
-        let (sink_factory, slot_info_provider, adjustment_fee_payers) =
-            create_sink_factory_and_relays(
-                &self.base_config,
-                &self.l1_config,
-                bidding_service.relay_sets().to_vec(),
-                wallet_balance_watcher,
-                bid_observer,
-                submission_policy,
-                bidding_service.clone(),
-                cancellation_token.clone(),
-            )
-            .await?;
+        let (
+            sink_factory,
+            slot_info_provider,
+            adjustment_fee_payers,
+            optimistic_v3_server_join_handle,
+        ) = create_sink_factory_and_relays(
+            &self.base_config,
+            &self.l1_config,
+            bidding_service.relay_sets().to_vec(),
+            wallet_balance_watcher,
+            bid_observer,
+            submission_policy,
+            bidding_service.clone(),
+            cancellation_token.clone(),
+        )
+        .await?;
 
         let mut live_builder = create_builder_from_sink(
             &self.base_config,
@@ -205,7 +209,9 @@ impl LiveBuilderConfig for FlashbotsConfig {
         if let Some(handle) = clickhouse_shutdown_handle {
             live_builder.add_critical_task(handle);
         }
-
+        if let Some(optimistic_v3_server_join_handle) = optimistic_v3_server_join_handle {
+            live_builder.add_critical_task(optimistic_v3_server_join_handle);
+        }
         let mut module = RpcModule::new(());
         module.register_async_method("bid_subsidiseBlock", move |params, _| {
             handle_subsidise_block(bidding_service.clone(), params)

--- a/crates/rbuilder-utils/src/clickhouse/backup/mod.rs
+++ b/crates/rbuilder-utils/src/clickhouse/backup/mod.rs
@@ -13,6 +13,7 @@ use derive_more::{Deref, DerefMut};
 use redb::{ReadableDatabase, ReadableTable, ReadableTableMetadata};
 use strum::AsRefStr;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::{
     backoff::BackoffInterval,
@@ -761,7 +762,14 @@ impl<T: ClickhouseRowExt, MetricsType: Metrics> Backup<T, MetricsType> {
     }
 
     /// Spawns the inserter runner on the given task executor.
-    pub fn spawn(mut self, task_executor: &TaskExecutor, name: String, target: &'static str)
+    /// Returns a JoinHandle that resolves when the task completes.
+    /// On shutdown will stop processing new data flush the backup. New data might be lost.
+    pub fn spawn(
+        mut self,
+        task_executor: &TaskExecutor,
+        name: String,
+        target: &'static str,
+    ) -> JoinHandle<()>
     where
         MetricsType: Send + Sync + 'static,
         for<'a> <T as clickhouse::Row>::Value<'a>: Sync,
@@ -784,7 +792,7 @@ impl<T: ClickhouseRowExt, MetricsType: Metrics> Backup<T, MetricsType> {
                 "Clickhouse backup cleanup complete"
             );
             drop(shutdown_guard);
-        });
+        })
     }
 }
 

--- a/crates/rbuilder-utils/src/clickhouse/indexer.rs
+++ b/crates/rbuilder-utils/src/clickhouse/indexer.rs
@@ -13,6 +13,7 @@ use clickhouse::{
 };
 use reth_tasks::TaskExecutor;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::{
     clickhouse::{
@@ -215,7 +216,14 @@ impl<T: ClickhouseIndexableData, MetricsType: Metrics> InserterRunner<T, Metrics
     }
 
     /// Spawns the inserter runner on the given task executor.
-    pub fn spawn(mut self, task_executor: &TaskExecutor, name: String, target: &'static str)
+    /// Returns a JoinHandle that resolves when the task completes.
+    /// On shutdown will stop processing new data flush the inserter. New data might be lost.
+    pub fn spawn(
+        mut self,
+        task_executor: &TaskExecutor,
+        name: String,
+        target: &'static str,
+    ) -> JoinHandle<()>
     where
         T: Send + Sync + 'static,
         MetricsType: Send + Sync + 'static,
@@ -242,8 +250,7 @@ impl<T: ClickhouseIndexableData, MetricsType: Metrics> InserterRunner<T, Metrics
                 }
             }
             drop(shutdown_guard);
-
-        });
+        })
     }
 }
 

--- a/crates/rbuilder-utils/src/clickhouse/mod.rs
+++ b/crates/rbuilder-utils/src/clickhouse/mod.rs
@@ -7,6 +7,7 @@ use ::serde::{Deserialize, Serialize};
 use clickhouse::Client;
 use reth_tasks::TaskExecutor;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::clickhouse::{
     backup::{
@@ -59,6 +60,7 @@ impl From<Quantities> for clickhouse::inserter::Quantities {
 const BACKUP_INPUT_CHANNEL_BUFFER_SIZE: usize = 128;
 
 /// Main func to spawn the clickhouse inserter and backup tasks.
+/// Returns a JoinHandle that resolves when both tasks have completed.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_clickhouse_inserter_and_backup<
     DataType: ClickhouseIndexableData + Send + Sync + 'static,
@@ -75,7 +77,8 @@ pub fn spawn_clickhouse_inserter_and_backup<
     send_timeout: Duration,
     end_timeout: Duration,
     tracing_target: &'static str,
-) where
+) -> JoinHandle<()>
+where
     for<'a> <DataType::ClickhouseRowType as clickhouse::Row>::Value<'a>: Sync,
 {
     let backup_table_name = RowType::TABLE_NAME.to_string();
@@ -93,6 +96,13 @@ pub fn spawn_clickhouse_inserter_and_backup<
         disk_backup_db,
     )
     .with_memory_backup_config(MemoryBackupConfig::new(memory_max_size_bytes));
-    inserter_runner.spawn(task_executor, backup_table_name.clone(), tracing_target);
-    backup.spawn(task_executor, backup_table_name, tracing_target);
+
+    let inserter_handle =
+        inserter_runner.spawn(task_executor, backup_table_name.clone(), tracing_target);
+    let backup_handle = backup.spawn(task_executor, backup_table_name, tracing_target);
+
+    // Spawn a wrapper task that waits for both to complete
+    tokio::spawn(async move {
+        let _ = tokio::join!(inserter_handle, backup_handle);
+    })
 }

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -219,6 +219,7 @@ impl BaseConfig {
     pub async fn create_builder_with_provider_factory<P>(
         &self,
         cancellation_token: tokio_util::sync::CancellationToken,
+        global_abort: tokio_util::sync::CancellationToken,
         unfinished_built_blocks_input_factory: UnfinishedBuiltBlocksInputFactory<P>,
         slot_source: MevBoostSlotDataGenerator,
         provider: P,
@@ -259,6 +260,8 @@ impl BaseConfig {
             blocklist_provider,
 
             global_cancellation: cancellation_token.clone(),
+            global_abort,
+            critical_tasks_join_handles: Vec::new(),
             process_killer: ProcessKiller::new(cancellation_token),
             extra_rpc: RpcModule::new(()),
             unfinished_built_blocks_input_factory,

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -201,11 +201,6 @@ where
     builder
         .run(ready_to_build, start_slot_watchdog_sender)
         .await?;
-    info!(
-        wait_time_secs = MAX_WAIT_TIME.as_secs(),
-        "Main thread waiting to die..."
-    );
-    std::thread::sleep(MAX_WAIT_TIME);
     info!("Main thread exiting");
     Ok(())
 }

--- a/crates/rbuilder/src/live_builder/cli.rs
+++ b/crates/rbuilder/src/live_builder/cli.rs
@@ -17,10 +17,7 @@ use crate::{
         builders::{BacktestSimulateBlockInput, Block},
         PartialBlockExecutionTracer,
     },
-    live_builder::{
-        process_killer::{ProcessKiller, MAX_WAIT_TIME},
-        watchdog::spawn_watchdog_thread,
-    },
+    live_builder::{process_killer::ProcessKiller, watchdog::spawn_watchdog_thread},
     provider::StateProviderFactory,
     telemetry,
     utils::bls::generate_random_bls_address,

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -1165,6 +1165,7 @@ where
 }
 
 /// Take the end of the pipeline (sink_factory) + pre-created slot_info_provider and creates an empty builder (it still needs the with_builders to be called)
+#[allow(clippy::too_many_arguments)]
 pub async fn create_builder_from_sink<P>(
     base_config: &BaseConfig,
     l1_config: &L1Config,

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -78,7 +78,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::sync::Mutex as TokioMutex;
+use tokio::{sync::Mutex as TokioMutex, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use url::Url;
@@ -395,7 +395,11 @@ impl L1Config {
         })
     }
 
-    /// Creates the RelaySubmitSinkFactory and also returns the associated relays (MevBoostRelaySlotInfoProvider).
+    /// Creates:
+    /// - RelaySubmitSinkFactory
+    /// - The associated relays (MevBoostRelaySlotInfoProvider).
+    /// - A hashmap of adjustment fee payers.
+    /// - JoinHandle for the optimistic V3 server.
     #[allow(clippy::type_complexity)]
     pub fn create_relays_sealed_sink_factory(
         &self,
@@ -408,6 +412,7 @@ impl L1Config {
         RelaySubmitSinkFactory,
         Vec<MevBoostRelaySlotInfoProvider>,
         ahash::HashMap<MevBoostRelayID, Address>,
+        Option<JoinHandle<()>>,
     )> {
         let signing_domain = get_signing_domain(
             chain_spec.chain,
@@ -416,7 +421,7 @@ impl L1Config {
         )?;
 
         let mut optimistic_v3_config = None;
-        if self
+        let optimistic_v3_server_join_handle = if self
             .relays
             .iter()
             .any(|r| r.submit_config.as_ref().is_some_and(|c| c.optimistic_v3))
@@ -433,7 +438,7 @@ impl L1Config {
             }
 
             let optimistic_v3_cache = OptimisticV3BlockCache::default();
-            optimistic_v3::spawn_server(
+            let optimistic_v3_server_join_handle = optimistic_v3::spawn_server(
                 address,
                 signing_domain,
                 self.optimistic_v3_relay_pubkeys.clone(),
@@ -444,8 +449,11 @@ impl L1Config {
             optimistic_v3_config = Some(OptimisticV3Config {
                 builder_url: builder_url.into_bytes(),
                 cache: optimistic_v3_cache,
-            })
-        }
+            });
+            Some(optimistic_v3_server_join_handle)
+        } else {
+            None
+        };
 
         let submission_config = self.submission_config(
             chain_spec,
@@ -479,7 +487,12 @@ impl L1Config {
             })
             .collect();
 
-        Ok((sink_factory, slot_info_providers, adjustment_fee_payers))
+        Ok((
+            sink_factory,
+            slot_info_providers,
+            adjustment_fee_payers,
+            optimistic_v3_server_join_handle,
+        ))
     }
 
     pub fn registration_update_interval(&self) -> Duration {
@@ -516,20 +529,24 @@ impl LiveBuilderConfig for Config {
         let (wallet_balance_watcher, _) =
             create_wallet_balance_watcher(provider.clone(), &self.base_config).await?;
 
-        let (sink_factory, slot_info_provider, adjustment_fee_payers) =
-            create_sink_factory_and_relays(
-                &self.base_config,
-                &self.l1_config,
-                bidding_service.relay_sets(),
-                wallet_balance_watcher,
-                Box::new(NullBidObserver {}),
-                Box::new(AlwaysSubmitPolicy {}),
-                bidding_service,
-                cancellation_token.clone(),
-            )
-            .await?;
+        let (
+            sink_factory,
+            slot_info_provider,
+            adjustment_fee_payers,
+            optimistic_v3_server_join_handle,
+        ) = create_sink_factory_and_relays(
+            &self.base_config,
+            &self.l1_config,
+            bidding_service.relay_sets(),
+            wallet_balance_watcher,
+            Box::new(NullBidObserver {}),
+            Box::new(AlwaysSubmitPolicy {}),
+            bidding_service,
+            cancellation_token.clone(),
+        )
+        .await?;
 
-        let live_builder = create_builder_from_sink(
+        let mut live_builder = create_builder_from_sink(
             &self.base_config,
             &self.l1_config,
             provider,
@@ -544,6 +561,9 @@ impl LiveBuilderConfig for Config {
             self.live_builders()?,
             self.base_config.max_order_execution_duration_warning(),
         );
+        if let Some(optimistic_v3_server_join_handle) = optimistic_v3_server_join_handle {
+            live_builder.add_critical_task(optimistic_v3_server_join_handle);
+        }
         Ok(live_builder.with_builders(builders))
     }
 
@@ -1082,6 +1102,11 @@ where
     .await??)
 }
 
+/// Returns:
+/// - UnfinishedBuiltBlocksInputFactory
+/// - The associated relays (MevBoostRelaySlotInfoProvider).
+/// - A hashmap of adjustment fee payers.
+/// - JoinHandle for the optimistic V3 server.
 #[allow(clippy::too_many_arguments)]
 pub async fn create_sink_factory_and_relays<P>(
     base_config: &BaseConfig,
@@ -1096,18 +1121,23 @@ pub async fn create_sink_factory_and_relays<P>(
     UnfinishedBuiltBlocksInputFactory<P>,
     Vec<MevBoostRelaySlotInfoProvider>,
     ahash::HashMap<MevBoostRelayID, Address>,
+    Option<JoinHandle<()>>,
 )>
 where
     P: StateProviderFactory + Clone + 'static,
 {
-    let (sink_sealed_factory, slot_info_provider, adjustment_fee_payers) = l1_config
-        .create_relays_sealed_sink_factory(
-            base_config.chain_spec()?,
-            relay_sets.clone(),
-            bid_observer,
-            submission_policy,
-            cancellation_token.clone(),
-        )?;
+    let (
+        sink_sealed_factory,
+        slot_info_provider,
+        adjustment_fee_payers,
+        optimistic_v3_server_join_handle,
+    ) = l1_config.create_relays_sealed_sink_factory(
+        base_config.chain_spec()?,
+        relay_sets.clone(),
+        bid_observer,
+        submission_policy,
+        cancellation_token.clone(),
+    )?;
 
     if !l1_config.relay_bid_scrapers.is_empty() {
         let sender = Arc::new(BiddingService2BidSender::new(bidding_service.clone()));
@@ -1126,7 +1156,12 @@ where
         relay_sets,
     );
 
-    Ok((sink_factory, slot_info_provider, adjustment_fee_payers))
+    Ok((
+        sink_factory,
+        slot_info_provider,
+        adjustment_fee_payers,
+        optimistic_v3_server_join_handle,
+    ))
 }
 
 /// Take the end of the pipeline (sink_factory) + pre-created slot_info_provider and creates an empty builder (it still needs the with_builders to be called)

--- a/crates/rbuilder/src/live_builder/config.rs
+++ b/crates/rbuilder/src/live_builder/config.rs
@@ -503,6 +503,7 @@ impl LiveBuilderConfig for Config {
     where
         P: StateProviderFactory + Clone + 'static,
     {
+        let abort_token = CancellationToken::new();
         let parsed_config = parse_true_block_value_bidding_service_config(
             &self.true_block_value_bidding_service_config,
         )?;
@@ -536,6 +537,7 @@ impl LiveBuilderConfig for Config {
             slot_info_provider,
             adjustment_fee_payers,
             cancellation_token,
+            abort_token.clone(),
         )
         .await?;
         let builders = create_builders(
@@ -1136,6 +1138,7 @@ pub async fn create_builder_from_sink<P>(
     slot_info_provider: Vec<MevBoostRelaySlotInfoProvider>,
     adjustment_fee_payers: ahash::HashMap<MevBoostRelayID, Address>,
     cancellation_token: CancellationToken,
+    abort_token: CancellationToken,
 ) -> eyre::Result<super::LiveBuilder<P>>
 where
     P: StateProviderFactory,
@@ -1155,6 +1158,7 @@ where
     base_config
         .create_builder_with_provider_factory(
             cancellation_token,
+            abort_token,
             sink_factory,
             payload_event,
             provider,

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -536,34 +536,34 @@ async fn try_send_to_orderpool<V, T, S>(
 }
 
 /// Gracefully shuts down the builder, waiting for tasks to complete with timeouts.
-///
-/// First waits for all tasks (inner jobs + critical tasks) with a graceful timeout.
+/// First waits for all tasks (non-critical and critical tasks) with a graceful timeout.
 /// If the timeout is reached, signals the abort token and waits only for critical tasks
 /// with a second timeout.
 async fn shutdown_builder(
     global_cancellation: CancellationToken,
     global_abort: CancellationToken,
-    inner_jobs_handles: Vec<JoinHandle<()>>,
+    non_critical_tasks_join_handles: Vec<JoinHandle<()>>,
     critical_tasks_join_handles: Vec<JoinHandle<()>>,
 ) {
     info!("Builder shutting down");
     global_cancellation.cancel();
 
     // Collect handles into FuturesUnordered for concurrent waiting
-    let mut inner_jobs: FuturesUnordered<_> = inner_jobs_handles.into_iter().collect();
+    let mut non_critical_tasks: FuturesUnordered<_> =
+        non_critical_tasks_join_handles.into_iter().collect();
     let mut critical_tasks: FuturesUnordered<_> = critical_tasks_join_handles.into_iter().collect();
 
     // First phase: wait for all handles with graceful timeout
     let graceful_deadline = tokio::time::Instant::now() + GRACEFUL_SHUTDOWN_TIMEOUT;
 
     loop {
-        if inner_jobs.is_empty() && critical_tasks.is_empty() {
+        if non_critical_tasks.is_empty() && critical_tasks.is_empty() {
             break;
         }
 
         tokio::select! {
             biased;
-            Some(result) = inner_jobs.next(), if !inner_jobs.is_empty() => {
+            Some(result) = non_critical_tasks.next(), if !non_critical_tasks.is_empty() => {
                 if let Err(err) = result {
                     warn!(?err, "Job handle await error");
                 }
@@ -575,7 +575,7 @@ async fn shutdown_builder(
             }
             _ = tokio::time::sleep_until(graceful_deadline) => {
                 warn!(
-                    remaining_inner_jobs = inner_jobs.len(),
+                    remaining_inner_jobs = non_critical_tasks.len(),
                     remaining_critical_tasks = critical_tasks.len(),
                     "Graceful shutdown timeout reached, signaling abort"
                 );
@@ -606,7 +606,7 @@ async fn shutdown_builder(
         }
     } else {
         info!(
-            non_critical_task_remaining = inner_jobs.len(),
+            non_critical_task_remaining = non_critical_tasks.len(),
             "No critical tasks remaining, shutting down",
         );
     }

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -574,7 +574,6 @@ async fn shutdown_builder(
                 }
             }
             _ = tokio::time::sleep_until(graceful_deadline) => {
-                warn!("Graceful shutdown timeout reached, signaling abort");
                 warn!(
                     remaining_inner_jobs = inner_jobs.len(),
                     remaining_critical_tasks = critical_tasks.len(),

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     live_builder::{
         order_flow_tracing::order_flow_tracer_manager::OrderFlowTracerManager,
         order_input::{start_orderpool_jobs, OrderInputConfig},
-        process_killer::ProcessKiller,
+        process_killer::{ProcessKiller, CRITICAL_SHUTDOWN_TIMEOUT, GRACEFUL_SHUTDOWN_TIMEOUT},
         simulation::OrderSimulationPool,
     },
     provider::StateProviderFactory,
@@ -33,6 +33,7 @@ use block_list_provider::BlockListProvider;
 use block_output::unfinished_block_processing::UnfinishedBuiltBlocksInputFactory;
 use building::BlockBuildingPool;
 use eyre::Context;
+use futures::{stream::FuturesUnordered, StreamExt};
 use jsonrpsee::RpcModule;
 use order_input::ReplaceableOrderPoolCommand;
 use payload_events::{InternalPayloadId, MevBoostSlotDataGenerator};
@@ -118,8 +119,16 @@ where
     pub extra_data: Vec<u8>,
     pub blocklist_provider: Arc<dyn BlockListProvider>,
 
+    /// This cancellation token is used to cancel block building in a nice way.
+    /// Every task getting this token should try to cancel asap if possible without any data corruption.
     pub global_cancellation: CancellationToken,
     pub process_killer: ProcessKiller,
+    /// If after some time rbuilder does not achieve graceful shutdown with global_cancellation it will signal this token.
+    /// Task getting this token should abort any waiting/processing of new data assuming upstream data source is hanged and try to
+    /// perform cleanup asap.
+    pub global_abort: CancellationToken,
+    /// We should try to wait for these tasks to finish before shutting down to avoid data corruption.
+    pub critical_tasks_join_handles: Vec<JoinHandle<()>>,
 
     pub unfinished_built_blocks_input_factory: UnfinishedBuiltBlocksInputFactory<P>,
     pub builders: Vec<Arc<dyn BlockBuildingAlgorithm<P>>>,
@@ -148,12 +157,19 @@ where
         Self { builders, ..self }
     }
 
+    pub fn add_critical_task(&mut self, handle: JoinHandle<()>) {
+        self.critical_tasks_join_handles.push(handle);
+    }
+
     pub async fn run(
-        self,
+        mut self,
         ready_to_build: Arc<AtomicBool>, // If Some, we should send a message for every slot we start building.
         start_slot_watchdog_sender: Option<flume::Sender<()>>,
     ) -> eyre::Result<()> {
         let global_cancellation = self.global_cancellation.clone();
+        let global_abort = self.global_abort.clone();
+        let critical_tasks_join_handles = std::mem::take(&mut self.critical_tasks_join_handles);
+
         let mut inner_jobs_handles = Vec::new();
         let res = self
             .run_no_cleanup(
@@ -162,14 +178,13 @@ where
                 start_slot_watchdog_sender,
             )
             .await;
-        info!("Builder shutting down");
-        global_cancellation.cancel();
-        for handle in inner_jobs_handles {
-            handle
-                .await
-                .map_err(|err| warn!(?err, "Job handle await error"))
-                .unwrap_or_default();
-        }
+        shutdown_builder(
+            global_cancellation,
+            global_abort,
+            inner_jobs_handles,
+            critical_tasks_join_handles,
+        )
+        .await;
         res
     }
 
@@ -517,5 +532,78 @@ async fn try_send_to_orderpool<V, T, S>(
         Err(e) => {
             error!("Error creating order from transaction: {:#}", e);
         }
+    }
+}
+
+/// Gracefully shuts down the builder, waiting for tasks to complete with timeouts.
+///
+/// First waits for all tasks (inner jobs + critical tasks) with a graceful timeout.
+/// If the timeout is reached, signals the abort token and waits only for critical tasks
+/// with a second timeout.
+async fn shutdown_builder(
+    global_cancellation: CancellationToken,
+    global_abort: CancellationToken,
+    inner_jobs_handles: Vec<JoinHandle<()>>,
+    critical_tasks_join_handles: Vec<JoinHandle<()>>,
+) {
+    info!("Builder shutting down");
+    global_cancellation.cancel();
+
+    // Collect handles into FuturesUnordered for concurrent waiting
+    let mut inner_jobs: FuturesUnordered<_> = inner_jobs_handles.into_iter().collect();
+    let mut critical_tasks: FuturesUnordered<_> = critical_tasks_join_handles.into_iter().collect();
+
+    // First phase: wait for all handles with graceful timeout
+    let graceful_deadline = tokio::time::Instant::now() + GRACEFUL_SHUTDOWN_TIMEOUT;
+
+    loop {
+        if inner_jobs.is_empty() && critical_tasks.is_empty() {
+            break;
+        }
+
+        tokio::select! {
+            biased;
+            Some(result) = inner_jobs.next(), if !inner_jobs.is_empty() => {
+                if let Err(err) = result {
+                    warn!(?err, "Job handle await error");
+                }
+            }
+            Some(result) = critical_tasks.next(), if !critical_tasks.is_empty() => {
+                if let Err(err) = result {
+                    warn!(?err, "Critical task handle await error");
+                }
+            }
+            _ = tokio::time::sleep_until(graceful_deadline) => {
+                warn!("Graceful shutdown timeout reached, signaling abort");
+                global_abort.cancel();
+                break;
+            }
+        }
+    }
+
+    // Second phase: if there are remaining critical tasks, wait with second timeout
+    if !critical_tasks.is_empty() {
+        let critical_deadline = tokio::time::Instant::now() + CRITICAL_SHUTDOWN_TIMEOUT;
+        loop {
+            tokio::select! {
+                biased;
+                result = critical_tasks.next() => {
+                    match result {
+                        Some(Err(err)) => warn!(?err, "Critical task handle await error"),
+                        Some(Ok(())) => {}
+                        None => break,
+                    }
+                }
+                _ = tokio::time::sleep_until(critical_deadline) => {
+                    warn!("Critical tasks shutdown timeout reached");
+                    break;
+                }
+            }
+        }
+    } else {
+        info!(
+            non_critical_task_remaining = inner_jobs.len(),
+            "No critical tasks remaining, shutting down",
+        );
     }
 }

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -575,6 +575,11 @@ async fn shutdown_builder(
             }
             _ = tokio::time::sleep_until(graceful_deadline) => {
                 warn!("Graceful shutdown timeout reached, signaling abort");
+                warn!(
+                    remaining_inner_jobs = inner_jobs.len(),
+                    remaining_critical_tasks = critical_tasks.len(),
+                    "Graceful shutdown timeout reached, signaling abort"
+                );
                 global_abort.cancel();
                 break;
             }

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -565,7 +565,7 @@ async fn shutdown_builder(
             biased;
             Some(result) = non_critical_tasks.next(), if !non_critical_tasks.is_empty() => {
                 if let Err(err) = result {
-                    warn!(?err, "Job handle await error");
+                    warn!(?err, "Non critical task handle await error");
                 }
             }
             Some(result) = critical_tasks.next(), if !critical_tasks.is_empty() => {
@@ -575,7 +575,7 @@ async fn shutdown_builder(
             }
             _ = tokio::time::sleep_until(graceful_deadline) => {
                 warn!(
-                    remaining_inner_jobs = non_critical_tasks.len(),
+                    remaining_non_critical_tasks = non_critical_tasks.len(),
                     remaining_critical_tasks = critical_tasks.len(),
                     "Graceful shutdown timeout reached, signaling abort"
                 );

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -606,7 +606,7 @@ async fn shutdown_builder(
         }
     } else {
         info!(
-            non_critical_task_remaining = non_critical_tasks.len(),
+            remaining_non_critical_tasks = non_critical_tasks.len(),
             "No critical tasks remaining, shutting down",
         );
     }

--- a/crates/rbuilder/src/live_builder/process_killer.rs
+++ b/crates/rbuilder/src/live_builder/process_killer.rs
@@ -17,17 +17,29 @@ pub const RUN_SUBMIT_TO_RELAYS_JOB_CANCEL_TIME_SECONDS: u64 = 1;
 /// We use a whole block as heuristic for the time to close.
 pub const BLOCK_BUILDING_CLOSE_TIME_SECONDS: u64 = SLOT_DURATION_SECS;
 
-pub const RUN_SUBMIT_TO_RELAYS_JOB_CANCEL_TIME: Duration =
-    Duration::from_secs(RUN_SUBMIT_TO_RELAYS_JOB_CANCEL_TIME_SECONDS);
+/// v3 might need to keep the server running for a while until the slot ends.
+pub const OPTIMISTIC_V3_CLOSE_TIME_SECONDS: u64 = SLOT_DURATION_SECS;
+
+/// Time to flush the clickhouse backup to disk.
+pub const CLICKHOUSE_CLOSE_TIME_SECONDS: u64 = 10;
 
 /// This time should be enough to let the process to finish its work and exit gracefully.
 /// Example of this need is the clickhouse backup that takes a while to finish and we don't want to loose any blocks.
 /// This should be > than everything we have to wait for in the constants above.
-pub const MAX_WAIT_TIME_SECONDS: u64 = BLOCK_BUILDING_CLOSE_TIME_SECONDS;
-pub const MAX_WAIT_TIME: Duration = Duration::from_secs(MAX_WAIT_TIME_SECONDS);
+
+pub const GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS: u64 = BLOCK_BUILDING_CLOSE_TIME_SECONDS;
+pub const GRACEFUL_SHUTDOWN_TIMEOUT: Duration =
+    Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS);
 
 /// Time needed to let the tracing subscriber to flush its buffers.
 pub const FLUSH_TRACE_TIME: Duration = Duration::from_millis(200);
+pub const CRITICAL_SHUTDOWN_TIMEOUT_SECONDS: u64 = CLICKHOUSE_CLOSE_TIME_SECONDS;
+pub const CRITICAL_SHUTDOWN_TIMEOUT: Duration =
+    Duration::from_secs(CRITICAL_SHUTDOWN_TIMEOUT_SECONDS);
+
+pub const MAX_WAIT_TIME_SECONDS: u64 =
+    GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS + CRITICAL_SHUTDOWN_TIMEOUT_SECONDS;
+pub const MAX_WAIT_TIME: Duration = Duration::from_secs(MAX_WAIT_TIME_SECONDS);
 
 /// Time we wait before killing the process abruptly in ProcessKiller::kill().
 /// We add 1 second to allow the process to finish its work and exit gracefully.

--- a/crates/rbuilder/src/live_builder/process_killer.rs
+++ b/crates/rbuilder/src/live_builder/process_killer.rs
@@ -9,10 +9,6 @@ use alloy_eips::merge::SLOT_DURATION_SECS;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
-/// Time for the run_submit_to_relays_job to stop submitting blocks after the cancellation token is cancelled.
-/// It's just a loop that signs blocks and submits them async (on detached tasks) so if should not take more than a second.
-pub const RUN_SUBMIT_TO_RELAYS_JOB_CANCEL_TIME_SECONDS: u64 = 1;
-
 /// Time for the block building to close after the cancellation token is cancelled.
 /// We use a whole block as heuristic for the time to close.
 pub const BLOCK_BUILDING_CLOSE_TIME_SECONDS: u64 = SLOT_DURATION_SECS;
@@ -26,7 +22,6 @@ pub const CLICKHOUSE_CLOSE_TIME_SECONDS: u64 = 10;
 /// This time should be enough to let the process to finish its work and exit gracefully.
 /// Example of this need is the clickhouse backup that takes a while to finish and we don't want to loose any blocks.
 /// This should be > than everything we have to wait for in the constants above.
-
 pub const GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS: u64 = BLOCK_BUILDING_CLOSE_TIME_SECONDS;
 pub const GRACEFUL_SHUTDOWN_TIMEOUT: Duration =
     Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS);

--- a/crates/rbuilder/src/mev_boost/optimistic_v3.rs
+++ b/crates/rbuilder/src/mev_boost/optimistic_v3.rs
@@ -1,4 +1,5 @@
 use crate::{
+    live_builder::process_killer::OPTIMISTIC_V3_CLOSE_TIME_SECONDS,
     telemetry::{exponential_buckets_range, REGISTRY},
     utils,
 };
@@ -19,6 +20,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant, SystemTime},
 };
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::*;
 use warp::{
@@ -88,7 +90,7 @@ pub fn spawn_server(
     relay_pubkeys: HashSet<BlsPublicKey>,
     blocks: OptimisticV3BlockCache,
     cancellation: CancellationToken,
-) -> eyre::Result<()> {
+) -> eyre::Result<JoinHandle<()>> {
     // Spawn relay server.
     let handler = Handler {
         domain,
@@ -111,13 +113,13 @@ pub fn spawn_server(
         let now = std::time::Instant::now();
         info!(target: "relay_server", "Received cancellation, initiating graceful shutdown");
         // Sleep for 12 seconds to avoid being demoted for the current slot.
-        tokio::time::sleep(Duration::from_secs(12)).await;
+        tokio::time::sleep(Duration::from_secs(OPTIMISTIC_V3_CLOSE_TIME_SECONDS)).await;
         info!(target: "relay_server", elapsed = ?now.elapsed(), "Graceful shutdown complete");
     });
-    tokio::spawn(server);
+    let res = tokio::spawn(server);
     info!(target: "relay_server", %address, "Relay server listening");
 
-    Ok(())
+    Ok(res)
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## 📝 Summary

Shutdown is now performed in 2 steps:
1- Cancellation: We propagate a cancel signal so we stop building, data stops flowing and channels close.
We expect all critical threads to finish.
2- Abort: If some critical thread is still alive we trigger a second signal so critical tasks stop waiting for data (assuming the source is hanged) and perform any necessary clean up.
Sleeps were replaced by JoinHandles.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
