### PR TITLE
feat: more paranoid reth db checks

### DIFF
--- a/crates/eth-sparse-mpt/src/lib.rs
+++ b/crates/eth-sparse-mpt/src/lib.rs
@@ -75,7 +75,7 @@ impl SparseTrieSharedCache {
             parent_state_root,
         );
         let mut cache_v2 = v2::SharedCacheV2::default();
-        cache_v2.last_block_hash = parent_block_hash;
+        cache_v2.parent_state_root = parent_state_root;
         let mut cache_v_experimental = v_experimental::SharedCacheVExperimental::default();
         cache_v_experimental.last_block_hash = parent_block_hash;
         Self {

--- a/crates/eth-sparse-mpt/src/v2/fetch.rs
+++ b/crates/eth-sparse-mpt/src/v2/fetch.rs
@@ -11,16 +11,29 @@ use rayon::prelude::*;
 use alloy_primitives::B256;
 use nybbles::Nibbles;
 use reth_provider::{
-    providers::ConsistentDbView, BlockHashReader, BlockNumReader, BlockReader, DBProvider,
-    DatabaseProviderFactory,
+    providers::ConsistentDbView, BlockReader, DBProvider, DatabaseProviderFactory,
 };
 use reth_trie::{
     proof::{Proof, StorageProof},
-    MultiProofTargets,
+    MultiProofTargets, StateRoot,
 };
-use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseTrieCursorFactory};
+use reth_trie_db::{DatabaseHashedCursorFactory, DatabaseStateRoot, DatabaseTrieCursorFactory};
 
 use super::SharedCacheV2;
+
+pub fn check_state_root_in_db(
+    provider: &impl DBProvider,
+    expected_state_root: B256,
+) -> Result<(), SparseTrieError> {
+    let db_state_root = StateRoot::from_tx(provider.tx_ref())
+        .root()
+        .map_err(SparseTrieError::other)?;
+    if db_state_root == expected_state_root {
+        Ok(())
+    } else {
+        Err(SparseTrieError::WrongDatabaseTrieError)
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct MissingNodesFetcher {
@@ -59,7 +72,7 @@ impl MissingNodesFetcher {
     {
         let fetched_nodes: Arc<Mutex<usize>> = Default::default();
 
-        let last_block_hash = shared_cache.last_block_hash;
+        let parent_state_root = shared_cache.parent_state_root;
         std::mem::take(&mut self.storage_proof_targets)
             .into_par_iter()
             .map(
@@ -67,16 +80,8 @@ impl MissingNodesFetcher {
                     let provider = consistent_db_view
                         .provider_ro()
                         .map_err(SparseTrieError::other)?;
-                    if !last_block_hash.is_zero() {
-                        let block_number = provider
-                            .last_block_number()
-                            .map_err(SparseTrieError::other)?;
-                        let block_hash = provider
-                            .block_hash(block_number)
-                            .map_err(SparseTrieError::other)?;
-                        if block_hash != Some(shared_cache.last_block_hash) {
-                            return Err(SparseTrieError::WrongDatabaseTrieError);
-                        }
+                    if !parent_state_root.is_zero() {
+                        check_state_root_in_db(&provider, parent_state_root)?;
                     }
 
                     let proof = StorageProof::new_hashed(
@@ -110,16 +115,8 @@ impl MissingNodesFetcher {
         let provider = consistent_db_view
             .provider_ro()
             .map_err(SparseTrieError::other)?;
-        if !last_block_hash.is_zero() {
-            let block_number = provider
-                .last_block_number()
-                .map_err(SparseTrieError::other)?;
-            let block_hash = provider
-                .block_hash(block_number)
-                .map_err(SparseTrieError::other)?;
-            if block_hash != Some(shared_cache.last_block_hash) {
-                return Err(SparseTrieError::WrongDatabaseTrieError);
-            }
+        if !parent_state_root.is_zero() {
+            check_state_root_in_db(&provider, parent_state_root)?
         }
 
         let proof = Proof::new(

--- a/crates/eth-sparse-mpt/src/v2/mod.rs
+++ b/crates/eth-sparse-mpt/src/v2/mod.rs
@@ -31,7 +31,7 @@ const PARALLEL_HASHING_STORAGE_NODES: bool = true;
 pub struct SharedCacheV2 {
     pub account_trie: ProofStore,
     pub storage_tries: Arc<DashMap<B256, ProofStore, FxBuildHasher>>,
-    pub last_block_hash: B256,
+    pub parent_state_root: B256,
 }
 
 impl SharedCacheV2 {


### PR DESCRIPTION
Now we check reth db account trie table for correct state root of the parent instead of checking latest block.

## 📝 Summary

<!--- A general summary of your changes -->

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
