### PR TITLE
MempoolTxsDetector is only fed with mempool txs.

### DIFF
--- a/crates/rbuilder/src/backtest/execute.rs
+++ b/crates/rbuilder/src/backtest/execute.rs
@@ -87,6 +87,8 @@ where
     Ok(ctx)
 }
 
+/// @Pending: change available_orders to some struct that allows to tell the difference between
+/// mempool txs and private txs.
 pub fn backtest_prepare_orders_from_building_context<P>(
     ctx: BlockBuildingContext,
     available_orders: Vec<OrdersWithTimestamp>,
@@ -100,7 +102,10 @@ where
         .map(|order| Arc::clone(&order.order))
         .collect();
     for order in &orders {
-        ctx.mempool_tx_detector.add_tx(order);
+        if let Order::Tx(mempool_tx) = order.as_ref() {
+            ctx.mempool_tx_detector
+                .add_tx(mempool_tx.tx_with_blobs.hash());
+        }
     }
 
     let (sim_orders, sim_errors) =

--- a/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
@@ -6,11 +6,10 @@ use std::{
 
 use alloy_primitives::{utils::format_ether, I256, U256};
 
-use crate::{
-    building::{builders::block_building_helper::BlockBuildingHelper, ThreadBlockBuildingContext},
-    live_builder::order_input::mempool_txs_detector::MempoolTxsDetector,
+use crate::building::{
+    builders::block_building_helper::BlockBuildingHelper, ThreadBlockBuildingContext,
 };
-use rbuilder_primitives::{order_statistics::OrderStatistics, Order, OrderId, SimulatedOrder};
+use rbuilder_primitives::{order_statistics::OrderStatistics, OrderId, SimulatedOrder};
 
 use super::block_building_helper::{BlockBuildingHelperError, FinalizeBlockResult};
 
@@ -95,12 +94,13 @@ impl<'a> BlockBuildingHelperStatsLogger<'a> {
 
     pub fn print(&self, orders: Vec<Arc<SimulatedOrder>>) {
         let mut order_id_to_order = HashMap::new();
-        let mempool_txs_detector = MempoolTxsDetector::new();
+        let mempool_txs_detector = self
+            .block_building_helper
+            .building_context()
+            .mempool_tx_detector
+            .clone();
         for sim_order in &orders {
             order_id_to_order.insert(sim_order.id(), sim_order.clone());
-            if let Order::Tx(mempool_tx) = sim_order.order.as_ref() {
-                mempool_txs_detector.add_tx(mempool_tx.tx_with_blobs.hash());
-            }
         }
 
         println!(

--- a/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
+++ b/crates/rbuilder/src/building/builders/block_building_helper_stats_logger.rs
@@ -10,7 +10,7 @@ use crate::{
     building::{builders::block_building_helper::BlockBuildingHelper, ThreadBlockBuildingContext},
     live_builder::order_input::mempool_txs_detector::MempoolTxsDetector,
 };
-use rbuilder_primitives::{order_statistics::OrderStatistics, OrderId, SimulatedOrder};
+use rbuilder_primitives::{order_statistics::OrderStatistics, Order, OrderId, SimulatedOrder};
 
 use super::block_building_helper::{BlockBuildingHelperError, FinalizeBlockResult};
 
@@ -98,7 +98,9 @@ impl<'a> BlockBuildingHelperStatsLogger<'a> {
         let mempool_txs_detector = MempoolTxsDetector::new();
         for sim_order in &orders {
             order_id_to_order.insert(sim_order.id(), sim_order.clone());
-            mempool_txs_detector.add_tx(&sim_order.order);
+            if let Order::Tx(mempool_tx) = sim_order.order.as_ref() {
+                mempool_txs_detector.add_tx(mempool_tx.tx_with_blobs.hash());
+            }
         }
 
         println!(

--- a/crates/rbuilder/src/building/mod.rs
+++ b/crates/rbuilder/src/building/mod.rs
@@ -148,6 +148,7 @@ impl BlockBuildingContext {
         faster_finalize: bool,
         mev_blocker_price: U256,
         adjustment_fee_payers: ahash::HashSet<Address>,
+        mempool_tx_detector: Arc<MempoolTxsDetector>,
     ) -> Option<BlockBuildingContext> {
         let attributes = EthPayloadBuilderAttributes::try_new(
             attributes.data.parent_block_hash,
@@ -219,7 +220,7 @@ impl BlockBuildingContext {
             shared_cached_reads: Default::default(),
             tx_execution_cache: Arc::new(TxExecutionCache::new(evm_caching_enable)),
             max_blob_gas_per_block,
-            mempool_tx_detector: Arc::new(MempoolTxsDetector::new()),
+            mempool_tx_detector,
             faster_finalize,
             mev_blocker_price,
             adjustment_fee_payers,
@@ -1319,9 +1320,7 @@ mod test {
         let detector = MempoolTxsDetector::new();
         let mut data_gen = TestDataGenerator::default();
         let tx1 = data_gen.create_tx_with_blobs_nonce(Default::default());
-        detector.add_tx(&Order::Tx(MempoolTx {
-            tx_with_blobs: tx1.clone(),
-        }));
+        detector.add_tx(tx1.hash());
         let tx2 = data_gen.create_tx_with_blobs_nonce(Default::default());
         let profit_1 = I256::unchecked_from(1000);
         let profit_2 = I256::unchecked_from(10000);
@@ -1371,7 +1370,7 @@ mod test {
         let order = Order::Tx(MempoolTx {
             tx_with_blobs: tx.clone(),
         });
-        detector.add_tx(&order);
+        detector.add_tx(tx.hash());
         let profit = I256::unchecked_from(1000);
         let order_ok = OrderOk {
             coinbase_profit: profit.unsigned_abs(),

--- a/crates/rbuilder/src/building/testing/test_chain_state.rs
+++ b/crates/rbuilder/src/building/testing/test_chain_state.rs
@@ -1,8 +1,7 @@
 use crate::{
     building::BlockBuildingContext,
     live_builder::{
-        block_list_provider::BlockList,
-        order_input::mempool_txs_detector::MempoolTxsDetector,
+        block_list_provider::BlockList, order_input::mempool_txs_detector::MempoolTxsDetector,
     },
     provider::RootHasher,
     roothash::RootHashContext,

--- a/crates/rbuilder/src/building/testing/test_chain_state.rs
+++ b/crates/rbuilder/src/building/testing/test_chain_state.rs
@@ -1,6 +1,9 @@
 use crate::{
     building::BlockBuildingContext,
-    live_builder::block_list_provider::BlockList,
+    live_builder::{
+        block_list_provider::BlockList,
+        order_input::mempool_txs_detector::MempoolTxsDetector,
+    },
     provider::RootHasher,
     roothash::RootHashContext,
     utils::{RootHasherImpl, Signer},
@@ -420,6 +423,7 @@ impl TestBlockContextBuilder {
             true,
             self.mev_block_price,
             Default::default(),
+            Arc::new(MempoolTxsDetector::new()),
         )
         .unwrap()
     }

--- a/crates/rbuilder/src/live_builder/base_config.rs
+++ b/crates/rbuilder/src/live_builder/base_config.rs
@@ -6,7 +6,7 @@ use crate::{
         order_flow_tracing::order_flow_tracer_manager::{
             NullOrderFlowTracerManager, OrderFlowTracerManager, OrderFlowTracerManagerImpl,
         },
-        order_input::OrderInputConfig,
+        order_input::{mempool_txs_detector::MempoolTxsDetector, OrderInputConfig},
         process_killer::ProcessKiller,
         LiveBuilder,
     },
@@ -278,6 +278,8 @@ impl BaseConfig {
             faster_finalize: self.faster_finalize,
             order_flow_tracer_manager,
             order_journal_observer_factory: Box::new(NullOrderJournalObserverFactory {}),
+
+            mempool_detector: Arc::new(MempoolTxsDetector::new()),
         })
     }
 

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -86,7 +86,6 @@ where
 
     /// Connects OrdersForBlock (source of orders) ->
     /// [Optional] OrderFlowTracerManager provided tracer ->
-    /// ReplaceableOrderStreamSniffer (notifies mempool txs to MempoolTxsDetector) ->
     /// BlobTypeOrderFilter (filters out Orders with incorrect blobs (pre/post fusaka)) ->
     /// OrderReplacementManager (Handles cancellations and replacements) -> Simulations and calls start_building_job
     pub fn start_block_building(
@@ -135,16 +134,10 @@ where
             )))
         };
 
-        let mempool_txs_detector_sniffer =
-            order_input::mempool_txs_detector::ReplaceableOrderStreamSniffer::new(
-                blob_type_order_filter,
-                block_ctx.mempool_tx_detector.clone(),
-            );
-
         // order_flow_tracer_manager may add some extra  ReplaceableOrderSink on the chain.
         let (sim_tracer, order_flow_input) = self.order_flow_tracer_manager.create_tracers(
             payload.slot_block_id(),
-            Box::new(mempool_txs_detector_sniffer),
+            blob_type_order_filter,
         );
 
         // sink removal is automatic via OrderSink::is_alive false

--- a/crates/rbuilder/src/live_builder/building/mod.rs
+++ b/crates/rbuilder/src/live_builder/building/mod.rs
@@ -135,10 +135,9 @@ where
         };
 
         // order_flow_tracer_manager may add some extra  ReplaceableOrderSink on the chain.
-        let (sim_tracer, order_flow_input) = self.order_flow_tracer_manager.create_tracers(
-            payload.slot_block_id(),
-            blob_type_order_filter,
-        );
+        let (sim_tracer, order_flow_input) = self
+            .order_flow_tracer_manager
+            .create_tracers(payload.slot_block_id(), blob_type_order_filter);
 
         // sink removal is automatic via OrderSink::is_alive false
         let _block_sub = self

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -413,8 +413,7 @@ where
             .pending_recovered()
             .chain(pool.all_transactions().queued_recovered())
         {
-            try_send_to_orderpool(tx, self.orderpool_sender.clone(), pool.clone(), &detector)
-                .await;
+            try_send_to_orderpool(tx, self.orderpool_sender.clone(), pool.clone(), &detector).await;
         }
 
         // Subscribe to new transactions in-process.
@@ -552,16 +551,12 @@ async fn try_send_to_orderpool<V, T, S>(
 {
     match TransactionSignedEcRecoveredWithBlobs::try_from_tx_without_blobs_and_pool(tx, pool) {
         Ok(tx) => {
-            mempool_detector.add_tx(tx.hash());
+            let tx_hash = tx.hash();
+            mempool_detector.add_tx(tx_hash);
             let order = Order::Tx(MempoolTx::new(tx));
             let command = ReplaceableOrderPoolCommand::Order(Arc::new(order));
             if let Err(e) = orderpool_sender.send(command).await {
-                mempool_detector.remove_tx(tx.hash());
-                error!("Error sending order to orderpool: {:#}", e);
-            }
-            let order = Order::Tx(MempoolTx::new(tx));
-            let command = ReplaceableOrderPoolCommand::Order(Arc::new(order));
-            if let Err(e) = orderpool_sender.send(command).await {
+                mempool_detector.remove_tx(tx_hash);
                 error!("Error sending order to orderpool: {:#}", e);
             }
         }

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -556,6 +556,12 @@ async fn try_send_to_orderpool<V, T, S>(
             let order = Order::Tx(MempoolTx::new(tx));
             let command = ReplaceableOrderPoolCommand::Order(Arc::new(order));
             if let Err(e) = orderpool_sender.send(command).await {
+                mempool_detector.remove_tx(tx.hash());
+                error!("Error sending order to orderpool: {:#}", e);
+            }
+            let order = Order::Tx(MempoolTx::new(tx));
+            let command = ReplaceableOrderPoolCommand::Order(Arc::new(order));
+            if let Err(e) = orderpool_sender.send(command).await {
                 error!("Error sending order to orderpool: {:#}", e);
             }
         }

--- a/crates/rbuilder/src/live_builder/mod.rs
+++ b/crates/rbuilder/src/live_builder/mod.rs
@@ -38,7 +38,7 @@ use building::BlockBuildingPool;
 use eyre::Context;
 use futures::{stream::FuturesUnordered, StreamExt};
 use jsonrpsee::RpcModule;
-use order_input::ReplaceableOrderPoolCommand;
+use order_input::{mempool_txs_detector::MempoolTxsDetector, ReplaceableOrderPoolCommand};
 use payload_events::{InternalPayloadId, MevBoostSlotDataGenerator};
 use rbuilder_primitives::{MempoolTx, Order, TransactionSignedEcRecoveredWithBlobs};
 use reth::transaction_pool::{
@@ -147,6 +147,8 @@ where
 
     pub order_flow_tracer_manager: Box<dyn OrderFlowTracerManager>,
     pub order_journal_observer_factory: Box<dyn OrderJournalObserverFactory + Send + Sync>,
+
+    pub mempool_detector: Arc<MempoolTxsDetector>,
 }
 
 impl<P> LiveBuilder<P>
@@ -230,6 +232,7 @@ where
 
         let (header_sender, header_receiver) = mpsc::channel(CLEAN_TASKS_CHANNEL_SIZE);
 
+        let mempool_detector = self.mempool_detector.clone();
         let orderpool_subscriber = {
             let (handle, sub) = start_orderpool_jobs(
                 self.order_input_config,
@@ -239,6 +242,7 @@ where
                 self.orderpool_sender,
                 self.orderpool_receiver,
                 header_receiver,
+                mempool_detector.clone(),
             )
             .await?;
             inner_jobs_handles.push(handle);
@@ -370,6 +374,7 @@ where
                     .iter()
                     .filter_map(|(_, r)| r.adjustment_fee_payer)
                     .collect(),
+                mempool_detector.clone(),
             ) {
                 mark_building_started(block_ctx.timestamp());
                 builder_pool.start_block_building(
@@ -401,13 +406,15 @@ where
         T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
         S: BlobStore,
     {
+        let detector = self.mempool_detector.clone();
         // Initialize the orderpool with every item in the reth pool.
         for tx in pool
             .all_transactions()
             .pending_recovered()
             .chain(pool.all_transactions().queued_recovered())
         {
-            try_send_to_orderpool(tx, self.orderpool_sender.clone(), pool.clone()).await;
+            try_send_to_orderpool(tx, self.orderpool_sender.clone(), pool.clone(), &detector)
+                .await;
         }
 
         // Subscribe to new transactions in-process.
@@ -416,7 +423,7 @@ where
         tokio::spawn(async move {
             while let Some(e) = recv.recv().await {
                 let tx = e.transaction.transaction.transaction().clone();
-                try_send_to_orderpool(tx, orderpool_sender.clone(), pool.clone()).await;
+                try_send_to_orderpool(tx, orderpool_sender.clone(), pool.clone(), &detector).await;
             }
         });
 
@@ -537,6 +544,7 @@ async fn try_send_to_orderpool<V, T, S>(
     tx: Recovered<TransactionSigned>,
     orderpool_sender: mpsc::Sender<ReplaceableOrderPoolCommand>,
     pool: Pool<V, T, S>,
+    mempool_detector: &Arc<MempoolTxsDetector>,
 ) where
     V: TransactionValidator<Transaction = EthPooledTransaction> + 'static,
     T: TransactionOrdering<Transaction = <V as TransactionValidator>::Transaction>,
@@ -544,6 +552,7 @@ async fn try_send_to_orderpool<V, T, S>(
 {
     match TransactionSignedEcRecoveredWithBlobs::try_from_tx_without_blobs_and_pool(tx, pool) {
         Ok(tx) => {
+            mempool_detector.add_tx(tx.hash());
             let order = Order::Tx(MempoolTx::new(tx));
             let command = ReplaceableOrderPoolCommand::Order(Arc::new(order));
             if let Err(e) = orderpool_sender.send(command).await {

--- a/crates/rbuilder/src/live_builder/order_input/mempool_txs_detector.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mempool_txs_detector.rs
@@ -1,44 +1,8 @@
-use std::sync::Arc;
-
 use ahash::RandomState;
 use alloy_primitives::TxHash;
 use dashmap::DashSet;
 
-use rbuilder_primitives::{BundleReplacementData, Order, TransactionSignedEcRecoveredWithBlobs};
-
-use super::replaceable_order_sink::ReplaceableOrderSink;
-
-/// Get's in the middle of a ReplaceableOrder stream a feeds a MempoolTxsDetector.
-#[derive(Debug)]
-pub struct ReplaceableOrderStreamSniffer {
-    detector: Arc<MempoolTxsDetector>,
-    sink: Box<dyn ReplaceableOrderSink>,
-}
-
-impl ReplaceableOrderStreamSniffer {
-    pub fn new(sink: Box<dyn ReplaceableOrderSink>, detector: Arc<MempoolTxsDetector>) -> Self {
-        Self { detector, sink }
-    }
-
-    pub fn detector(&self) -> Arc<MempoolTxsDetector> {
-        self.detector.clone()
-    }
-}
-
-impl ReplaceableOrderSink for ReplaceableOrderStreamSniffer {
-    fn insert_order(&mut self, order: Arc<Order>) -> bool {
-        self.detector.add_tx(&order);
-        self.sink.insert_order(order)
-    }
-
-    fn remove_bundle(&mut self, replacement_data: BundleReplacementData) -> bool {
-        self.sink.remove_bundle(replacement_data)
-    }
-
-    fn is_alive(&self) -> bool {
-        self.sink.is_alive()
-    }
-}
+use rbuilder_primitives::TransactionSignedEcRecoveredWithBlobs;
 
 /// Given a TransactionSignedEcRecoveredWithBlobs answers if the tx is from the mempool or not.
 /// Current implementation is super simple, it just checks the tx hash against a set of hashes.
@@ -54,10 +18,12 @@ impl MempoolTxsDetector {
         }
     }
 
-    pub fn add_tx(&self, order: &Order) {
-        if let Order::Tx(mempool_tx) = order {
-            self.mempool_txs.insert(mempool_tx.tx_with_blobs.hash());
-        }
+    pub fn add_tx(&self, hash: TxHash) {
+        self.mempool_txs.insert(hash);
+    }
+
+    pub fn remove_tx(&self, hash: TxHash) {
+        self.mempool_txs.remove(&hash);
     }
 
     pub fn is_mempool(&self, tx: &TransactionSignedEcRecoveredWithBlobs) -> bool {

--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -233,6 +233,7 @@ impl ReplaceableOrderPoolCommand {
 /// - Clean up task to remove old stuff.
 ///
 /// @Pending reengineering to modularize rpc, extra_rpc here is a patch to upgrade the created rpc server.
+#[allow(clippy::too_many_arguments)]
 pub async fn start_orderpool_jobs<P>(
     config: OrderInputConfig,
     provider_factory: P,

--- a/crates/rbuilder/src/live_builder/order_input/mod.rs
+++ b/crates/rbuilder/src/live_builder/order_input/mod.rs
@@ -241,6 +241,7 @@ pub async fn start_orderpool_jobs<P>(
     order_sender: mpsc::Sender<ReplaceableOrderPoolCommand>,
     order_receiver: mpsc::Receiver<ReplaceableOrderPoolCommand>,
     header_receiver: mpsc::Receiver<Header>,
+    mempool_detector: Arc<mempool_txs_detector::MempoolTxsDetector>,
 ) -> eyre::Result<(JoinHandle<()>, OrderPoolSubscriber)>
 where
     P: StateProviderFactory + 'static,
@@ -252,7 +253,10 @@ where
         warn!("ignore_blobs is set to true, some order input is ignored");
     }
 
-    let orderpool = Arc::new(Mutex::new(OrderPool::new(config.time_to_keep_mempool_txs)));
+    let orderpool = Arc::new(Mutex::new(OrderPool::new(
+        config.time_to_keep_mempool_txs,
+        mempool_detector.clone(),
+    )));
     let subscriber = OrderPoolSubscriber {
         orderpool: orderpool.clone(),
     };
@@ -279,6 +283,7 @@ where
         let txpool_fetcher = txpool_fetcher::subscribe_to_txpool_with_blobs(
             config.clone(),
             order_sender.clone(),
+            mempool_detector.clone(),
             global_cancel.clone(),
         )
         .await?;

--- a/crates/rbuilder/src/live_builder/order_input/orderpool.rs
+++ b/crates/rbuilder/src/live_builder/order_input/orderpool.rs
@@ -1,4 +1,5 @@
 use super::{
+    mempool_txs_detector::MempoolTxsDetector,
     order_sink::{OrderPoolCommand, OrderSender2OrderSink},
     replaceable_order_sink::ReplaceableOrderSink,
     ReplaceableOrderPoolCommand,
@@ -94,11 +95,15 @@ pub struct OrderPool {
     next_sink_id: u64,
     /// After this time a mempool tx is dropped.
     time_to_keep_mempool_txs: Duration,
+    mempool_detector: Arc<MempoolTxsDetector>,
 }
 
 impl OrderPool {
     /// Instantiate a new OrderPool.
-    pub fn new(time_to_keep_mempool_txs: Duration) -> Self {
+    pub fn new(
+        time_to_keep_mempool_txs: Duration,
+        mempool_detector: Arc<MempoolTxsDetector>,
+    ) -> Self {
         OrderPool {
             mempool_txs: Vec::new(),
             bundles_by_target_block: HashMap::default(),
@@ -109,6 +114,7 @@ impl OrderPool {
             bundle_cancellations: Default::default(),
             time_to_keep_mempool_txs,
             mempool_txs_size: 0,
+            mempool_detector,
         }
     }
 
@@ -266,6 +272,9 @@ impl OrderPool {
                 Self::must_retain_order(time, order, new_state, &self.time_to_keep_mempool_txs);
             if !retain {
                 self.mempool_txs_size -= Self::measure_tx(order);
+                if let Order::Tx(mempool_tx) = order.as_ref() {
+                    self.mempool_detector.remove_tx(mempool_tx.tx_with_blobs.hash());
+                }
             }
             retain
         });

--- a/crates/rbuilder/src/live_builder/order_input/orderpool.rs
+++ b/crates/rbuilder/src/live_builder/order_input/orderpool.rs
@@ -273,7 +273,8 @@ impl OrderPool {
             if !retain {
                 self.mempool_txs_size -= Self::measure_tx(order);
                 if let Order::Tx(mempool_tx) = order.as_ref() {
-                    self.mempool_detector.remove_tx(mempool_tx.tx_with_blobs.hash());
+                    self.mempool_detector
+                        .remove_tx(mempool_tx.tx_with_blobs.hash());
                 }
             }
             retain

--- a/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
+++ b/crates/rbuilder/src/live_builder/order_input/txpool_fetcher.rs
@@ -23,6 +23,7 @@ use tracing::{error, info, trace};
 pub async fn subscribe_to_txpool_with_blobs(
     config: OrderInputConfig,
     results: mpsc::Sender<ReplaceableOrderPoolCommand>,
+    mempool_detector: Arc<super::mempool_txs_detector::MempoolTxsDetector>,
     global_cancel: CancellationToken,
 ) -> eyre::Result<JoinHandle<()>> {
     let mempool = config
@@ -69,7 +70,6 @@ pub async fn subscribe_to_txpool_with_blobs(
                     continue;
                 }
             };
-
             let tx = MempoolTx::new(tx_with_blobs);
             let order = Order::Tx(tx);
             let parse_duration = start.elapsed();
@@ -82,7 +82,9 @@ pub async fn subscribe_to_txpool_with_blobs(
                 .send_timeout(orderpool_command, config.results_channel_timeout)
                 .await
             {
-                Ok(()) => {}
+                Ok(()) => {
+                    mempool_detector.add_tx(tx_hash);
+                }
                 Err(SendTimeoutError::Timeout(_)) => {
                     error!("Failed to send txpool tx to results channel, timeout");
                 }
@@ -140,6 +142,9 @@ mod test {
                 ..OrderInputConfig::default_e2e()
             },
             sender,
+            Arc::new(
+                crate::live_builder::order_input::mempool_txs_detector::MempoolTxsDetector::new(),
+            ),
             CancellationToken::new(),
         )
         .await


### PR DESCRIPTION
## 📝 Summary

MempoolTxsDetector used to consider as mempool any MempoolTx but those coming from eth_sendRawTransaction should not be considered as mempool.
MempoolTxsDetector was changed, now it's a long lived object.
We insert txs into MempoolTxsDetector on the read mempool tasks and clean it on the OrderPool to avoid leaks.


## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
