### PR TITLE
perf: bypass precompile cache (0% hit rate)

### DIFF
--- a/crates/rbuilder-primitives/src/evm_inspector.rs
+++ b/crates/rbuilder-primitives/src/evm_inspector.rs
@@ -1,7 +1,6 @@
 use ahash::HashMap;
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, B256, U256};
-use alloy_rpc_types::AccessList;
 use reth_primitives::{Recovered, TransactionSigned};
 use revm::{
     bytecode::opcode,
@@ -10,7 +9,6 @@ use revm::{
     interpreter::{interpreter_types::Jumps, CallInputs, CallOutcome, Interpreter},
     Inspector,
 };
-use revm_inspectors::access_list::AccessListInspector;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SlotKey {
@@ -257,7 +255,6 @@ where
 
 #[derive(Debug)]
 pub struct RBuilderEVMInspector<'a> {
-    access_list_inspector: AccessListInspector,
     used_state_inspector: Option<UsedStateEVMInspector<'a>>,
 }
 
@@ -266,22 +263,14 @@ impl<'a> RBuilderEVMInspector<'a> {
         tx: &Recovered<TransactionSigned>,
         used_state_trace: Option<&'a mut UsedStateTrace>,
     ) -> Self {
-        let access_list_inspector =
-            AccessListInspector::new(tx.access_list().cloned().unwrap_or_default());
-
         let mut used_state_inspector = used_state_trace.map(UsedStateEVMInspector::new);
         if let Some(i) = &mut used_state_inspector {
             i.use_tx_nonce(tx);
         }
 
         Self {
-            access_list_inspector,
             used_state_inspector,
         }
-    }
-
-    pub fn into_access_list(self) -> AccessList {
-        self.access_list_inspector.into_access_list()
     }
 }
 
@@ -292,7 +281,6 @@ where
 {
     #[inline]
     fn step(&mut self, interp: &mut Interpreter, context: &mut CTX) {
-        self.access_list_inspector.step(interp, context);
         if let Some(used_state_inspector) = &mut self.used_state_inspector {
             used_state_inspector.step(interp, context);
         }

--- a/crates/rbuilder/src/building/order_commit.rs
+++ b/crates/rbuilder/src/building/order_commit.rs
@@ -1162,6 +1162,35 @@ where
     Factory: EvmFactory,
 {
     let tx = tx_with_blobs.internal_tx_unsecure();
+
+    // Skip the AccessListInspector entirely — it calls step() on every EVM opcode
+    // just to track accessed addresses for the blocklist check. Instead, we check
+    // the blocklist against ResultAndState.state (EvmState = HashMap<Address, Account>)
+    // which already contains every address touched during execution.
+    // This eliminates ~50% of CPU overhead during block building.
+    if used_state_tracer.is_none() {
+        let mut evm = evm_factory.create_evm(db, evm_env);
+        let res = match evm.transact(tx) {
+            Ok(res) => res,
+            Err(err) => match err {
+                EVMError::Transaction(tx_err) => {
+                    return Ok(Err(TransactionErr::InvalidTransaction(tx_err)))
+                }
+                EVMError::Database(_) | EVMError::Header(_) | EVMError::Custom(_) => {
+                    return Err(err.into())
+                }
+            },
+        };
+        // Check blocklist against addresses in the execution state diff
+        if !blocklist.is_empty() && res.state.keys().any(|addr| blocklist.contains(addr)) {
+            return Ok(Err(TransactionErr::Blocklist));
+        }
+        return Ok(Ok(res));
+    }
+
+    // Slow path: used_state_tracer is active (parallel builder conflict detection).
+    // Still need the inspector for UsedStateEVMInspector, but we can skip AccessListInspector
+    // and use the state diff for blocklist checking instead.
     let mut rbuilder_inspector = RBuilderEVMInspector::new(tx, used_state_tracer);
 
     let mut evm = evm_factory.create_evm_with_inspector(db, evm_env, &mut rbuilder_inspector);
@@ -1177,8 +1206,8 @@ where
         },
     };
     drop(evm);
-    let access_list = rbuilder_inspector.into_access_list();
-    if access_list.flatten().any(|(a, _)| blocklist.contains(&a)) {
+    // Use state diff for blocklist check instead of access list
+    if !blocklist.is_empty() && res.state.keys().any(|addr| blocklist.contains(addr)) {
         return Ok(Err(TransactionErr::Blocklist));
     }
 

--- a/crates/rbuilder/src/building/precompile_cache.rs
+++ b/crates/rbuilder/src/building/precompile_cache.rs
@@ -58,31 +58,10 @@ impl<CTX: ContextTr, P: PrecompileProvider<CTX, Output = InterpreterResult>> Pre
         context: &mut CTX,
         inputs: &CallInputs,
     ) -> Result<Option<Self::Output>, String> {
-        let key = (self.spec, inputs.input.bytes(context), inputs.gas_limit);
-
-        // get the result if it exists
-        if let Some(precompiles) = self.cache.lock().get_mut(&inputs.target_address) {
-            if let Some(result) = precompiles.get(&key) {
-                inc_precompile_cache_hits();
-                return result.clone().map(Some);
-            }
-        }
-
-        inc_precompile_cache_misses();
-
-        // call the precompile if cache miss
-        let output = self.precompile.run(context, inputs);
-
-        if let Some(output) = output.clone().transpose() {
-            // insert the result into the cache
-            self.cache
-                .lock()
-                .entry(inputs.target_address)
-                .or_insert(PrecompileResultCache::new(NonZeroUsize::new(2048).unwrap()))
-                .put(key, output);
-        }
-
-        output
+        // Skip the cache entirely — profiling shows 0 hits across 177K calls.
+        // The cache key includes gas_limit which varies per call, preventing hits.
+        // The Bytes clone + mutex lock/unlock overhead is pure waste.
+        self.precompile.run(context, inputs)
     }
 
     fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {


### PR DESCRIPTION
## Summary

- Bypass the `PrecompileCache` entirely — profiling shows **0 hits across 177,614 calls**
- The cache key includes `gas_limit` which varies per call, preventing any hits
- Each miss incurs a mutex lock + `Bytes` clone + HashMap lookup + second mutex lock + LruCache insert

## Motivation

Prometheus metrics from builder-lab profiling:
```
simulation_precompile_cache_hits 0
simulation_precompile_cache_misses 177614
```

The cache key is `(SpecId, Bytes, u64)` where the `u64` is `gas_limit`. Since `gas_limit` varies per precompile call (it's the remaining gas, not a fixed value), identical precompile inputs with different remaining gas produce different cache keys, preventing hits entirely.

## Benchmark Results

Tested with builder-lab, 100 TPS contender, 60s profiling window, stacked on top of the AccessListInspector removal (#902):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Block fill time (p50) | 57.2ms | 53.3ms | **-6.8%** |
| Block fill time (p95) | 94.9ms | 80.7ms | **-15.0%** |
| E2E latency (p50) | 59ms | 55ms | **-6.8%** |
| E2E latency (p95) | 101ms | 84ms | **-16.8%** |

## Future improvement

Rather than bypassing the cache, it could be made effective by removing `gas_limit` from the cache key — precompile results don't depend on the gas limit passed to them (they either succeed within their fixed gas cost or fail). This would require verifying that all precompile implementations are indeed gas-limit-independent.

## Test plan

- [x] Blocks built and submitted correctly at 100 TPS
- [x] Confirmed 0% cache hit rate via Prometheus metrics
- [x] Profiling shows reduced overhead
- [ ] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)