### PR TITLE
Dx/order journal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9582,6 +9582,7 @@ dependencies = [
  "built",
  "clickhouse",
  "ctor",
+ "dashmap 6.1.0",
  "derivative",
  "exponential-backoff",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9605,6 +9605,7 @@ dependencies = [
  "reqwest 0.12.24",
  "serde",
  "serde_json",
+ "serde_repr",
  "serde_with",
  "thiserror 1.0.69",
  "time",
@@ -13630,6 +13631,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2 1.0.103",
+ "quote 1.0.42",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/crates/rbuilder-operator/Cargo.toml
+++ b/crates/rbuilder-operator/Cargo.toml
@@ -85,6 +85,7 @@ lazy_static.workspace = true
 ahash.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
 serde_repr = "0.1.20"
+dashmap = { version = "6.1.0"}
 
 [features]
 test-utils = []

--- a/crates/rbuilder-operator/Cargo.toml
+++ b/crates/rbuilder-operator/Cargo.toml
@@ -84,6 +84,7 @@ parking_lot.workspace = true
 lazy_static.workspace = true
 ahash.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
+serde_repr = "0.1.20"
 
 [features]
 test-utils = []

--- a/crates/rbuilder-operator/src/clickhouse.rs
+++ b/crates/rbuilder-operator/src/clickhouse.rs
@@ -143,8 +143,6 @@ pub enum OrderJournalOrderType {
 }
 
 /// Enum matching ClickHouse `Enum8('Add' = 0, 'Remove' = 1)`.
-
-/// Enum matching ClickHouse `Enum8('Add' = 1, 'Remove' = 2)`.
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]
 #[repr(i8)]
 pub enum OrderJournalOperationType {
@@ -159,9 +157,9 @@ pub enum OrderJournalOperationType {
 ///   server_id       LowCardinality(String)
 ///   slot_number     UInt64
 ///   parent_block    FixedString(32)
-///   order_type      Enum8('Tx' = 1, 'Bundle' = 2)
+///   order_type      Enum8('Tx' = 0, 'Bundle' = 1)
 ///   order_hash      FixedString(32)
-///   operation_type  Enum8('Add' = 1, 'Remove' = 2)
+///   operation_type  Enum8('Add' = 0, 'Remove' = 1)
 ///   sequence_number UInt32
 ///   timestamp       DateTime64(6)
 #[derive(Debug, Clone, Serialize, Deserialize, Row)]

--- a/crates/rbuilder-operator/src/clickhouse.rs
+++ b/crates/rbuilder-operator/src/clickhouse.rs
@@ -134,13 +134,15 @@ impl ClickhouseIndexableData for BlockRow {
     }
 }
 
-/// Enum matching ClickHouse `Enum8('Tx' = 1, 'Bundle' = 2)`.
+/// Enum matching ClickHouse `Enum8('Tx' = 0, 'Bundle' = 1)`.
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]
 #[repr(i8)]
 pub enum OrderJournalOrderType {
     Tx = 0,
     Bundle = 1,
 }
+
+/// Enum matching ClickHouse `Enum8('Add' = 0, 'Remove' = 1)`.
 
 /// Enum matching ClickHouse `Enum8('Add' = 1, 'Remove' = 2)`.
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]

--- a/crates/rbuilder-operator/src/clickhouse.rs
+++ b/crates/rbuilder-operator/src/clickhouse.rs
@@ -1,34 +1,40 @@
-//! Clickhouse integration to save all the blocks we build and submit to relays.
+//! Clickhouse integration to save all the blocks we build and submit to relays,
+//! and to record the order journal (add/remove events) to the `available_orders_journal` table.
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use alloy_primitives::{utils::format_ether, Address, U256};
+use alloy_primitives::{utils::format_ether, Address, B256, U256};
 use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use clickhouse::{Client, Row};
 use rbuilder::{
-    building::BuiltBlockTrace,
+    building::{
+        journal::{OrderJournalObserver, SimulatedOrderJournalCommand},
+        BuiltBlockTrace,
+    },
     live_builder::{
         block_output::{
             bidding_service_interface::{BidObserver, RelaySet},
             relay_submit::{AlwaysSubmitPolicy, RelaySubmissionPolicy},
         },
         payload_events::MevBoostSlotData,
+        simulation::SimulatedOrderCommand,
     },
 };
 use rbuilder_primitives::{Order, OrderId};
 use rbuilder_utils::clickhouse::{
     backup::{
         primitives::{ClickhouseIndexableData, ClickhouseRowExt},
-        DiskBackup, DiskBackupConfig,
+        DiskBackup,
     },
     serde::{option_u256, vec_u256},
     spawn_clickhouse_inserter_and_backup,
 };
+use rbuilder_utils::tasks::TaskExecutor;
 use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
 use tracing::error;
 
 use crate::{
@@ -125,17 +131,124 @@ impl ClickhouseIndexableData for BlockRow {
     }
 }
 
-const KILO: u64 = 1024;
-const MEGA: u64 = KILO * KILO;
+/// Enum matching ClickHouse `Enum8('Tx' = 1, 'Bundle' = 2)`.
+#[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]
+#[repr(i8)]
+pub enum OrderJournalOrderType {
+    Tx = 1,
+    Bundle = 2,
+}
+
+/// Enum matching ClickHouse `Enum8('Add' = 1, 'Remove' = 2)`.
+#[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]
+#[repr(i8)]
+pub enum OrderJournalOperationType {
+    Add = 1,
+    Remove = 2,
+}
+
+/// Row for the `available_orders_journal` ClickHouse table.
+/// Records each Add/Remove order event as it flows through the builder.
+///
+/// Field order and types must exactly match the ClickHouse schema (validation is off):
+///   server_id       LowCardinality(String)
+///   slot_number     UInt64
+///   parent_block    FixedString(32)
+///   order_type      Enum8('Tx' = 1, 'Bundle' = 2)
+///   order_hash      FixedString(32)
+///   operation_type  Enum8('Add' = 1, 'Remove' = 2)
+///   sequence_number UInt32
+///   timestamp       DateTime64(6)
+#[derive(Debug, Clone, Serialize, Deserialize, Row)]
+pub struct OrderJournalRow {
+    pub server_id: String,
+    pub slot_number: u64,
+    #[serde(with = "serde_b256_fixed_bytes")]
+    pub parent_block: B256,
+    pub order_type: OrderJournalOrderType,
+    #[serde(with = "serde_b256_fixed_bytes")]
+    pub order_hash: B256,
+    pub operation_type: OrderJournalOperationType,
+    pub sequence_number: u32,
+    pub timestamp: i64,
+}
+
+/// Serde helper to serialize/deserialize `B256` as `[u8; 32]` for ClickHouse `FixedString(32)`.
+///
+/// ClickHouse `FixedString(32)` expects exactly 32 raw bytes in RowBinary (no length prefix).
+/// Using `serialize_bytes` would emit a varint length prefix + data (matching `String`), which
+/// misaligns the binary stream and causes parse errors on subsequent rows.
+/// Instead, we delegate to `[u8; 32]`'s serde impl which serializes as a fixed-size tuple.
+mod serde_b256_fixed_bytes {
+    use alloy_primitives::B256;
+    use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(value: &B256, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let bytes: &[u8; 32] = value.as_ref();
+        bytes.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<B256, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes: [u8; 32] = Deserialize::deserialize(deserializer)?;
+        Ok(B256::from(bytes))
+    }
+}
+
+impl OrderJournalRow {
+    fn trace_id(&self) -> String {
+        format!(
+            "{}:{}:{}",
+            self.slot_number, self.parent_block, self.sequence_number
+        )
+    }
+}
+
+const ORDER_JOURNAL_TABLE_NAME: &str = "available_orders_journal";
+
+impl ClickhouseRowExt for OrderJournalRow {
+    type TraceId = String;
+    const TABLE_NAME: &'static str = ORDER_JOURNAL_TABLE_NAME;
+
+    fn trace_id(&self) -> String {
+        self.trace_id()
+    }
+
+    fn to_row_ref(row: &Self) -> &<Self as Row>::Value<'_> {
+        row
+    }
+}
+
+impl ClickhouseIndexableData for OrderJournalRow {
+    type ClickhouseRowType = OrderJournalRow;
+
+    const DATA_NAME: &'static str = <OrderJournalRow as ClickhouseRowExt>::TABLE_NAME;
+
+    fn trace_id(&self) -> String {
+        self.trace_id()
+    }
+
+    fn to_row(self, _builder_name: String) -> Self::ClickhouseRowType {
+        self
+    }
+}
+
+pub(crate) const KILO: u64 = 1024;
+pub(crate) const MEGA: u64 = KILO * KILO;
 
 // Super worst scenario we submit 500 blocks per second so we have 10 seconds of buffer.
 // After this having this queued blocks we will start to drop. BlockRow is small enough (in the order of 10K, only hashes/ids, not full orders) so 5K BlockRows is not too much memory.
 const BUILT_BLOCKS_CHANNEL_SIZE: usize = 5 * 1024;
 const BLOCKS_TABLE_NAME: &str = "blocks";
 const DEFAULT_MAX_DISK_SIZE_MB: u64 = 10 * KILO;
-const DEFAULT_MAX_MEMORY_SIZE_MB: u64 = KILO;
-const DEFAULT_SEND_TIMEOUT_MS: u64 = 2000;
-const DEFAULT_END_TIMEOUT_MS: u64 = 3000;
+pub const DEFAULT_MAX_MEMORY_SIZE_MB: u64 = KILO;
+pub const DEFAULT_SEND_TIMEOUT_MS: u64 = 2000;
+pub const DEFAULT_END_TIMEOUT_MS: u64 = 3000;
 #[derive(Debug)]
 pub struct BuiltBlocksWriter {
     blocks_tx: mpsc::Sender<BlockRow>,
@@ -159,108 +272,90 @@ impl BackupNotTooBigRelaySubmissionPolicy {
 
 impl RelaySubmissionPolicy for BackupNotTooBigRelaySubmissionPolicy {
     fn should_submit(&self) -> bool {
-        (CLICKHOUSE_DISK_BACKUP_SIZE_BYTES.get() as u64) < self.disk_max_size_to_submit
+        (CLICKHOUSE_DISK_BACKUP_SIZE_BYTES
+            .with_label_values(&[BLOCKS_TABLE_NAME])
+            .get() as u64)
+            < self.disk_max_size_to_submit
     }
 }
 
-impl BuiltBlocksWriter {
-    /// Returns the writer, the submission policy, and a JoinHandle for the clickhouse tasks.
-    /// The JoinHandle can be awaited to ensure clickhouse tasks have completed during shutdown.
-    /// It's a little ugly/coupled that we generate the submission policy here but it was easier than injecting a metric observer.
-    /// abort_token is a last resort cancellation token used to cancel clickhouse tasks if the BuiltBlocksWriter is not
-    /// released. It will tell clickhouse to stop listening for new blocks and flush the backup process.
-    pub fn new(
-        config: BuiltBlocksClickhouseConfig,
-        rbuilder_commit: String,
-        abort_token: CancellationToken,
-    ) -> eyre::Result<(
-        Self,
-        Box<dyn RelaySubmissionPolicy + Send + Sync>,
-        JoinHandle<()>,
-    )> {
-        let backup_max_size_bytes =
-            config.disk_max_size_mb.unwrap_or(DEFAULT_MAX_DISK_SIZE_MB) * MEGA;
-        let submission_policy: Box<dyn RelaySubmissionPolicy + Send + Sync> =
-            if let Some(disk_max_size_to_submit_bids_to_relays_mb) =
-                config.disk_max_size_to_submit_bids_to_relays_mb
-            {
-                let disk_max_size_to_submit_bids_to_relays =
-                    disk_max_size_to_submit_bids_to_relays_mb * MEGA;
-                if disk_max_size_to_submit_bids_to_relays > backup_max_size_bytes {
-                    eyre::bail!(
+/// Creates a [`RelaySubmissionPolicy`] based on the ClickHouse backup config and sets the
+/// corresponding disk backup size gauges.
+///
+/// If `disk_max_size_to_submit_bids_to_relays_mb` is set, returns a policy that stops
+/// submitting when the blocks disk backup exceeds that threshold; otherwise returns
+/// [`AlwaysSubmitPolicy`].
+pub fn create_relay_submission_policy(
+    config: &BuiltBlocksClickhouseConfig,
+) -> eyre::Result<Box<dyn RelaySubmissionPolicy + Send + Sync>> {
+    let backup_max_size_bytes = config.disk_max_size_mb.unwrap_or(DEFAULT_MAX_DISK_SIZE_MB) * MEGA;
+    let submission_policy: Box<dyn RelaySubmissionPolicy + Send + Sync> =
+        if let Some(disk_max_size_to_submit_bids_to_relays_mb) =
+            config.disk_max_size_to_submit_bids_to_relays_mb
+        {
+            let disk_max_size_to_submit_bids_to_relays =
+                disk_max_size_to_submit_bids_to_relays_mb * MEGA;
+            if disk_max_size_to_submit_bids_to_relays > backup_max_size_bytes {
+                eyre::bail!(
                     "disk_max_size_to_submit_bids_to_relays_mb must be less than disk_max_size_mb"
                 );
-                }
-                set_disk_backup_max_size_to_submit_bids_to_relays(
-                    disk_max_size_to_submit_bids_to_relays,
-                );
-                Box::new(BackupNotTooBigRelaySubmissionPolicy::new(
-                    disk_max_size_to_submit_bids_to_relays,
-                ))
-            } else {
-                Box::new(AlwaysSubmitPolicy {})
-            };
+            }
+            set_disk_backup_max_size_to_submit_bids_to_relays(
+                disk_max_size_to_submit_bids_to_relays,
+            );
+            Box::new(BackupNotTooBigRelaySubmissionPolicy::new(
+                disk_max_size_to_submit_bids_to_relays,
+            ))
+        } else {
+            Box::new(AlwaysSubmitPolicy {})
+        };
 
-        let client = Client::default()
-            .with_url(config.host)
-            .with_database(config.database)
-            .with_user(config.username)
-            .with_password(config.password.value()?)
-            .with_validation(false); // CRITICAL for U256 serialization.
+    set_disk_backup_max_size(backup_max_size_bytes);
 
-        let task_manager = rbuilder_utils::tasks::TaskManager::current();
-        let task_executor = task_manager.executor();
+    Ok(submission_policy)
+}
 
-        set_disk_backup_max_size(backup_max_size_bytes);
-
+impl BuiltBlocksWriter {
+    /// Creates the writer and spawns the background ClickHouse inserter + backup tasks.
+    /// Returns `(Self, JoinHandle<()>)` where the handle should be awaited during shutdown.
+    ///
+    /// Accepts pre-created shared ClickHouse infrastructure (`client`, `task_executor`, `disk_backup`)
+    /// so the same resources can be shared with other writers (e.g. `OrderJournalWriter`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        client: &Client,
+        task_executor: &TaskExecutor,
+        disk_backup: DiskBackup,
+        builder_name: String,
+        rbuilder_commit: String,
+        memory_max_size_bytes: u64,
+        send_timeout: Duration,
+        end_timeout: Duration,
+    ) -> (Self, JoinHandle<()>) {
         let (block_tx, block_rx) = mpsc::channel::<BlockRow>(BUILT_BLOCKS_CHANNEL_SIZE);
-        let disk_backup = DiskBackup::new(
-            DiskBackupConfig::new()
-                .with_path(Some(config.disk_database_path))
-                .with_max_size_bytes(Some(
-                    config.disk_max_size_mb.unwrap_or(DEFAULT_MAX_DISK_SIZE_MB) * MEGA,
-                )),
-            &task_executor,
-        )
-        .expect("could not create disk backup");
-
-        let send_timeout =
-            Duration::from_millis(config.send_timeout_ms.unwrap_or(DEFAULT_SEND_TIMEOUT_MS));
-        let end_timeout =
-            Duration::from_millis(config.end_timeout_ms.unwrap_or(DEFAULT_END_TIMEOUT_MS));
 
         let clickhouse_shutdown_handle =
             spawn_clickhouse_inserter_and_backup::<BlockRow, BlockRow, ClickhouseMetrics>(
-                &client,
+                client,
                 block_rx,
-                &task_executor,
+                task_executor,
                 BLOCKS_TABLE_NAME.to_string(),
                 "".to_string(), // No buildername used in blocks table.
                 disk_backup,
-                config
-                    .memory_max_size_mb
-                    .unwrap_or(DEFAULT_MAX_MEMORY_SIZE_MB)
-                    * MEGA,
+                memory_max_size_bytes,
                 send_timeout,
                 end_timeout,
                 BLOCKS_TABLE_NAME,
             );
 
-        // Task to forward the abort to the task_manager.
-        tokio::spawn(async move {
-            abort_token.cancelled().await;
-            task_manager.graceful_shutdown();
-        });
-
-        Ok((
+        (
             Self {
                 blocks_tx: block_tx,
                 rbuilder_commit,
-                builder_name: config.builder_name,
+                builder_name,
             },
-            submission_policy,
             clickhouse_shutdown_handle,
-        ))
+        )
     }
 }
 
@@ -429,5 +524,91 @@ impl BidObserver for BuiltBlocksWriter {
                 error!(?err, "Failed to send block to clickhouse");
             }
         });
+    }
+}
+
+/// Channel size for the order journal. Orders are small and arrive frequently.
+const ORDER_JOURNAL_CHANNEL_SIZE: usize = 10 * 1024;
+
+/// Writes order journal events (Add/Remove) to the `available_orders_journal` ClickHouse table.
+#[derive(Debug)]
+pub struct OrderJournalWriter {
+    journal_tx: mpsc::Sender<OrderJournalRow>,
+    builder_name: String,
+}
+
+impl OrderJournalWriter {
+    /// Creates the writer and spawns the background ClickHouse inserter + backup tasks.
+    /// Returns `(Self, JoinHandle<()>)` where the handle should be awaited during shutdown.
+    pub fn new(
+        client: &Client,
+        task_executor: &TaskExecutor,
+        disk_backup: DiskBackup,
+        builder_name: String,
+        memory_max_size_bytes: u64,
+        send_timeout: Duration,
+        end_timeout: Duration,
+    ) -> (Self, JoinHandle<()>) {
+        let (journal_tx, journal_rx) = mpsc::channel::<OrderJournalRow>(ORDER_JOURNAL_CHANNEL_SIZE);
+
+        let shutdown_handle = spawn_clickhouse_inserter_and_backup::<
+            OrderJournalRow,
+            OrderJournalRow,
+            ClickhouseMetrics,
+        >(
+            client,
+            journal_rx,
+            task_executor,
+            ORDER_JOURNAL_TABLE_NAME.to_string(),
+            "".to_string(),
+            disk_backup,
+            memory_max_size_bytes,
+            send_timeout,
+            end_timeout,
+            ORDER_JOURNAL_TABLE_NAME,
+        );
+
+        (
+            Self {
+                journal_tx,
+                builder_name,
+            },
+            shutdown_handle,
+        )
+    }
+}
+
+impl OrderJournalObserver for OrderJournalWriter {
+    fn order_delivered(
+        &self,
+        slot_data: &MevBoostSlotData,
+        command: &SimulatedOrderJournalCommand,
+    ) {
+        let (order_id, operation_type) = match command.command() {
+            SimulatedOrderCommand::Simulation(sim_order) => {
+                (sim_order.id(), OrderJournalOperationType::Add)
+            }
+            SimulatedOrderCommand::Cancellation(id) => (*id, OrderJournalOperationType::Remove),
+        };
+
+        let order_type = match order_id {
+            OrderId::Tx(_) => OrderJournalOrderType::Tx,
+            OrderId::Bundle(_) => OrderJournalOrderType::Bundle,
+        };
+
+        let row = OrderJournalRow {
+            server_id: self.builder_name.clone(),
+            slot_number: slot_data.slot(),
+            parent_block: slot_data.parent_block_hash(),
+            order_type,
+            order_hash: order_id.fixed_bytes(),
+            operation_type,
+            sequence_number: command.sequence_number() as u32,
+            timestamp: (OffsetDateTime::now_utc().unix_timestamp_nanos() / 1000) as i64,
+        };
+
+        if let Err(err) = self.journal_tx.try_send(row) {
+            error!(?err, "Failed to send order journal row to clickhouse");
+        }
     }
 }

--- a/crates/rbuilder-operator/src/clickhouse.rs
+++ b/crates/rbuilder-operator/src/clickhouse.rs
@@ -102,6 +102,7 @@ pub struct BlockRow {
     /// These 2 should be Option but for clickhouse optimization we use defaults as null values.
     pub bid_to_beat_seen_time: i64,
     pub bid_to_beat_seen_relay: String,
+    pub next_journal_sequence_number: u32,
 }
 
 impl ClickhouseRowExt for BlockRow {
@@ -521,6 +522,7 @@ impl BidObserver for BuiltBlocksWriter {
                 triggering_bid_relay,
                 bid_to_beat_seen_time,
                 bid_to_beat_seen_relay,
+                next_journal_sequence_number: built_block_trace.next_journal_sequence_number as u32,
             };
             *block_uses += 1;
 

--- a/crates/rbuilder-operator/src/clickhouse.rs
+++ b/crates/rbuilder-operator/src/clickhouse.rs
@@ -271,10 +271,14 @@ impl BackupNotTooBigRelaySubmissionPolicy {
 }
 
 impl RelaySubmissionPolicy for BackupNotTooBigRelaySubmissionPolicy {
+    /// We assume should_submit is not called super often so we can look at maps.
     fn should_submit(&self) -> bool {
         (CLICKHOUSE_DISK_BACKUP_SIZE_BYTES
             .with_label_values(&[BLOCKS_TABLE_NAME])
             .get() as u64)
+            + (CLICKHOUSE_DISK_BACKUP_SIZE_BYTES
+                .with_label_values(&[ORDER_JOURNAL_TABLE_NAME])
+                .get() as u64)
             < self.disk_max_size_to_submit
     }
 }

--- a/crates/rbuilder-operator/src/clickhouse.rs
+++ b/crates/rbuilder-operator/src/clickhouse.rs
@@ -135,16 +135,16 @@ impl ClickhouseIndexableData for BlockRow {
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]
 #[repr(i8)]
 pub enum OrderJournalOrderType {
-    Tx = 1,
-    Bundle = 2,
+    Tx = 0,
+    Bundle = 1,
 }
 
 /// Enum matching ClickHouse `Enum8('Add' = 1, 'Remove' = 2)`.
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr)]
 #[repr(i8)]
 pub enum OrderJournalOperationType {
-    Add = 1,
-    Remove = 2,
+    Add = 0,
+    Remove = 1,
 }
 
 /// Row for the `available_orders_journal` ClickHouse table.

--- a/crates/rbuilder-operator/src/clickhouse.rs
+++ b/crates/rbuilder-operator/src/clickhouse.rs
@@ -1,14 +1,15 @@
 //! Clickhouse integration to save all the blocks we build and submit to relays,
 //! and to record the order journal (add/remove events) to the `available_orders_journal` table.
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
-
 use alloy_primitives::{utils::format_ether, Address, B256, U256};
 use alloy_rpc_types_beacon::relay::SubmitBlockRequest as AlloySubmitBlockRequest;
 use clickhouse::{Client, Row};
+use dashmap::DashSet;
 use rbuilder::{
     building::{
-        journal::{OrderJournalObserver, SimulatedOrderJournalCommand},
+        journal::{
+            Error, OrderJournalObserver, OrderJournalObserverFactory, SimulatedOrderJournalCommand,
+        },
         BuiltBlockTrace,
     },
     live_builder::{
@@ -32,6 +33,7 @@ use rbuilder_utils::clickhouse::{
 use rbuilder_utils::tasks::TaskExecutor;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -536,14 +538,23 @@ impl BidObserver for BuiltBlocksWriter {
 /// Channel size for the order journal. Orders are small and arrive frequently.
 const ORDER_JOURNAL_CHANNEL_SIZE: usize = 10 * 1024;
 
-/// Writes order journal events (Add/Remove) to the `available_orders_journal` ClickHouse table.
-#[derive(Debug)]
-pub struct OrderJournalWriter {
-    journal_tx: mpsc::Sender<OrderJournalRow>,
-    builder_name: String,
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+struct SlotKey {
+    slot_number: u64,
+    parent_block: B256,
 }
 
-impl OrderJournalWriter {
+/// Factory that creates OrderJournalWriters for each slot.
+#[derive(Debug)]
+pub struct OrderJournalWriterFactory {
+    journal_tx: mpsc::Sender<OrderJournalRow>,
+    builder_name: String,
+    /// Alive OrderJournalWriters. Set in OrderJournalWriterFactory::create_observer removed on OrderJournalWriter::drop.
+    /// We never allow 2 simultaneous OrderJournalWriters for the same slot.
+    active_slots: Arc<DashSet<SlotKey>>,
+}
+
+impl OrderJournalWriterFactory {
     /// Creates the writer and spawns the background ClickHouse inserter + backup tasks.
     /// Returns `(Self, JoinHandle<()>)` where the handle should be awaited during shutdown.
     pub fn new(
@@ -578,18 +589,46 @@ impl OrderJournalWriter {
             Self {
                 journal_tx,
                 builder_name,
+                active_slots: Arc::new(DashSet::new()),
             },
             shutdown_handle,
         )
     }
 }
 
-impl OrderJournalObserver for OrderJournalWriter {
-    fn order_delivered(
+impl OrderJournalObserverFactory for OrderJournalWriterFactory {
+    fn create_observer(
         &self,
         slot_data: &MevBoostSlotData,
-        command: &SimulatedOrderJournalCommand,
-    ) {
+    ) -> Result<Box<dyn OrderJournalObserver + Send + Sync>, Error> {
+        let slot_key = SlotKey {
+            slot_number: slot_data.slot(),
+            parent_block: slot_data.parent_block_hash(),
+        };
+        if !self.active_slots.insert(slot_key.clone()) {
+            return Err(Error::SlotAlreadyInProgress);
+        }
+        let writer = OrderJournalWriter {
+            journal_tx: self.journal_tx.clone(),
+            builder_name: self.builder_name.clone(),
+            slot_key,
+            active_slots: self.active_slots.clone(),
+        };
+        Ok(Box::new(writer))
+    }
+}
+
+/// Writes order journal events (Add/Remove) to the `available_orders_journal` ClickHouse table.
+#[derive(Debug)]
+struct OrderJournalWriter {
+    journal_tx: mpsc::Sender<OrderJournalRow>,
+    builder_name: String,
+    slot_key: SlotKey,
+    active_slots: Arc<DashSet<SlotKey>>,
+}
+
+impl OrderJournalObserver for OrderJournalWriter {
+    fn order_delivered(&self, command: &SimulatedOrderJournalCommand) {
         let (order_id, operation_type) = match command.command() {
             SimulatedOrderCommand::Simulation(sim_order) => {
                 (sim_order.id(), OrderJournalOperationType::Add)
@@ -604,8 +643,8 @@ impl OrderJournalObserver for OrderJournalWriter {
 
         let row = OrderJournalRow {
             server_id: self.builder_name.clone(),
-            slot_number: slot_data.slot(),
-            parent_block: slot_data.parent_block_hash(),
+            slot_number: self.slot_key.slot_number,
+            parent_block: self.slot_key.parent_block,
             order_type,
             order_hash: order_id.fixed_bytes(),
             operation_type,
@@ -616,5 +655,11 @@ impl OrderJournalObserver for OrderJournalWriter {
         if let Err(err) = self.journal_tx.try_send(row) {
             error!(?err, "Failed to send order journal row to clickhouse");
         }
+    }
+}
+
+impl Drop for OrderJournalWriter {
+    fn drop(&mut self) {
+        self.active_slots.remove(&self.slot_key);
     }
 }

--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -41,12 +41,18 @@ use url::Url;
 
 use crate::{
     bidding_service_wrapper::client::bidding_service_client_adapter::BiddingServiceClientAdapter,
-    build_info::rbuilder_version, clickhouse::BuiltBlocksWriter,
+    build_info::rbuilder_version,
+    clickhouse::{
+        create_relay_submission_policy, BuiltBlocksWriter, OrderJournalWriter,
+        DEFAULT_END_TIMEOUT_MS, DEFAULT_MAX_MEMORY_SIZE_MB, DEFAULT_SEND_TIMEOUT_MS, MEGA,
+    },
     true_block_value_push::best_true_value_observer::BestTrueValueObserver,
 };
 
 use clickhouse::Client;
-use std::{path::PathBuf, sync::Arc};
+use rbuilder::building::journal::{NullOrderJournalObserver, OrderJournalObserver};
+use rbuilder_utils::clickhouse::backup::{DiskBackup, DiskBackupConfig};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::task::JoinHandle;
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
@@ -171,9 +177,9 @@ impl LiveBuilderConfig for FlashbotsConfig {
             )
             .await?;
 
-        let (bid_observer, submission_policy, clickhouse_shutdown_handle) = self
-            .create_bid_observer_and_submission_policy(&cancellation_token, &abort_token)
-            .await?;
+        let (bid_observer, submission_policy, order_journal_observer, clickhouse_shutdown_handles) =
+            self.create_bid_observer_and_submission_policy(&cancellation_token, &abort_token)
+                .await?;
 
         let (
             sink_factory,
@@ -204,7 +210,7 @@ impl LiveBuilderConfig for FlashbotsConfig {
         )
         .await?;
 
-        if let Some(handle) = clickhouse_shutdown_handle {
+        for handle in clickhouse_shutdown_handles {
             live_builder.add_critical_task(handle);
         }
         if let Some(optimistic_v3_server_join_handle) = optimistic_v3_server_join_handle {
@@ -214,7 +220,9 @@ impl LiveBuilderConfig for FlashbotsConfig {
         module.register_async_method("bid_subsidiseBlock", move |params, _| {
             handle_subsidise_block(bidding_service.clone(), params)
         })?;
-        let live_builder = live_builder.with_extra_rpc(module);
+        let live_builder = live_builder
+            .with_extra_rpc(module)
+            .with_order_journal_observer(order_journal_observer);
         let builders = create_builders(
             self.live_builders()?,
             self.base_config.max_order_execution_duration_warning(),
@@ -326,9 +334,9 @@ impl FlashbotsConfig {
 
     /// Depending on the cfg may create:
     /// - Dummy sink (no built_blocks_clickhouse_config)
-    /// - BuiltBlocksWriter that writes to clickhouse
+    /// - BuiltBlocksWriter that writes to clickhouse + OrderJournalWriter
     ///
-    /// Returns (BidObserver, RelaySubmissionPolicy, Option<JoinHandle> for clickhouse shutdown)
+    /// Returns (BidObserver, RelaySubmissionPolicy, OrderJournalObserver, Vec<JoinHandle> for clickhouse shutdown)
     #[allow(clippy::type_complexity)]
     fn create_clickhouse_writer_and_submission_policy(
         &self,
@@ -337,26 +345,99 @@ impl FlashbotsConfig {
     ) -> eyre::Result<(
         Option<Box<dyn BidObserver + Send + Sync>>,
         Box<dyn RelaySubmissionPolicy + Send + Sync>,
-        Option<JoinHandle<()>>,
+        Arc<dyn OrderJournalObserver + Send + Sync>,
+        Vec<JoinHandle<()>>,
     )> {
-        if let Some(built_blocks_clickhouse_config) = &self.built_blocks_clickhouse_config {
+        if let Some(config) = &self.built_blocks_clickhouse_config {
+            let (client, task_executor, disk_backup) =
+                Self::create_clickhouse_infra(config, clickhouse_abort_token.clone())?;
+
+            let send_timeout =
+                Duration::from_millis(config.send_timeout_ms.unwrap_or(DEFAULT_SEND_TIMEOUT_MS));
+            let end_timeout =
+                Duration::from_millis(config.end_timeout_ms.unwrap_or(DEFAULT_END_TIMEOUT_MS));
+            let memory_max_size_bytes: u64 = config
+                .memory_max_size_mb
+                .unwrap_or(DEFAULT_MAX_MEMORY_SIZE_MB)
+                * MEGA;
+
+            let submission_policy = create_relay_submission_policy(config)?;
+
             let rbuilder_version = rbuilder_version();
-            let (writer, submission_policy, shutdown_handle) = BuiltBlocksWriter::new(
-                built_blocks_clickhouse_config.clone(),
+            let (writer, blocks_handle) = BuiltBlocksWriter::new(
+                &client,
+                &task_executor,
+                disk_backup.clone(),
+                config.builder_name.clone(),
                 rbuilder_version.git_commit,
-                clickhouse_abort_token.clone(),
-            )?;
+                memory_max_size_bytes,
+                send_timeout,
+                end_timeout,
+            );
+
+            let (journal_writer, journal_handle) = OrderJournalWriter::new(
+                &client,
+                &task_executor,
+                disk_backup,
+                config.builder_name.clone(),
+                memory_max_size_bytes,
+                send_timeout,
+                end_timeout,
+            );
+
             Ok((
                 Some(Box::new(writer)),
                 submission_policy,
-                Some(shutdown_handle),
+                Arc::new(journal_writer),
+                vec![blocks_handle, journal_handle],
             ))
         } else {
             if block_processor_key.is_some() {
                 return Self::bail_blocks_processor_url_not_set();
             }
-            Ok((None, Box::new(AlwaysSubmitPolicy {}), None))
+            Ok((
+                None,
+                Box::new(AlwaysSubmitPolicy {}),
+                Arc::new(NullOrderJournalObserver {}),
+                vec![],
+            ))
         }
+    }
+
+    /// Creates the shared ClickHouse infrastructure (Client, TaskExecutor, DiskBackup)
+    /// from `BuiltBlocksClickhouseConfig`. The abort token is forwarded to the TaskManager
+    /// for graceful shutdown.
+    fn create_clickhouse_infra(
+        config: &BuiltBlocksClickhouseConfig,
+        abort_token: CancellationToken,
+    ) -> eyre::Result<(Client, rbuilder_utils::tasks::TaskExecutor, DiskBackup)> {
+        let client = Client::default()
+            .with_url(&config.host)
+            .with_database(&config.database)
+            .with_user(&config.username)
+            .with_password(config.password.value()?)
+            .with_validation(false); // CRITICAL for U256 serialization.
+
+        let task_manager = rbuilder_utils::tasks::TaskManager::current();
+        let task_executor = task_manager.executor();
+
+        let disk_backup = DiskBackup::new(
+            DiskBackupConfig::new()
+                .with_path(Some(&config.disk_database_path))
+                .with_max_size_bytes(Some(
+                    config.disk_max_size_mb.unwrap_or(10 * 1024) * 1024 * 1024,
+                )),
+            &task_executor,
+        )
+        .expect("could not create disk backup");
+
+        // Task to forward the abort to the task_manager.
+        tokio::spawn(async move {
+            abort_token.cancelled().await;
+            task_manager.graceful_shutdown();
+        });
+
+        Ok((client, task_executor, disk_backup))
     }
 
     fn bail_blocks_processor_url_not_set<T>() -> Result<T, eyre::Report> {
@@ -364,9 +445,10 @@ impl FlashbotsConfig {
     }
 
     /// Depending on the cfg add a BlocksProcessorClientBidObserver and/or a true value pusher.
-    /// Returns (BidObserver, RelaySubmissionPolicy, Option<JoinHandle> for clickhouse shutdown)
+    /// Returns (BidObserver, RelaySubmissionPolicy, OrderJournalObserver, Vec<JoinHandle> for clickhouse shutdown)
     /// cancellation_token: used to cancel tbv_pusher
     /// clickhouse_abort_token: used to cancel clickhouse tasks if source is hanged.
+    #[allow(clippy::type_complexity)]
     async fn create_bid_observer_and_submission_policy(
         &self,
         cancellation_token: &CancellationToken,
@@ -374,7 +456,8 @@ impl FlashbotsConfig {
     ) -> eyre::Result<(
         Box<dyn BidObserver + Send + Sync>,
         Box<dyn RelaySubmissionPolicy + Send + Sync>,
-        Option<JoinHandle<()>>,
+        Arc<dyn OrderJournalObserver + Send + Sync>,
+        Vec<JoinHandle<()>>,
     )> {
         let block_processor_key = if let Some(key_registration_url) = &self.key_registration_url {
             if self.blocks_processor_url.is_none() {
@@ -385,11 +468,15 @@ impl FlashbotsConfig {
             None
         };
 
-        let (clickhouse_writer, submission_policy, clickhouse_shutdown_handle) = self
-            .create_clickhouse_writer_and_submission_policy(
-                clickhouse_abort_token,
-                block_processor_key.clone(),
-            )?;
+        let (
+            clickhouse_writer,
+            submission_policy,
+            order_journal_observer,
+            clickhouse_shutdown_handles,
+        ) = self.create_clickhouse_writer_and_submission_policy(
+            clickhouse_abort_token,
+            block_processor_key.clone(),
+        )?;
         let bid_observer = RbuilderOperatorBidObserver {
             clickhouse_writer,
             tbv_pusher: self.create_tbv_pusher(block_processor_key, cancellation_token)?,
@@ -397,7 +484,8 @@ impl FlashbotsConfig {
         Ok((
             Box::new(bid_observer),
             submission_policy,
-            clickhouse_shutdown_handle,
+            order_journal_observer,
+            clickhouse_shutdown_handles,
         ))
     }
 

--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -10,6 +10,7 @@ use jsonrpsee::RpcModule;
 use rbuilder::{
     building::{
         builders::{parallel_builder::parallel_build_backtest, BacktestSimulateBlockInput, Block},
+        journal::{NullOrderJournalObserverFactory, OrderJournalObserverFactory},
         order_priority::{FullProfitInfoGetter, NonMempoolProfitInfoGetter},
         BuiltBlockTrace, PartialBlockExecutionTracer,
     },
@@ -43,14 +44,13 @@ use crate::{
     bidding_service_wrapper::client::bidding_service_client_adapter::BiddingServiceClientAdapter,
     build_info::rbuilder_version,
     clickhouse::{
-        create_relay_submission_policy, BuiltBlocksWriter, OrderJournalWriter,
+        create_relay_submission_policy, BuiltBlocksWriter, OrderJournalWriterFactory,
         DEFAULT_END_TIMEOUT_MS, DEFAULT_MAX_MEMORY_SIZE_MB, DEFAULT_SEND_TIMEOUT_MS, MEGA,
     },
     true_block_value_push::best_true_value_observer::BestTrueValueObserver,
 };
 
 use clickhouse::Client;
-use rbuilder::building::journal::{NullOrderJournalObserver, OrderJournalObserver};
 use rbuilder_utils::clickhouse::backup::{DiskBackup, DiskBackupConfig};
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::task::JoinHandle;
@@ -177,9 +177,14 @@ impl LiveBuilderConfig for FlashbotsConfig {
             )
             .await?;
 
-        let (bid_observer, submission_policy, order_journal_observer, clickhouse_shutdown_handles) =
-            self.create_bid_observer_and_submission_policy(&cancellation_token, &abort_token)
-                .await?;
+        let (
+            bid_observer,
+            submission_policy,
+            order_journal_observer_factory,
+            clickhouse_shutdown_handles,
+        ) = self
+            .create_bid_observer_and_submission_policy(&cancellation_token, &abort_token)
+            .await?;
 
         let (
             sink_factory,
@@ -222,7 +227,7 @@ impl LiveBuilderConfig for FlashbotsConfig {
         })?;
         let live_builder = live_builder
             .with_extra_rpc(module)
-            .with_order_journal_observer(order_journal_observer);
+            .with_order_journal_observer_factory(order_journal_observer_factory);
         let builders = create_builders(
             self.live_builders()?,
             self.base_config.max_order_execution_duration_warning(),
@@ -345,7 +350,7 @@ impl FlashbotsConfig {
     ) -> eyre::Result<(
         Option<Box<dyn BidObserver + Send + Sync>>,
         Box<dyn RelaySubmissionPolicy + Send + Sync>,
-        Arc<dyn OrderJournalObserver + Send + Sync>,
+        Box<dyn OrderJournalObserverFactory + Send + Sync>,
         Vec<JoinHandle<()>>,
     )> {
         if let Some(config) = &self.built_blocks_clickhouse_config {
@@ -375,7 +380,7 @@ impl FlashbotsConfig {
                 end_timeout,
             );
 
-            let (journal_writer, journal_handle) = OrderJournalWriter::new(
+            let (journal_writer, journal_handle) = OrderJournalWriterFactory::new(
                 &client,
                 &task_executor,
                 disk_backup,
@@ -388,7 +393,7 @@ impl FlashbotsConfig {
             Ok((
                 Some(Box::new(writer)),
                 submission_policy,
-                Arc::new(journal_writer),
+                Box::new(journal_writer),
                 vec![blocks_handle, journal_handle],
             ))
         } else {
@@ -398,7 +403,7 @@ impl FlashbotsConfig {
             Ok((
                 None,
                 Box::new(AlwaysSubmitPolicy {}),
-                Arc::new(NullOrderJournalObserver {}),
+                Box::new(NullOrderJournalObserverFactory {}),
                 vec![],
             ))
         }
@@ -456,7 +461,7 @@ impl FlashbotsConfig {
     ) -> eyre::Result<(
         Box<dyn BidObserver + Send + Sync>,
         Box<dyn RelaySubmissionPolicy + Send + Sync>,
-        Arc<dyn OrderJournalObserver + Send + Sync>,
+        Box<dyn OrderJournalObserverFactory + Send + Sync>,
         Vec<JoinHandle<()>>,
     )> {
         let block_processor_key = if let Some(key_registration_url) = &self.key_registration_url {
@@ -471,7 +476,7 @@ impl FlashbotsConfig {
         let (
             clickhouse_writer,
             submission_policy,
-            order_journal_observer,
+            order_journal_observer_factory,
             clickhouse_shutdown_handles,
         ) = self.create_clickhouse_writer_and_submission_policy(
             clickhouse_abort_token,
@@ -484,7 +489,7 @@ impl FlashbotsConfig {
         Ok((
             Box::new(bid_observer),
             submission_policy,
-            order_journal_observer,
+            order_journal_observer_factory,
             clickhouse_shutdown_handles,
         ))
     }

--- a/crates/rbuilder-operator/src/metrics.rs
+++ b/crates/rbuilder-operator/src/metrics.rs
@@ -6,7 +6,7 @@ use ctor::ctor;
 use lazy_static::lazy_static;
 use metrics_macros::register_metrics;
 use prometheus::{
-    HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
+    Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
 };
 use rbuilder::{
     telemetry::{exponential_buckets_range, REGISTRY},
@@ -14,6 +14,8 @@ use rbuilder::{
 };
 use rbuilder_utils::build_info::Version;
 use rbuilder_utils::clickhouse::Quantities;
+
+const TABLE_LABELS: &[&str] = &["table"];
 
 register_metrics! {
     pub static BLOCK_API_ERRORS: IntCounterVec = IntCounterVec::new(
@@ -28,50 +30,60 @@ register_metrics! {
     )
     .unwrap();
 
-    pub static CLICKHOUSE_WRITE_FAILURES: IntCounter = IntCounter::new("clickhouse_write_failures", "Clickhouse write failures for built blocks")
-    .unwrap();
-    pub static CLICKHOUSE_ROWS_COMMITTED: IntCounter = IntCounter::new("clickhouse_rows_committed", "Clickhouse built blocks commited directly to clickhouse (no backup involved)")
-    .unwrap();
-    pub static CLICKHOUSE_BYTES_COMMITTED: IntCounter = IntCounter::new("clickhouse_bytes_committed", "Clickhouse built blocks bytes commited directly to clickhouse (no backup involved)")
-    .unwrap();
-    pub static CLICKHOUSE_BATCHES_COMMITTED: IntCounter = IntCounter::new("clickhouse_batches_committed", "Clickhouse built blocks batches commited directly to clickhouse (no backup involved)")
-    .unwrap();
-    pub static CLICKHOUSE_ROWS_COMMITTED_FROM_BACKUP: IntCounter = IntCounter::new("clickhouse_rows_committed_from_backup", "Clickhouse built blocks commited to clickhouse from the local backup")
-    .unwrap();
-    pub static CLICKHOUSE_BYTES_COMMITTED_FROM_BACKUP: IntCounter = IntCounter::new("clickhouse_bytes_committed_from_backup", "Clickhouse built blocks bytes commited to clickhouse from the local backup")
-    .unwrap();
+    pub static CLICKHOUSE_WRITE_FAILURES: IntCounter =
+        IntCounter::new("clickhouse_write_failures", "Clickhouse write failures").unwrap();
+    pub static CLICKHOUSE_ROWS_COMMITTED: IntCounter =
+        IntCounter::new("clickhouse_rows_committed", "Clickhouse rows committed directly (no backup involved)").unwrap();
+    pub static CLICKHOUSE_BYTES_COMMITTED: IntCounter =
+        IntCounter::new("clickhouse_bytes_committed", "Clickhouse bytes committed directly (no backup involved)").unwrap();
+    pub static CLICKHOUSE_BATCHES_COMMITTED: IntCounter =
+        IntCounter::new("clickhouse_batches_committed", "Clickhouse batches committed directly (no backup involved)").unwrap();
+    pub static CLICKHOUSE_ROWS_COMMITTED_FROM_BACKUP: IntCounter =
+        IntCounter::new("clickhouse_rows_committed_from_backup", "Clickhouse rows committed from the local backup").unwrap();
+    pub static CLICKHOUSE_BYTES_COMMITTED_FROM_BACKUP: IntCounter =
+        IntCounter::new("clickhouse_bytes_committed_from_backup", "Clickhouse bytes committed from the local backup").unwrap();
 
-    pub static CLICKHOUSE_ROWS_LOST: IntCounter = IntCounter::new("clickhouse_rows_lost", "clickhouse_rows_lost")
-    .unwrap();
-    pub static CLICKHOUSE_BYTES_LOST: IntCounter = IntCounter::new("clickhouse_bytes_lost", "clickhouse_bytes_lost")
-    .unwrap();
+    pub static CLICKHOUSE_ROWS_LOST: IntCounter =
+        IntCounter::new("clickhouse_rows_lost", "Clickhouse rows lost").unwrap();
+    pub static CLICKHOUSE_BYTES_LOST: IntCounter =
+        IntCounter::new("clickhouse_bytes_lost", "Clickhouse bytes lost").unwrap();
 
-
-    pub static CLICKHOUSE_COMMIT_FAILURES: IntCounter = IntCounter::new("clickhouse_commit_failures", "Clickhouse built blocks batches commited failures")
-    .unwrap();
-    pub static CLICKHOUSE_BACKUP_DISK_ERRORS: IntCounter = IntCounter::new("clickhouse_backup_disk_errors", "Any problem related to the disk backup, it can be reading, writing, etc.")
-    .unwrap();
-    pub static CLICKHOUSE_BATCH_COMMIT_TIME: HistogramVec = HistogramVec::new(
-        HistogramOpts::new("clickhouse_batch_commit_time","Time to commit a block batch to Clickhouse (ms)")
+    pub static CLICKHOUSE_COMMIT_FAILURES: IntCounter =
+        IntCounter::new("clickhouse_commit_failures", "Clickhouse commit failures").unwrap();
+    pub static CLICKHOUSE_BACKUP_DISK_ERRORS: IntCounterVec = IntCounterVec::new(
+        Opts::new("clickhouse_backup_disk_errors", "Any problem related to the disk backup"),
+        TABLE_LABELS
+    ).unwrap();
+    pub static CLICKHOUSE_BATCH_COMMIT_TIME: Histogram = Histogram::with_opts(
+        HistogramOpts::new("clickhouse_batch_commit_time","Time to commit a batch to Clickhouse (ms)")
             .buckets(exponential_buckets_range(0.5, 3000.0, 50)),
-        &[]
     )
     .unwrap();
-    pub static CLICKHOUSE_QUEUE_SIZE: IntGauge =
-        IntGauge::new("clickhouse_queue_size", "Size of the queue of the task that is inserting into clickhouse").unwrap();
-    pub static CLICKHOUSE_DISK_BACKUP_SIZE_BYTES: IntGauge =
-        IntGauge::new("clickhouse_disk_backup_size_bytes", "Space used in bytes by the local DB for failed commit batches.").unwrap();
+    pub static CLICKHOUSE_QUEUE_SIZE: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("clickhouse_queue_size", "Size of the queue of the task inserting into clickhouse"),
+        TABLE_LABELS
+    ).unwrap();
+    pub static CLICKHOUSE_DISK_BACKUP_SIZE_BYTES: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("clickhouse_disk_backup_size_bytes", "Space used in bytes by the local DB for failed commit batches."),
+        TABLE_LABELS
+    ).unwrap();
     pub static CLICKHOUSE_DISK_BACKUP_MAX_SIZE_BYTES: IntGauge =
         IntGauge::new("clickhouse_disk_backup_max_size_bytes", "Max space used in bytes by the local DB for failed commit batches. If clickhouse_disk_backup_size_bytes reaches this value we drop data").unwrap();
     pub static CLICKHOUSE_DISK_BACKUP_MAX_SIZE_TO_SUBMIT_BIDS_TO_RELAYS_BYTES: IntGauge =
         IntGauge::new("clickhouse_disk_backup_max_size_to_submit_bids_to_relays_bytes",
         "While clickhouse_disk_backup_size_bytes is above this number we stop submitting bids to relays.").unwrap();
-    pub static CLICKHOUSE_DISK_BACKUP_SIZE_BATCHES: IntGauge =
-        IntGauge::new("clickhouse_disk_backup_size_batches", "Amount of batches in local DB for failed commit batches.").unwrap();
-    pub static CLICKHOUSE_MEMORY_BACKUP_SIZE_BYTES: IntGauge =
-        IntGauge::new("clickhouse_memory_backup_size_bytes", "Space used in bytes by the in memory DB for failed commit batches.").unwrap();
-    pub static CLICKHOUSE_MEMORY_BACKUP_SIZE_BATCHES: IntGauge =
-        IntGauge::new("clickhouse_memory_backup_size_batches", "Amount of batches in in memory DB for failed commit batches.").unwrap();
+    pub static CLICKHOUSE_DISK_BACKUP_SIZE_BATCHES: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("clickhouse_disk_backup_size_batches", "Amount of batches in local DB for failed commit batches."),
+        TABLE_LABELS
+    ).unwrap();
+    pub static CLICKHOUSE_MEMORY_BACKUP_SIZE_BYTES: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("clickhouse_memory_backup_size_bytes", "Space used in bytes by the in memory DB for failed commit batches."),
+        TABLE_LABELS
+    ).unwrap();
+    pub static CLICKHOUSE_MEMORY_BACKUP_SIZE_BATCHES: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("clickhouse_memory_backup_size_batches", "Amount of batches in in memory DB for failed commit batches."),
+        TABLE_LABELS
+    ).unwrap();
 }
 
 /*
@@ -123,31 +135,41 @@ impl rbuilder_utils::clickhouse::backup::metrics::Metrics for ClickhouseMetrics 
     }
 
     fn record_batch_commit_time(duration: Duration) {
-        CLICKHOUSE_BATCH_COMMIT_TIME
-            .with_label_values(&[])
-            .observe(utils::duration_ms(duration));
+        CLICKHOUSE_BATCH_COMMIT_TIME.observe(utils::duration_ms(duration));
     }
 
     fn increment_commit_failures(_err: String) {
         CLICKHOUSE_COMMIT_FAILURES.inc();
     }
 
-    fn set_queue_size(size: usize, _order: &'static str) {
-        CLICKHOUSE_QUEUE_SIZE.set(size as i64);
+    fn set_queue_size(size: usize, order: &'static str) {
+        CLICKHOUSE_QUEUE_SIZE
+            .with_label_values(&[order])
+            .set(size as i64);
     }
 
-    fn set_disk_backup_size(size_bytes: u64, batches: usize, _order: &'static str) {
-        CLICKHOUSE_DISK_BACKUP_SIZE_BYTES.set(size_bytes as i64);
-        CLICKHOUSE_DISK_BACKUP_SIZE_BATCHES.set(batches as i64);
+    fn set_disk_backup_size(size_bytes: u64, batches: usize, order: &'static str) {
+        CLICKHOUSE_DISK_BACKUP_SIZE_BYTES
+            .with_label_values(&[order])
+            .set(size_bytes as i64);
+        CLICKHOUSE_DISK_BACKUP_SIZE_BATCHES
+            .with_label_values(&[order])
+            .set(batches as i64);
     }
 
-    fn increment_backup_disk_errors(_order: &'static str, _error: &str) {
-        CLICKHOUSE_BACKUP_DISK_ERRORS.inc();
+    fn increment_backup_disk_errors(order: &'static str, _error: &str) {
+        CLICKHOUSE_BACKUP_DISK_ERRORS
+            .with_label_values(&[order])
+            .inc();
     }
 
-    fn set_memory_backup_size(size_bytes: u64, batches: usize, _order: &'static str) {
-        CLICKHOUSE_MEMORY_BACKUP_SIZE_BYTES.set(size_bytes as i64);
-        CLICKHOUSE_MEMORY_BACKUP_SIZE_BATCHES.set(batches as i64);
+    fn set_memory_backup_size(size_bytes: u64, batches: usize, order: &'static str) {
+        CLICKHOUSE_MEMORY_BACKUP_SIZE_BYTES
+            .with_label_values(&[order])
+            .set(size_bytes as i64);
+        CLICKHOUSE_MEMORY_BACKUP_SIZE_BATCHES
+            .with_label_values(&[order])
+            .set(batches as i64);
     }
 
     fn process_backup_data_lost_quantities(quantities: &Quantities) {

--- a/crates/rbuilder/src/backtest/mod.rs
+++ b/crates/rbuilder/src/backtest/mod.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use crate::{mev_boost::BuilderBlockReceived, utils::offset_datetime_to_timestamp_ms};
 use alloy_consensus::Transaction as TransactionTrait;
 use alloy_network_primitives::TransactionResponse;
-use alloy_primitives::{TxHash, I256};
+use alloy_primitives::{TxHash, B256, I256};
 use alloy_rpc_types::{BlockTransactions, Transaction};
 pub use fetch::HistoricalDataFetcher;
 use rbuilder_primitives::{
@@ -50,6 +50,15 @@ pub struct OrdersWithTimestamp {
     pub order: Arc<Order>,
 }
 
+/// Metadata needed to replay the order journal for a built block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JournalMetadata {
+    pub builder_name: String,
+    pub slot: u64,
+    pub parent_hash: B256,
+    pub next_journal_sequence_number: u32,
+}
+
 /// Historic data for a block.
 /// Used for backtesting.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,6 +67,7 @@ pub struct BuiltBlockData {
     pub orders_closed_at: OffsetDateTime,
     pub sealed_at: OffsetDateTime,
     pub profit: I256,
+    pub journal_metadata: Option<JournalMetadata>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/rbuilder/src/backtest/store.rs
+++ b/crates/rbuilder/src/backtest/store.rs
@@ -569,6 +569,7 @@ fn group_rows_into_block_data(
                     ),
                     sealed_at: timestamp_ms_to_offset_datetime(sealed_at_ts_ms as u64),
                     profit,
+                    journal_metadata: None,
                 },
             ))
         })
@@ -785,6 +786,7 @@ mod test {
                 .unwrap(),
             sealed_at: OffsetDateTime::from_unix_timestamp_nanos(1719845355123000000).unwrap(),
             profit: I256::try_from(42).unwrap(),
+            journal_metadata: None,
         };
         let block_data = FullSlotBlockData::new(
             12,

--- a/crates/rbuilder/src/bin/run-bundle-on-prefix.rs
+++ b/crates/rbuilder/src/bin/run-bundle-on-prefix.rs
@@ -162,6 +162,7 @@ impl LandedBlockInfo {
         let order_statistics = OrderStatistics::new();
         Ok(BlockBuildingHelperFromProvider::new(
             BuiltBlockId::ZERO,
+            0,
             block_state,
             ctx,
             &mut self.local_ctx,

--- a/crates/rbuilder/src/building/builders/block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper.rs
@@ -11,10 +11,10 @@ use tracing::{debug, trace, warn};
 
 use crate::{
     building::{
-        builders::BuiltBlockId, estimate_payout_gas_limit, tracers::GasUsedSimulationTracer,
-        BlockBuildingContext, BlockSpace, BlockState, BuiltBlockTrace, BuiltBlockTraceError,
-        CriticalCommitOrderError, EstimatePayoutGasErr, ExecutionError, ExecutionResult,
-        FinalizeAdjustmentState, FinalizeError, FinalizeResult,
+        builders::BuiltBlockId, estimate_payout_gas_limit, journal::JournalSequenceNumber,
+        tracers::GasUsedSimulationTracer, BlockBuildingContext, BlockSpace, BlockState,
+        BuiltBlockTrace, BuiltBlockTraceError, CriticalCommitOrderError, EstimatePayoutGasErr,
+        ExecutionError, ExecutionResult, FinalizeAdjustmentState, FinalizeError, FinalizeResult,
         FinalizeRevertStateCurrentIteration, NullPartialBlockExecutionTracer, PartialBlock,
         PartialBlockExecutionTracer, ThreadBlockBuildingContext,
     },
@@ -213,6 +213,7 @@ impl BlockBuildingHelperFromProvider<NullPartialBlockExecutionTracer> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         built_block_id: BuiltBlockId,
+        next_journal_sequence_number: JournalSequenceNumber,
         state_provider: Arc<dyn StateProvider>,
         building_ctx: BlockBuildingContext,
         local_ctx: &mut ThreadBlockBuildingContext,
@@ -224,6 +225,7 @@ impl BlockBuildingHelperFromProvider<NullPartialBlockExecutionTracer> {
     ) -> Result<Self, BlockBuildingHelperError> {
         BlockBuildingHelperFromProvider::new_with_execution_tracer(
             built_block_id,
+            next_journal_sequence_number,
             state_provider,
             building_ctx,
             local_ctx,
@@ -249,6 +251,7 @@ impl<
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_execution_tracer(
         built_block_id: BuiltBlockId,
+        next_journal_sequence_number: JournalSequenceNumber,
         state_provider: Arc<dyn StateProvider>,
         building_ctx: BlockBuildingContext,
         local_ctx: &mut ThreadBlockBuildingContext,
@@ -282,7 +285,8 @@ impl<
         partial_block.reserve_block_space(payout_tx_space);
         let payout_tx_gas = payout_tx_space.gas;
 
-        let mut built_block_trace = BuiltBlockTrace::new(built_block_id);
+        let mut built_block_trace =
+            BuiltBlockTrace::new(built_block_id, next_journal_sequence_number);
         built_block_trace.available_orders_statistics = available_orders_statistics;
         Ok(Self {
             _fee_recipient_balance_start: fee_recipient_balance_start,

--- a/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
+++ b/crates/rbuilder/src/building/builders/mock_block_building_helper.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc;
+
 use crate::{
     building::{
         builders::BuiltBlockId, BlockBuildingContext, BuiltBlockTrace, CriticalCommitOrderError,
@@ -16,8 +18,6 @@ use rbuilder_primitives::{order_statistics::OrderStatistics, SimValue, Simulated
 use reth_primitives::SealedBlock;
 use revm::database::BundleState;
 use time::OffsetDateTime;
-use tokio::sync::broadcast;
-use tokio_util::sync::CancellationToken;
 
 use super::{
     block_building_helper::{BlockBuildingHelper, BlockBuildingHelperError, FinalizeBlockResult},
@@ -37,7 +37,7 @@ impl MockBlockBuildingHelper {
     pub fn new(true_block_value: U256) -> Self {
         let built_block_trace = BuiltBlockTrace {
             true_bid_value: true_block_value,
-            ..BuiltBlockTrace::new(BuiltBlockId::ZERO)
+            ..BuiltBlockTrace::new(BuiltBlockId::ZERO, 0)
         };
         Self {
             built_block_trace,
@@ -143,12 +143,7 @@ impl BlockBuildingHelper for MockBlockBuildingHelper {
 pub struct MockRootHasher {}
 
 impl RootHasher for MockRootHasher {
-    fn run_prefetcher(
-        &self,
-        _simulated_orders: broadcast::Receiver<SimulatedOrderCommand>,
-        _cancel: CancellationToken,
-    ) {
-    }
+    fn run_prefetcher(&self, _simulated_orders: mpsc::Receiver<SimulatedOrderCommand>) {}
 
     fn account_proofs(
         &self,

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -6,7 +6,10 @@ pub mod ordering_builder;
 pub mod parallel_builder;
 
 use crate::{
-    building::{BlockBuildingContext, BuiltBlockTrace, SimulatedOrderSink},
+    building::{
+        journal::{JournalSequenceNumber, SimulatedOrderJournalCommand},
+        BlockBuildingContext, BuiltBlockTrace, SimulatedOrderSink,
+    },
     live_builder::{
         block_output::unfinished_block_processing::UnfinishedBuiltBlocksInput,
         building::built_block_cache::BuiltBlockCache, payload_events::InternalPayloadId,
@@ -34,7 +37,7 @@ use tokio::sync::{
     broadcast::error::{RecvError, TryRecvError},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use super::{simulated_order_command_to_sink, OrderPriority, PrioritizedOrderStore};
 
@@ -86,7 +89,7 @@ impl Default for BuiltBlockIdSource {
 pub struct LiveBuilderInput<P> {
     pub provider: P,
     pub ctx: BlockBuildingContext,
-    pub input: broadcast::Receiver<SimulatedOrderCommand>,
+    pub input: broadcast::Receiver<SimulatedOrderJournalCommand>,
     pub sink: UnfinishedBuiltBlocksInput,
     pub builder_name: String,
     pub cancel: CancellationToken,
@@ -100,28 +103,47 @@ pub struct LiveBuilderInput<P> {
 /// Call consume_next_cancellations and use cancel_data
 #[derive(Debug)]
 pub struct OrderConsumer {
-    orders: broadcast::Receiver<SimulatedOrderCommand>,
+    orders: broadcast::Receiver<SimulatedOrderJournalCommand>,
     // consume_next_batch scratchpad
     new_commands: Vec<SimulatedOrderCommand>,
+    /// last journal sequence number processed + 1. 0 means nothing processed yet.
+    next_journal_sequence_number: JournalSequenceNumber,
 }
 
 impl OrderConsumer {
-    pub fn new(orders: broadcast::Receiver<SimulatedOrderCommand>) -> Self {
+    pub fn new(orders: broadcast::Receiver<SimulatedOrderJournalCommand>) -> Self {
         Self {
             orders,
             new_commands: Vec::new(),
+            next_journal_sequence_number: 0,
         }
     }
 
-    /// Returns true if success, on false builder should stop
+    fn add_command(&mut self, command: SimulatedOrderJournalCommand) {
+        self.new_commands.push(command.command().clone());
+        if command.sequence_number() != self.next_journal_sequence_number {
+            error!(
+                "Journal sequence number mismatch. Expected: {}, Got: {}",
+                self.next_journal_sequence_number,
+                command.sequence_number()
+            );
+        }
+        self.next_journal_sequence_number = command.sequence_number() + 1;
+    }
+    /// On Ok returned:
+    ///     None -> builder should stop
+    ///     Some(next_seq) -> next_seq is the next expected sequence number for the order journal (last seen + 1)
+    /// Returns true if success, on false
     /// New commands are accumulatd in self.new_commands
     /// Call apply_new_commands to easily consume them.
     /// This method will block until the first command is received
-    pub fn blocking_consume_next_commands(&mut self) -> eyre::Result<bool> {
+    pub fn blocking_consume_next_commands(
+        &mut self,
+    ) -> eyre::Result<Option<JournalSequenceNumber>> {
         match self.orders.blocking_recv() {
-            Ok(order) => self.new_commands.push(order),
+            Ok(order) => self.add_command(order),
             Err(RecvError::Closed) => {
-                return Ok(false);
+                return Ok(None);
             }
             Err(RecvError::Lagged(msg)) => {
                 warn!(msg, "Builder thread lagging on sim orders channel");
@@ -129,12 +151,12 @@ impl OrderConsumer {
         }
         for _ in 0..1024 {
             match self.orders.try_recv() {
-                Ok(order) => self.new_commands.push(order),
+                Ok(order) => self.add_command(order),
                 Err(TryRecvError::Empty) => {
                     break;
                 }
                 Err(TryRecvError::Closed) => {
-                    return Ok(false);
+                    return Ok(None);
                 }
                 Err(TryRecvError::Lagged(msg)) => {
                     warn!(msg, "Builder thread lagging on sim orders channel");
@@ -142,7 +164,7 @@ impl OrderConsumer {
                 }
             }
         }
-        Ok(true)
+        Ok(Some(self.next_journal_sequence_number))
     }
 
     pub fn new_commands(&self) -> &[SimulatedOrderCommand] {
@@ -157,6 +179,8 @@ impl OrderConsumer {
     }
 }
 
+/// Struct that allows to consume new SimulatedOrderJournalCommands from a broadcast::Receiver<SimulatedOrderJournalCommand> and get the new orders in a prioritized way.
+/// It's intended for single thread usage. It must be used by calling blocking_consume_next_batch and then current_block_orders.
 #[derive(Debug)]
 pub struct OrderIntakeConsumer<OrderPriorityType> {
     nonces: NonceCache,
@@ -168,7 +192,10 @@ pub struct OrderIntakeConsumer<OrderPriorityType> {
 }
 
 impl<OrderPriorityType: OrderPriority> OrderIntakeConsumer<OrderPriorityType> {
-    pub fn new(nonces: NonceCache, orders: broadcast::Receiver<SimulatedOrderCommand>) -> Self {
+    pub fn new(
+        nonces: NonceCache,
+        orders: broadcast::Receiver<SimulatedOrderJournalCommand>,
+    ) -> Self {
         Self {
             nonces,
             block_orders: PrioritizedOrderStore::new(vec![]),
@@ -177,23 +204,23 @@ impl<OrderPriorityType: OrderPriority> OrderIntakeConsumer<OrderPriorityType> {
         }
     }
 
-    /// Returns true if success, on false builder should stop
+    /// On Ok returned:
+    ///     None -> builder should stop
+    ///     Some(next_seq) -> next_seq is the next expected sequence number for the order journal (last seen + 1)
     /// Blocks until the first item in the next batch is available.
-    pub fn blocking_consume_next_batch(&mut self) -> eyre::Result<bool> {
-        if !self.order_consumer.blocking_consume_next_commands()? {
-            return Ok(false);
+    pub fn blocking_consume_next_batch(&mut self) -> eyre::Result<Option<JournalSequenceNumber>> {
+        if let Some(next_seq) = self.order_consumer.blocking_consume_next_commands()? {
+            self.update_onchain_nonces()?;
+            self.order_consumer
+                .apply_new_commands(&mut self.block_orders);
+            return Ok(Some(next_seq));
+        } else {
+            return Ok(None);
         }
-        if !self.update_onchain_nonces()? {
-            return Ok(false);
-        }
-
-        self.order_consumer
-            .apply_new_commands(&mut self.block_orders);
-        Ok(true)
     }
 
     /// Updates block_orders with all the nonce needed for the new orders
-    fn update_onchain_nonces(&mut self) -> eyre::Result<bool> {
+    fn update_onchain_nonces(&mut self) -> eyre::Result<()> {
         let new_orders = self
             .order_consumer
             .new_commands()
@@ -217,7 +244,7 @@ impl<OrderPriorityType: OrderPriority> OrderIntakeConsumer<OrderPriorityType> {
             }
         }
         self.block_orders.update_onchain_nonces(&nonces);
-        Ok(true)
+        Ok(())
     }
 
     pub fn current_block_orders(&self) -> PrioritizedOrderStore<OrderPriorityType> {
@@ -236,7 +263,7 @@ impl<OrderPriorityType: OrderPriority> OrderIntakeConsumer<OrderPriorityType> {
 pub struct BlockBuildingAlgorithmInput<P> {
     pub provider: P,
     pub ctx: BlockBuildingContext,
-    pub input: broadcast::Receiver<SimulatedOrderCommand>,
+    pub input: broadcast::Receiver<SimulatedOrderJournalCommand>,
     /// output for the blocks
     pub sink: UnfinishedBuiltBlocksInput,
     /// A cache common to several builders so they can optimize their work looking at other builders blocks.

--- a/crates/rbuilder/src/building/builders/mod.rs
+++ b/crates/rbuilder/src/building/builders/mod.rs
@@ -213,9 +213,9 @@ impl<OrderPriorityType: OrderPriority> OrderIntakeConsumer<OrderPriorityType> {
             self.update_onchain_nonces()?;
             self.order_consumer
                 .apply_new_commands(&mut self.block_orders);
-            return Ok(Some(next_seq));
+            Ok(Some(next_seq))
         } else {
-            return Ok(None);
+            Ok(None)
         }
     }
 

--- a/crates/rbuilder/src/building/builders/ordering_builder.rs
+++ b/crates/rbuilder/src/building/builders/ordering_builder.rs
@@ -12,6 +12,7 @@ use crate::{
             block_building_helper::BlockBuildingHelper, BuiltBlockId, LiveBuilderInput,
             OrderIntakeConsumer,
         },
+        journal::JournalSequenceNumber,
         order_is_worth_executing, BlockBuildingContext, ExecutionError,
         NullPartialBlockExecutionTracer, OrderPriority, PartialBlockExecutionTracer,
         PrioritizedOrderStore, SimulatedOrderSink, Sorting, ThreadBlockBuildingContext,
@@ -131,9 +132,12 @@ pub fn run_ordering_builder<P, OrderPriorityType>(
             break 'building;
         }
 
-        match order_intake_consumer.blocking_consume_next_batch() {
-            Ok(ok) => {
-                if !ok {
+        let next_journal_sequence_number = match order_intake_consumer.blocking_consume_next_batch()
+        {
+            Ok(next_seq) => {
+                if let Some(next_seq) = next_seq {
+                    next_seq
+                } else {
                     break 'building;
                 }
             }
@@ -141,10 +145,11 @@ pub fn run_ordering_builder<P, OrderPriorityType>(
                 error!(?err, "Error consuming next order batch");
                 continue;
             }
-        }
+        };
 
         let orders = order_intake_consumer.current_block_orders();
         match builder.build_block(
+            next_journal_sequence_number,
             orders,
             input.built_block_id_source.get_new_id(),
             input.cancel.clone(),
@@ -194,6 +199,7 @@ where
         Arc::new(BuiltBlockCache::new()),
     );
     let mut block_builder = builder.build_block_with_execution_tracer(
+        0,
         block_orders,
         BuiltBlockId::ZERO,
         CancellationToken::new(),
@@ -254,11 +260,13 @@ impl OrderingBuilderContext {
 
     pub fn build_block<OrderPriorityType: OrderPriority>(
         &mut self,
+        next_journal_sequence_number: JournalSequenceNumber,
         block_orders: PrioritizedOrderStore<OrderPriorityType>,
         built_block_id: BuiltBlockId,
         cancel_block: CancellationToken,
     ) -> eyre::Result<Box<dyn BlockBuildingHelper>> {
         self.build_block_with_execution_tracer(
+            next_journal_sequence_number,
             block_orders,
             built_block_id,
             cancel_block,
@@ -274,6 +282,7 @@ impl OrderingBuilderContext {
         PartialBlockExecutionTracerType: PartialBlockExecutionTracer + Clone + Send + Sync + 'static,
     >(
         &mut self,
+        next_journal_sequence_number: JournalSequenceNumber,
         mut block_orders: PrioritizedOrderStore<OrderPriorityType>,
         built_block_id: BuiltBlockId,
         cancel_block: CancellationToken,
@@ -291,6 +300,7 @@ impl OrderingBuilderContext {
 
         let mut block_building_helper = BlockBuildingHelperFromProvider::new_with_execution_tracer(
             built_block_id,
+            next_journal_sequence_number,
             self.state.clone(),
             self.ctx.clone(),
             &mut self.local_ctx,

--- a/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/block_building_result_assembler.rs
@@ -179,15 +179,16 @@ impl BlockBuildingResultAssembler {
     /// # Returns
     ///
     /// A Result containing the new block building helper or an error.
+    #[allow(unreachable_code)]
     pub fn build_new_block(
         &mut self,
         best_orderings_per_group: &mut [(ResolutionResult, ConflictGroup)],
         orders_closed_at: OffsetDateTime,
     ) -> eyre::Result<Box<dyn BlockBuildingHelper>> {
         let build_start = Instant::now();
-
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
             self.built_block_id_source.get_new_id(),
+            0,
             self.state.clone(),
             self.ctx.clone(),
             &mut self.local_ctx,
@@ -253,6 +254,10 @@ impl BlockBuildingResultAssembler {
             }
         }
         block_building_helper.set_trace_fill_time(build_start.elapsed());
+        panic!(
+            "TODO: next_journal_sequence_number not set in BlockBuildingHelperFromProvider::new"
+        );
+
         Ok(Box::new(block_building_helper))
     }
 
@@ -263,6 +268,7 @@ impl BlockBuildingResultAssembler {
     ) -> eyre::Result<Box<dyn BlockBuildingHelper>> {
         let mut block_building_helper = BlockBuildingHelperFromProvider::new(
             self.built_block_id_source.get_new_id(),
+            0,
             self.state.clone(),
             self.ctx.clone(),
             &mut self.local_ctx,

--- a/crates/rbuilder/src/building/builders/parallel_builder/order_intake_store.rs
+++ b/crates/rbuilder/src/building/builders/parallel_builder/order_intake_store.rs
@@ -2,9 +2,8 @@ use std::sync::Arc;
 
 use tokio::sync::broadcast;
 
-use crate::{
-    building::{builders::OrderConsumer, SimulatedOrderStore},
-    live_builder::simulation::SimulatedOrderCommand,
+use crate::building::{
+    builders::OrderConsumer, journal::SimulatedOrderJournalCommand, SimulatedOrderStore,
 };
 use rbuilder_primitives::SimulatedOrder;
 
@@ -19,7 +18,7 @@ pub struct OrderIntakeStore {
 }
 
 impl OrderIntakeStore {
-    pub fn new(orders_input_stream: broadcast::Receiver<SimulatedOrderCommand>) -> Self {
+    pub fn new(orders_input_stream: broadcast::Receiver<SimulatedOrderJournalCommand>) -> Self {
         let order_sink = SimulatedOrderStore::new();
         Self {
             order_consumer: OrderConsumer::new(orders_input_stream),

--- a/crates/rbuilder/src/building/built_block_trace.rs
+++ b/crates/rbuilder/src/building/built_block_trace.rs
@@ -1,5 +1,5 @@
 use crate::{
-    building::builders::BuiltBlockId,
+    building::{builders::BuiltBlockId, journal::JournalSequenceNumber},
     live_builder::block_output::bidding_service_interface::CompetitionBidContext,
 };
 
@@ -63,6 +63,8 @@ pub struct BuiltBlockTrace {
     pub filtered_build_considered_orders_statistics: OrderStatistics,
     /// Anything we call BlockBuildingHelper::commit_order on but didn't include (redundant with filtered_build_considered_orders_statistics-included_orders) during pre-filtered build step
     pub filtered_build_failed_orders_statistics: OrderStatistics,
+    /// last journal sequence number + 1 that we saw in the order journal. 0 means nothing processed.
+    pub next_journal_sequence_number: JournalSequenceNumber,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -78,7 +80,10 @@ pub enum BuiltBlockTraceError {
 }
 
 impl BuiltBlockTrace {
-    pub fn new(build_block_id: BuiltBlockId) -> Self {
+    pub fn new(
+        build_block_id: BuiltBlockId,
+        next_journal_sequence_number: JournalSequenceNumber,
+    ) -> Self {
         Self {
             included_orders: Vec::new(),
             bid_value: U256::from(0),
@@ -105,6 +110,7 @@ impl BuiltBlockTrace {
             build_block_id,
             subsidy: I256::ZERO,
             multi_bid_copy_duration: Duration::ZERO,
+            next_journal_sequence_number,
         }
     }
 

--- a/crates/rbuilder/src/building/journal.rs
+++ b/crates/rbuilder/src/building/journal.rs
@@ -1,4 +1,4 @@
-use crate::live_builder::simulation::SimulatedOrderCommand;
+use crate::live_builder::{payload_events::MevBoostSlotData, simulation::SimulatedOrderCommand};
 
 /// Sequence number of the SimulatedOrderCommand in the journal.
 /// Starts at 0 and increments by 1 for each SimulatedOrderCommand.
@@ -24,5 +24,21 @@ impl SimulatedOrderJournalCommand {
 
     pub fn command(&self) -> &SimulatedOrderCommand {
         &self.command
+    }
+}
+
+pub trait OrderJournalObserver: std::fmt::Debug {
+    fn order_delivered(&self, slot_data: &MevBoostSlotData, command: &SimulatedOrderJournalCommand);
+}
+
+#[derive(Debug)]
+pub struct NullOrderJournalObserver {}
+
+impl OrderJournalObserver for NullOrderJournalObserver {
+    fn order_delivered(
+        &self,
+        _slot_data: &MevBoostSlotData,
+        _command: &SimulatedOrderJournalCommand,
+    ) {
     }
 }

--- a/crates/rbuilder/src/building/journal.rs
+++ b/crates/rbuilder/src/building/journal.rs
@@ -1,4 +1,12 @@
+use thiserror::Error;
+
 use crate::live_builder::{payload_events::MevBoostSlotData, simulation::SimulatedOrderCommand};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("slot already in progress")]
+    SlotAlreadyInProgress,
+}
 
 /// Sequence number of the SimulatedOrderCommand in the journal.
 /// Starts at 0 and increments by 1 for each SimulatedOrderCommand.
@@ -27,18 +35,32 @@ impl SimulatedOrderJournalCommand {
     }
 }
 
+pub trait OrderJournalObserverFactory: std::fmt::Debug {
+    fn create_observer(
+        &self,
+        slot_data: &MevBoostSlotData,
+    ) -> Result<Box<dyn OrderJournalObserver + Send + Sync>, Error>;
+}
+
 pub trait OrderJournalObserver: std::fmt::Debug {
-    fn order_delivered(&self, slot_data: &MevBoostSlotData, command: &SimulatedOrderJournalCommand);
+    fn order_delivered(&self, command: &SimulatedOrderJournalCommand);
+}
+
+#[derive(Debug)]
+pub struct NullOrderJournalObserverFactory {}
+
+impl OrderJournalObserverFactory for NullOrderJournalObserverFactory {
+    fn create_observer(
+        &self,
+        _slot_data: &MevBoostSlotData,
+    ) -> Result<Box<dyn OrderJournalObserver + Send + Sync>, Error> {
+        Ok(Box::new(NullOrderJournalObserver {}))
+    }
 }
 
 #[derive(Debug)]
 pub struct NullOrderJournalObserver {}
 
 impl OrderJournalObserver for NullOrderJournalObserver {
-    fn order_delivered(
-        &self,
-        _slot_data: &MevBoostSlotData,
-        _command: &SimulatedOrderJournalCommand,
-    ) {
-    }
+    fn order_delivered(&self, _command: &SimulatedOrderJournalCommand) {}
 }

--- a/crates/rbuilder/src/building/journal.rs
+++ b/crates/rbuilder/src/building/journal.rs
@@ -1,0 +1,28 @@
+use crate::live_builder::simulation::SimulatedOrderCommand;
+
+/// Sequence number of the SimulatedOrderCommand in the journal.
+/// Starts at 0 and increments by 1 for each SimulatedOrderCommand.
+pub type JournalSequenceNumber = usize;
+/// SimulatedOrderCommands than enter block building in a sequential way.
+#[derive(Clone, Debug)]
+pub struct SimulatedOrderJournalCommand {
+    command: SimulatedOrderCommand,
+    sequence_number: JournalSequenceNumber,
+}
+
+impl SimulatedOrderJournalCommand {
+    pub fn new(command: SimulatedOrderCommand, sequence_number: JournalSequenceNumber) -> Self {
+        Self {
+            command,
+            sequence_number,
+        }
+    }
+
+    pub fn sequence_number(&self) -> JournalSequenceNumber {
+        self.sequence_number
+    }
+
+    pub fn command(&self) -> &SimulatedOrderCommand {
+        &self.command
+    }
+}

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -81,6 +81,7 @@ pub mod cached_reads;
 pub mod conflict;
 pub mod evm;
 pub mod fmt;
+pub mod journal;
 pub mod order_commit;
 pub mod payout_tx;
 pub mod precompile_cache;

--- a/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
+++ b/crates/rbuilder/src/building/testing/bundle_tests/mod.rs
@@ -443,7 +443,7 @@ fn test_bundle_consistency_check() -> eyre::Result<()> {
     let blocklist = HashSet::default();
     // check revertible tx detection
     {
-        let mut built_block_trace = BuiltBlockTrace::new(BuiltBlockId::ZERO);
+        let mut built_block_trace = BuiltBlockTrace::new(BuiltBlockId::ZERO, 0);
 
         // send to the blocked address
         test_setup.begin_bundle_order(block_number);
@@ -478,7 +478,7 @@ fn test_bundle_consistency_check() -> eyre::Result<()> {
         let blocklist = vec![test_setup.named_address(NamedAddr::User(0))?]
             .into_iter()
             .collect();
-        let mut built_block_trace = BuiltBlockTrace::new(BuiltBlockId::ZERO);
+        let mut built_block_trace = BuiltBlockTrace::new(BuiltBlockId::ZERO, 0);
 
         test_setup.begin_bundle_order(block_number);
         test_setup.add_dummy_tx_0_1_no_rev()?;
@@ -496,7 +496,7 @@ fn test_bundle_consistency_check() -> eyre::Result<()> {
         let blocklist = vec![test_setup.named_address(NamedAddr::User(1))?]
             .into_iter()
             .collect();
-        let mut built_block_trace = BuiltBlockTrace::new(BuiltBlockId::ZERO);
+        let mut built_block_trace = BuiltBlockTrace::new(BuiltBlockId::ZERO, 0);
 
         test_setup.begin_bundle_order(block_number);
         test_setup.add_dummy_tx_0_1_no_rev()?;

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -1,7 +1,7 @@
 //! Config should always be deserializable, default values should be used
 //!
 use crate::{
-    building::journal::NullOrderJournalObserver,
+    building::journal::NullOrderJournalObserverFactory,
     live_builder::{
         order_flow_tracing::order_flow_tracer_manager::{
             NullOrderFlowTracerManager, OrderFlowTracerManager, OrderFlowTracerManagerImpl,
@@ -277,7 +277,7 @@ impl BaseConfig {
             simulation_use_random_coinbase: self.simulation_use_random_coinbase,
             faster_finalize: self.faster_finalize,
             order_flow_tracer_manager,
-            order_journal_observer: Arc::new(NullOrderJournalObserver {}),
+            order_journal_observer_factory: Box::new(NullOrderJournalObserverFactory {}),
         })
     }
 

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -1,6 +1,7 @@
 //! Config should always be deserializable, default values should be used
 //!
 use crate::{
+    building::journal::NullOrderJournalObserver,
     live_builder::{
         order_flow_tracing::order_flow_tracer_manager::{
             NullOrderFlowTracerManager, OrderFlowTracerManager, OrderFlowTracerManagerImpl,
@@ -276,6 +277,7 @@ impl BaseConfig {
             simulation_use_random_coinbase: self.simulation_use_random_coinbase,
             faster_finalize: self.faster_finalize,
             order_flow_tracer_manager,
+            order_journal_observer: Arc::new(NullOrderJournalObserver {}),
         })
     }
 

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -3,7 +3,7 @@ pub mod built_block_cache;
 use crate::{
     building::{
         builders::{BlockBuildingAlgorithm, BlockBuildingAlgorithmInput, BuiltBlockIdSource},
-        journal::SimulatedOrderJournalCommand,
+        journal::{OrderJournalObserver, SimulatedOrderJournalCommand},
         BlockBuildingContext,
     },
     live_builder::{
@@ -53,6 +53,7 @@ pub struct BlockBuildingPool<P> {
     run_sparse_trie_prefetcher: bool,
     order_flow_tracer_manager: Box<dyn OrderFlowTracerManager>,
     built_block_id_source: Arc<BuiltBlockIdSource>,
+    order_journal_observer: Arc<dyn OrderJournalObserver + Send + Sync>,
 }
 
 impl<P> BlockBuildingPool<P>
@@ -68,6 +69,7 @@ where
         order_simulation_pool: OrderSimulationPool<P>,
         run_sparse_trie_prefetcher: bool,
         order_flow_tracer_manager: Box<dyn OrderFlowTracerManager>,
+        order_journal_observer: Arc<dyn OrderJournalObserver + Send + Sync>,
     ) -> Self {
         BlockBuildingPool {
             provider,
@@ -78,6 +80,7 @@ where
             run_sparse_trie_prefetcher,
             order_flow_tracer_manager,
             built_block_id_source: Arc::new(BuiltBlockIdSource::new()),
+            order_journal_observer,
         }
     }
 
@@ -171,6 +174,7 @@ where
         mut input: SlotOrderSimResults,
         cancel: CancellationToken,
     ) {
+        let slot_data_copy = slot_data.clone();
         let built_block_cache = Arc::new(BuiltBlockCache::new());
         let builder_sink =
             self.sink_factory
@@ -218,6 +222,8 @@ where
             });
         }
 
+        let order_journal_observer = self.order_journal_observer.clone();
+
         thread::spawn(move || {
             let mut next_journal_sequence_number = 0;
             while let Some(input) = input.orders.blocking_recv() {
@@ -226,6 +232,7 @@ where
                 let journal_command =
                     SimulatedOrderJournalCommand::new(input, next_journal_sequence_number);
                 next_journal_sequence_number += 1;
+                order_journal_observer.order_delivered(&slot_data_copy, &journal_command);
                 // we don't create new subscribers to the broadcast so here we can be sure that err means end of receivers
                 if broadcast_input.send(journal_command).is_err() {
                     trace!("Cancelling simulated orders send job, destination stopped");

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -3,6 +3,7 @@ pub mod built_block_cache;
 use crate::{
     building::{
         builders::{BlockBuildingAlgorithm, BlockBuildingAlgorithmInput, BuiltBlockIdSource},
+        journal::SimulatedOrderJournalCommand,
         BlockBuildingContext,
     },
     live_builder::{
@@ -18,13 +19,19 @@ use crate::{
     provider::StateProviderFactory,
 };
 use reth_chainspec::EthereumHardforks as _;
-use std::{sync::Arc, thread, time::Duration};
+use std::{
+    sync::{mpsc, Arc},
+    thread,
+    time::Duration,
+};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 
 /// Interval for checking if last block still corresponds to the parent of the given block building context
 const CHECK_LAST_BLOCK_INTERVAL: Duration = Duration::from_millis(100);
+/// Size of channels for sending simulated orders to the builders or root hash prefetching.
+const SIMULATED_ORDERS_CHANNEL_CAPACITY: usize = 10_000;
 
 use super::{
     block_output::unfinished_block_processing::UnfinishedBuiltBlocksInputFactory,
@@ -32,7 +39,7 @@ use super::{
         self, order_replacement_manager::OrderReplacementManager, orderpool::OrdersForBlock,
     },
     payload_events,
-    simulation::OrderSimulationPool,
+    simulation::{OrderSimulationPool, SimulatedOrderCommand},
 };
 
 /// Struct to connect the pipeline for block building.
@@ -168,7 +175,11 @@ where
         let builder_sink =
             self.sink_factory
                 .create_sink(slot_data, built_block_cache.clone(), cancel.clone());
-        let (broadcast_input, _) = broadcast::channel(10_000);
+        let (broadcast_input, _) = broadcast::channel(SIMULATED_ORDERS_CHANNEL_CAPACITY);
+
+        let (root_hasher_prefetcher_sender, root_hasher_prefetcher_receiver) =
+            mpsc::sync_channel::<SimulatedOrderCommand>(SIMULATED_ORDERS_CHANNEL_CAPACITY);
+
         let block_number = ctx.block();
         for builder in self.builders.iter() {
             let builder_name = builder.name();
@@ -201,17 +212,22 @@ where
         }
 
         if self.run_sparse_trie_prefetcher {
-            let input = broadcast_input.subscribe();
-
             tokio::task::spawn_blocking(move || {
-                ctx.root_hasher.run_prefetcher(input, cancel);
+                ctx.root_hasher
+                    .run_prefetcher(root_hasher_prefetcher_receiver);
             });
         }
 
         thread::spawn(move || {
+            let mut next_journal_sequence_number = 0;
             while let Some(input) = input.orders.blocking_recv() {
+                // Failing is not critical.
+                let _ = root_hasher_prefetcher_sender.try_send(input.clone());
+                let journal_command =
+                    SimulatedOrderJournalCommand::new(input, next_journal_sequence_number);
+                next_journal_sequence_number += 1;
                 // we don't create new subscribers to the broadcast so here we can be sure that err means end of receivers
-                if broadcast_input.send(input).is_err() {
+                if broadcast_input.send(journal_command).is_err() {
                     trace!("Cancelling simulated orders send job, destination stopped");
                     return;
                 }

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -3,7 +3,7 @@ pub mod built_block_cache;
 use crate::{
     building::{
         builders::{BlockBuildingAlgorithm, BlockBuildingAlgorithmInput, BuiltBlockIdSource},
-        journal::{OrderJournalObserver, SimulatedOrderJournalCommand},
+        journal::{OrderJournalObserverFactory, SimulatedOrderJournalCommand},
         BlockBuildingContext,
     },
     live_builder::{
@@ -26,7 +26,7 @@ use std::{
 };
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 /// Interval for checking if last block still corresponds to the parent of the given block building context
 const CHECK_LAST_BLOCK_INTERVAL: Duration = Duration::from_millis(100);
@@ -53,7 +53,7 @@ pub struct BlockBuildingPool<P> {
     run_sparse_trie_prefetcher: bool,
     order_flow_tracer_manager: Box<dyn OrderFlowTracerManager>,
     built_block_id_source: Arc<BuiltBlockIdSource>,
-    order_journal_observer: Arc<dyn OrderJournalObserver + Send + Sync>,
+    order_journal_observer_factory: Box<dyn OrderJournalObserverFactory + Send + Sync>,
 }
 
 impl<P> BlockBuildingPool<P>
@@ -69,7 +69,7 @@ where
         order_simulation_pool: OrderSimulationPool<P>,
         run_sparse_trie_prefetcher: bool,
         order_flow_tracer_manager: Box<dyn OrderFlowTracerManager>,
-        order_journal_observer: Arc<dyn OrderJournalObserver + Send + Sync>,
+        order_journal_observer_factory: Box<dyn OrderJournalObserverFactory + Send + Sync>,
     ) -> Self {
         BlockBuildingPool {
             provider,
@@ -80,7 +80,7 @@ where
             run_sparse_trie_prefetcher,
             order_flow_tracer_manager,
             built_block_id_source: Arc::new(BuiltBlockIdSource::new()),
-            order_journal_observer,
+            order_journal_observer_factory,
         }
     }
 
@@ -174,7 +174,20 @@ where
         mut input: SlotOrderSimResults,
         cancel: CancellationToken,
     ) {
-        let slot_data_copy = slot_data.clone();
+        let order_journal_observer = match self
+            .order_journal_observer_factory
+            .create_observer(&slot_data)
+        {
+            Ok(order_journal_observer) => order_journal_observer,
+            Err(err) => {
+                error!(
+                    ?err,
+                    "Failed to create order journal observer, cancelling building job"
+                );
+                cancel.cancel();
+                return;
+            }
+        };
         let built_block_cache = Arc::new(BuiltBlockCache::new());
         let builder_sink =
             self.sink_factory
@@ -222,8 +235,6 @@ where
             });
         }
 
-        let order_journal_observer = self.order_journal_observer.clone();
-
         thread::spawn(move || {
             let mut next_journal_sequence_number = 0;
             while let Some(input) = input.orders.blocking_recv() {
@@ -232,7 +243,7 @@ where
                 let journal_command =
                     SimulatedOrderJournalCommand::new(input, next_journal_sequence_number);
                 next_journal_sequence_number += 1;
-                order_journal_observer.order_delivered(&slot_data_copy, &journal_command);
+                order_journal_observer.order_delivered(&journal_command);
                 // we don't create new subscribers to the broadcast so here we can be sure that err means end of receivers
                 if broadcast_input.send(journal_command).is_err() {
                     trace!("Cancelling simulated orders send job, destination stopped");

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -13,7 +13,9 @@ pub mod wallet_balance_watcher;
 pub mod watchdog;
 
 use crate::{
-    building::{builders::BlockBuildingAlgorithm, BlockBuildingContext},
+    building::{
+        builders::BlockBuildingAlgorithm, journal::OrderJournalObserver, BlockBuildingContext,
+    },
     live_builder::{
         order_flow_tracing::order_flow_tracer_manager::OrderFlowTracerManager,
         order_input::{start_orderpool_jobs, OrderInputConfig},
@@ -143,6 +145,7 @@ where
     pub simulation_use_random_coinbase: bool,
 
     pub order_flow_tracer_manager: Box<dyn OrderFlowTracerManager>,
+    pub order_journal_observer: Arc<dyn OrderJournalObserver + Send + Sync>,
 }
 
 impl<P> LiveBuilder<P>
@@ -155,6 +158,16 @@ where
 
     pub fn with_builders(self, builders: Vec<Arc<dyn BlockBuildingAlgorithm<P>>>) -> Self {
         Self { builders, ..self }
+    }
+
+    pub fn with_order_journal_observer(
+        self,
+        order_journal_observer: Arc<dyn OrderJournalObserver + Send + Sync>,
+    ) -> Self {
+        Self {
+            order_journal_observer,
+            ..self
+        }
     }
 
     pub fn add_critical_task(&mut self, handle: JoinHandle<()>) {
@@ -246,6 +259,7 @@ where
             order_simulation_pool,
             self.run_sparse_trie_prefetcher,
             self.order_flow_tracer_manager,
+            self.order_journal_observer,
         );
 
         ready_to_build.store(true, Ordering::Relaxed);

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -14,7 +14,8 @@ pub mod watchdog;
 
 use crate::{
     building::{
-        builders::BlockBuildingAlgorithm, journal::OrderJournalObserver, BlockBuildingContext,
+        builders::BlockBuildingAlgorithm, journal::OrderJournalObserverFactory,
+        BlockBuildingContext,
     },
     live_builder::{
         order_flow_tracing::order_flow_tracer_manager::OrderFlowTracerManager,
@@ -145,7 +146,7 @@ where
     pub simulation_use_random_coinbase: bool,
 
     pub order_flow_tracer_manager: Box<dyn OrderFlowTracerManager>,
-    pub order_journal_observer: Arc<dyn OrderJournalObserver + Send + Sync>,
+    pub order_journal_observer_factory: Box<dyn OrderJournalObserverFactory + Send + Sync>,
 }
 
 impl<P> LiveBuilder<P>
@@ -160,12 +161,12 @@ where
         Self { builders, ..self }
     }
 
-    pub fn with_order_journal_observer(
+    pub fn with_order_journal_observer_factory(
         self,
-        order_journal_observer: Arc<dyn OrderJournalObserver + Send + Sync>,
+        order_journal_observer_factory: Box<dyn OrderJournalObserverFactory + Send + Sync>,
     ) -> Self {
         Self {
-            order_journal_observer,
+            order_journal_observer_factory,
             ..self
         }
     }
@@ -259,7 +260,7 @@ where
             order_simulation_pool,
             self.run_sparse_trie_prefetcher,
             self.order_flow_tracer_manager,
-            self.order_journal_observer,
+            self.order_journal_observer_factory,
         );
 
         ready_to_build.store(true, Ordering::Relaxed);

--- a/crates/rbuilder/src/provider/ipc_state_provider.rs
+++ b/crates/rbuilder/src/provider/ipc_state_provider.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     fmt::Debug,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{mpsc, Arc},
     time::Duration,
 };
 
@@ -30,8 +30,6 @@ use revm::{
     primitives::HashMap,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use tokio::sync::broadcast;
-use tokio_util::sync::CancellationToken;
 use tracing::{trace, trace_span};
 
 use crate::{
@@ -437,11 +435,7 @@ pub struct StatRootHashCalculator {
 }
 
 impl RootHasher for StatRootHashCalculator {
-    fn run_prefetcher(
-        &self,
-        _simulated_orders: broadcast::Receiver<SimulatedOrderCommand>,
-        _cancel: CancellationToken,
-    ) {
+    fn run_prefetcher(&self, _simulated_orders: mpsc::Receiver<SimulatedOrderCommand>) {
         unimplemented!()
     }
 

--- a/crates/rbuilder/src/provider/mod.rs
+++ b/crates/rbuilder/src/provider/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc;
+
 use crate::{
     building::ThreadBlockBuildingContext, live_builder::simulation::SimulatedOrderCommand,
     roothash::RootHashError,
@@ -9,8 +11,6 @@ use eth_sparse_mpt::utils::{HashMap, HashSet};
 use reth_errors::ProviderResult;
 use reth_provider::StateProviderBox;
 use revm::database::BundleState;
-use tokio::sync::broadcast;
-use tokio_util::sync::CancellationToken;
 
 pub mod ipc_state_provider;
 pub mod reth_prov;
@@ -46,11 +46,7 @@ pub trait StateProviderFactory: Send + Sync {
 pub trait RootHasher: std::fmt::Debug + Send + Sync {
     /// Must be called once before using.
     /// This is too specific and prone to error (you may forget to call it), maybe it's a better idea to pass this to StateProviderFactory::root_hasher and let each RootHasher decide what to do?
-    fn run_prefetcher(
-        &self,
-        simulated_orders: broadcast::Receiver<SimulatedOrderCommand>,
-        cancel: CancellationToken,
-    );
+    fn run_prefetcher(&self, simulated_orders: mpsc::Receiver<SimulatedOrderCommand>);
 
     /// State root for changes outcome on top of parent block.
     /// Incermental change is a list of accounts that are changed for the block since the last call to state_root

--- a/crates/rbuilder/src/roothash/prefetcher.rs
+++ b/crates/rbuilder/src/roothash/prefetcher.rs
@@ -1,4 +1,4 @@
-use std::{iter, time::Instant};
+use std::{iter, sync::mpsc, time::Instant};
 
 use ahash::{HashMap, HashSet};
 use alloy_eips::BlockNumHash;
@@ -6,20 +6,26 @@ use alloy_primitives::Address;
 use eth_sparse_mpt::*;
 use reth::providers::providers::ConsistentDbView;
 use reth_provider::{BlockReader, DatabaseProviderFactory};
-use tokio::sync::broadcast::{
-    self,
-    error::{RecvError, TryRecvError},
-};
-use tokio_util::sync::CancellationToken;
-use tracing::{error, trace, warn};
+use tracing::{error, trace};
 
 use crate::{
     live_builder::simulation::SimulatedOrderCommand, telemetry::inc_root_hash_prefetch_count,
     utils::elapsed_ms,
 };
-use rbuilder_primitives::evm_inspector::SlotKey;
+use rbuilder_primitives::evm_inspector::{SlotKey, UsedStateTrace};
 
 const CONSUME_SIM_ORDERS_BATCH: usize = 128;
+
+fn add_trace_to_used_state_traces(
+    used_state_traces: &mut Vec<UsedStateTrace>,
+    sim_order: &SimulatedOrderCommand,
+) {
+    if let SimulatedOrderCommand::Simulation(sim_order) = sim_order {
+        if let Some(used_state_trace) = &sim_order.used_state_trace {
+            used_state_traces.push(used_state_trace.clone());
+        }
+    }
+}
 
 /// Runs a process that prefetches pieces of the trie based on the slots used by the order in simulation
 /// Its a blocking call so it should be spawned on the separate thread.
@@ -28,8 +34,7 @@ pub fn run_trie_prefetcher<P>(
     shared_sparse_mpt_cache: SparseTrieSharedCache,
     version: ETHSpareMPTVersion,
     provider: P,
-    mut simulated_orders: broadcast::Receiver<SimulatedOrderCommand>,
-    cancel: CancellationToken,
+    simulated_orders: mpsc::Receiver<SimulatedOrderCommand>,
 ) where
     P: DatabaseProviderFactory<Provider: BlockReader> + Send + Sync + Clone,
 {
@@ -48,56 +53,18 @@ pub fn run_trie_prefetcher<P>(
     loop {
         used_state_traces.clear();
         fetch_request.clear();
-
-        if cancel.is_cancelled() {
+        // Block for the first order or until the channel is closed
+        let Ok(sim_order) = simulated_orders.recv() else {
             return;
-        }
-
+        };
+        add_trace_to_used_state_traces(&mut used_state_traces, &sim_order);
+        // Try to batch as many extra orders as possible.
         for _ in 0..CONSUME_SIM_ORDERS_BATCH {
             match simulated_orders.try_recv() {
-                Ok(SimulatedOrderCommand::Simulation(sim_order)) => {
-                    if let Some(used_state_trace) = &sim_order.used_state_trace {
-                        used_state_traces.push(used_state_trace.clone());
-                    } else {
-                        continue;
-                    }
-                }
-                Ok(_) => continue,
-                Err(TryRecvError::Empty) => {
-                    if !used_state_traces.is_empty() {
-                        break;
-                    }
-                    // block so thread can sleep if there are no inputs
-                    match simulated_orders.blocking_recv() {
-                        Ok(SimulatedOrderCommand::Simulation(sim_order)) => {
-                            if let Some(used_state_trace) = &sim_order.used_state_trace {
-                                used_state_traces.push(used_state_trace.clone());
-                            } else {
-                                continue;
-                            }
-                        }
-                        Ok(_) => continue,
-                        Err(RecvError::Closed) => return,
-                        Err(RecvError::Lagged(msg)) => {
-                            warn!(
-                                "State trie prefetching thread lagging on sim orders channel: {}",
-                                msg
-                            );
-                            break;
-                        }
-                    }
-                }
-                Err(TryRecvError::Closed) => {
-                    return;
-                }
-                Err(TryRecvError::Lagged(msg)) => {
-                    warn!(
-                        "State trie prefetching thread lagging on sim orders channel: {}",
-                        msg
-                    );
-                    break;
-                }
-            };
+                Ok(sim_order) => add_trace_to_used_state_traces(&mut used_state_traces, &sim_order),
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => return,
+            }
         }
 
         for used_state_trace in used_state_traces.drain(..) {

--- a/crates/rbuilder/src/utils/provider_factory_reopen.rs
+++ b/crates/rbuilder/src/utils/provider_factory_reopen.rs
@@ -24,9 +24,11 @@ use reth_provider::{
     TrieReader,
 };
 use revm::database::BundleState;
-use std::{ops::DerefMut, path::PathBuf, sync::Arc};
-use tokio::sync::broadcast;
-use tokio_util::sync::CancellationToken;
+use std::{
+    ops::DerefMut,
+    path::PathBuf,
+    sync::{mpsc, Arc},
+};
 use tracing::{debug, error};
 
 /// This struct is used as a workaround for https://github.com/paradigmxyz/reth/issues/7836
@@ -300,18 +302,13 @@ where
         + Clone
         + 'static,
 {
-    fn run_prefetcher(
-        &self,
-        simulated_orders: broadcast::Receiver<SimulatedOrderCommand>,
-        cancel: CancellationToken,
-    ) {
+    fn run_prefetcher(&self, simulated_orders: mpsc::Receiver<SimulatedOrderCommand>) {
         run_trie_prefetcher(
             self.parent_num_hash,
             self.sparse_trie_shared_cache.clone(),
             self.config.sparse_mpt_version,
             self.provider.clone(),
             simulated_orders,
-            cancel,
         );
     }
 


### PR DESCRIPTION
## 📝 Summary

When order are broadcasted to the builders they are wrapped in a SimulatedOrderJournalCommand which contains a sequence number. The order id + this sequence number is stored in a new table.
When we build a block we store the last sequence number and store it in a new column in the blocks table.
This will later allow to check for the full flow the builder had when it built the block.


## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
