### PR TITLE
Builder name always needed on rbuilder-operator

### DIFF
--- a/crates/rbuilder-operator/src/flashbots_config.rs
+++ b/crates/rbuilder-operator/src/flashbots_config.rs
@@ -162,6 +162,10 @@ impl LiveBuilderConfig for FlashbotsConfig {
     where
         P: StateProviderFactory + Clone + 'static,
     {
+        if self.builder_name.is_empty() {
+            eyre::bail!("builder_name must be set on BuilderNet nodes");
+        }
+
         let abort_token = CancellationToken::new();
         if self.l1_config.relay_bid_scrapers.is_empty() {
             eyre::bail!("relay_bid_scrapers is not set");


### PR DESCRIPTION
## 📝 Summary

Builder name always needed on rbuilder-operator


## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
