### PR TITLE
chore: Sharebundle cleanup

### DIFF
--- a/crates/rbuilder-primitives/src/lib.rs
+++ b/crates/rbuilder-primitives/src/lib.rs
@@ -135,7 +135,7 @@ pub struct Nonce {
     pub optional: bool,
 }
 
-/// Information regarding a new/update replaceable Bundle/ShareBundle.
+/// Information regarding a new/update replaceable Bundle.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ReplacementData<KeyType> {
     pub key: KeyType,

--- a/crates/rbuilder/src/backtest/redistribute/mod.rs
+++ b/crates/rbuilder/src/backtest/redistribute/mod.rs
@@ -68,7 +68,6 @@ pub enum InclusionChange {
 pub enum ExtendedOrderId {
     Tx(B256),
     Bundle { uuid: Uuid, hash: B256 },
-    ShareBundle(B256),
 }
 
 impl ExtendedOrderId {

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -443,14 +443,6 @@ pub struct ReservedPayout {
     pub base_fee: U256,
 }
 
-#[derive(Debug, Clone)]
-pub struct ShareBundleCommitResult {
-    pub bundle_ok: BundleOk,
-    pub coinbase_diff_before_payouts: U256,
-    pub total_payouts_promissed: U256,
-    pub payouts_promissed: HashMap<Address, ReservedPayout>,
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum CriticalCommitOrderError {
     #[error("Reth error: {0}")]

--- a/crates/rbuilder/src/live_builder/order_input/order_replacement_manager.rs
+++ b/crates/rbuilder/src/live_builder/order_input/order_replacement_manager.rs
@@ -16,7 +16,6 @@ use super::{order_sink::OrderSink, replaceable_order_sink::ReplaceableOrderSink}
 /// honor the replacement with highest `sequence_number`.
 ///
 /// Although all the structs and fields say "bundle" we always refer to Bundle
-/// or ShareBundle.
 ///
 /// For each bundle we keep the current [`BundleReplacementState`]
 #[derive(Debug)]
@@ -84,7 +83,7 @@ struct ValidBundleState {
     pub order_id: OrderId,
 }
 
-/// Last state we have for a replaceable ShareBundle.
+/// Last state we have for a replaceable Bundle.
 /// It updates itself on new orders.
 /// On new seq:
 ///     Valid upgrades if seq > current.

--- a/docs/LIVEBUILDER_DATAFLOW.md
+++ b/docs/LIVEBUILDER_DATAFLOW.md
@@ -92,7 +92,7 @@ Although this stage is referred to as "building," it doesn't completely build th
 The block building process begins with a flow of `ReplaceableOrderPoolCommand`s arriving from the `OrderPool` (subscribed via an OrderPoolSubscriber). These operations can be:
 - Adding a new order (`ReplaceableOrderPoolCommand::Order`)
 - Replacing an existing order (`ReplaceableOrderPoolCommand::Order` for an existing uuid)
-- Canceling an order (`ReplaceableOrderPoolCommand::CancelBundle`/`ReplaceableOrderPoolCommand::CancelShareBundle`)
+- Canceling an order (`ReplaceableOrderPoolCommand::CancelBundle`)
 
 Throughout the order pipeline, we consistently use these commands instead of plain `Orders` since the entire pipeline must handle updates and cancellations.
 


### PR DESCRIPTION
## 📝 Summary

Removes remaining code related to the ShareBundle type

## 💡 Motivation and Context

Since the type `ShareBundle` was removed in https://github.com/flashbots/rbuilder/pull/830, 

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [x] Added tests (if applicable)
