### PR TITLE
Improved metric to avoid alerts

### DIFF
--- a/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
+++ b/crates/rbuilder/src/live_builder/block_output/relay_submit.rs
@@ -10,8 +10,7 @@ use crate::{
     telemetry::{
         add_relay_submit_time, add_subsidy_value, inc_conn_relay_errors,
         inc_failed_block_simulations, inc_initiated_submissions, inc_other_relay_errors,
-        inc_relay_accepted_submissions, inc_subsidized_blocks, inc_too_many_req_relay_errors,
-        mark_submission_start_time,
+        inc_relay_accepted_submissions, inc_too_many_req_relay_errors, mark_submission_start_time,
     },
     utils::{duration_ms, error_storage::store_error_event},
 };
@@ -695,8 +694,8 @@ impl RelaySubmitSinkFactory {
                         .await;
                         if let Some(info) = last_info {
                             if info.bid_value > info.true_bid_value {
-                                inc_subsidized_blocks(false);
-                                add_subsidy_value(info.bid_value - info.true_bid_value, false);
+                                let subsidy_value = info.bid_value - info.true_bid_value;
+                                add_subsidy_value(subsidy_value, false);
                             }
                         }
                     }

--- a/crates/rbuilder/src/live_builder/wallet_balance_watcher.rs
+++ b/crates/rbuilder/src/live_builder/wallet_balance_watcher.rs
@@ -7,7 +7,7 @@ use tracing::{info, warn};
 
 use crate::{
     provider::StateProviderFactory,
-    telemetry::{add_subsidy_value, inc_subsidized_blocks, set_builder_balance},
+    telemetry::{add_subsidy_value, set_builder_balance},
 };
 
 use super::block_output::bidding_service_interface::LandedBlockInfo;
@@ -168,7 +168,6 @@ where
                     "Subsidy detected"
                 );
                 add_subsidy_value(subsidy_value, true);
-                inc_subsidized_blocks(true);
             }
             self.balance = landed_block_info.builder_balance;
             self.block_number = landed_block_info.block_number;

--- a/crates/rbuilder/src/telemetry/metrics/mod.rs
+++ b/crates/rbuilder/src/telemetry/metrics/mod.rs
@@ -674,13 +674,23 @@ fn subsidized_label(landed: bool) -> &'static str {
     }
 }
 
-pub fn inc_subsidized_blocks(landed: bool) {
+fn inc_subsidized_blocks(landed: bool) {
     SUBSIDIZED_BLOCK_COUNT
         .with_label_values(&[subsidized_label(landed)])
         .inc();
 }
 
+/// Hardcoded .1 ETH
+const MAX_POSSIBLE_SUBSIDY: U256 =
+    U256::from_limbs([10u64.pow((Unit::ETHER.get() - 1) as u32), 0, 0, 0]);
+
+/// We filter any negative delta bigger than MAX_POSSIBLE_SUBSIDY so we don't consider withdrawals as subsidies and ruin the metric (that could trigger alerts)
+/// This might miss some subsidies (we could have a withdrawal AND a subsidy)
 pub fn add_subsidy_value(value: U256, landed: bool) {
+    if value > MAX_POSSIBLE_SUBSIDY {
+        return;
+    }
+    inc_subsidized_blocks(landed);
     let value_float = 2.0_f64.powf(value.approx_log2()) / 10_f64.pow(Unit::ETHER.get());
     SUBSIDY_VALUE
         .with_label_values(&[subsidized_label(landed)])


### PR DESCRIPTION
## 📝 Summary

Now big negative balance deltas will not be counted as subsidies.
This might miss some subsidies (we could have a withdrawal AND a subsidy) but it's not critical.

## 💡 Motivation and Context

While receiving the Nobel Prize, I got a BuilderNet alert "subsidies too high" and had to forfeit it.
I turns out the subsidies were doing cocaine.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
