### PR TITLE
CI: Docker build for ARM64 too

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -314,7 +314,7 @@ jobs:
           file: docker/Dockerfile.rbuilder
           context: .
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 


### PR DESCRIPTION
Add ARM64 as target platform for Docker builds.