### PR TITLE
fix(ci): Avoid release artifact collision

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,47 +165,61 @@ jobs:
             --bin bid-scraper \
             --bin rbuilder-rebalancer
 
+      - name: Package binaries
+        if: steps.platform-check.outputs.skip != 'true'
+        env:
+          VERSION: ${{ needs.extract-version.outputs.VERSION }}
+          TARGET: ${{ matrix.target }}
+          FEATURES_SUFFIX: ${{ matrix.features && format('-{0}', matrix.features) || '' }}
+        run: |
+          cd target/${{ matrix.profile }}
+          for bin in rbuilder rbuilder-operator tbv-bidding-service reth-rbuilder bid-scraper rbuilder-rebalancer; do
+            if [ -f "$bin" ]; then
+              tar czf "${bin}-${VERSION}-${TARGET}${FEATURES_SUFFIX}.tar.gz" "$bin"
+            fi
+          done
+
       - name: Upload rbuilder artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/rbuilder
+          path: target/${{ matrix.profile }}/rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
 
       - name: Upload rbuilder-operator artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: rbuilder-operator-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/rbuilder-operator
+          path: target/${{ matrix.profile }}/rbuilder-operator-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
 
       - name: Upload tbv-bidding-service artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: tbv-bidding-service-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/tbv-bidding-service
+          path: target/${{ matrix.profile }}/tbv-bidding-service-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
 
       - name: Upload reth-rbuilder artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: reth-rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/reth-rbuilder
+          path: target/${{ matrix.profile }}/reth-rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
 
       - name: Upload bid-scraper artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: bid-scraper-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/bid-scraper
+          path: target/${{ matrix.profile }}/bid-scraper-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
 
       - name: Upload rbuilder-rebalancer artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: rbuilder-rebalancer-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/rbuilder-rebalancer
+          path: target/${{ matrix.profile }}/rbuilder-rebalancer-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
 
       - name: Upload *.deb packages
         if: steps.platform-check.outputs.skip != 'true' && matrix.platform == 'linux'
@@ -287,15 +301,15 @@ jobs:
           echo "Artifact name attempted: rbuilder-${{ env.VERSION }}-x86_64-unknown-linux-gnu${{ github.event.inputs.features && format('-{0}', github.event.inputs.features) || '' }}"
           echo "This is expected if build-binary job didn't run or Linux build was skipped."
 
-      - name: Verify binary exists
+      - name: Extract and verify binary
         if: steps.download-binary.outcome == 'success'
         run: |
+          tar xzf rbuilder-*.tar.gz
           if [ -f "./rbuilder" ]; then
-            echo "✅ Binary downloaded successfully"
+            echo "✅ Binary extracted successfully"
             ls -lh ./rbuilder
           else
-            echo "❌ Binary file not found after download"
-            find . -name "rbuilder" -type f || echo "No rbuilder file found"
+            echo "❌ Binary file not found after extraction"
             exit 1
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,7 +165,7 @@ jobs:
             --bin bid-scraper \
             --bin rbuilder-rebalancer
 
-      - name: Package binaries
+      - name: Rename binaries
         if: steps.platform-check.outputs.skip != 'true'
         env:
           VERSION: ${{ needs.extract-version.outputs.VERSION }}
@@ -174,9 +174,7 @@ jobs:
         run: |
           cd target/${{ matrix.profile }}
           for bin in rbuilder rbuilder-operator tbv-bidding-service reth-rbuilder bid-scraper rbuilder-rebalancer; do
-            if [ -f "$bin" ]; then
-              tar czf "${bin}-${VERSION}-${TARGET}${FEATURES_SUFFIX}.tar.gz" "$bin"
-            fi
+            [ -f "$bin" ] && mv "$bin" "${bin}-${VERSION}-${TARGET}${FEATURES_SUFFIX}"
           done
 
       - name: Upload rbuilder artifact
@@ -184,42 +182,42 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
+          path: target/${{ matrix.profile }}/rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}
 
       - name: Upload rbuilder-operator artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: rbuilder-operator-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/rbuilder-operator-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
+          path: target/${{ matrix.profile }}/rbuilder-operator-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}
 
       - name: Upload tbv-bidding-service artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: tbv-bidding-service-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/tbv-bidding-service-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
+          path: target/${{ matrix.profile }}/tbv-bidding-service-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}
 
       - name: Upload reth-rbuilder artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: reth-rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/reth-rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
+          path: target/${{ matrix.profile }}/reth-rbuilder-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}
 
       - name: Upload bid-scraper artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: bid-scraper-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/bid-scraper-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
+          path: target/${{ matrix.profile }}/bid-scraper-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}
 
       - name: Upload rbuilder-rebalancer artifact
         if: steps.platform-check.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: rbuilder-rebalancer-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && '-' }}${{ matrix.features }}
-          path: target/${{ matrix.profile }}/rbuilder-rebalancer-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}.tar.gz
+          path: target/${{ matrix.profile }}/rbuilder-rebalancer-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.features && format('-{0}', matrix.features) || '' }}
 
       - name: Upload *.deb packages
         if: steps.platform-check.outputs.skip != 'true' && matrix.platform == 'linux'
@@ -301,15 +299,17 @@ jobs:
           echo "Artifact name attempted: rbuilder-${{ env.VERSION }}-x86_64-unknown-linux-gnu${{ github.event.inputs.features && format('-{0}', github.event.inputs.features) || '' }}"
           echo "This is expected if build-binary job didn't run or Linux build was skipped."
 
-      - name: Extract and verify binary
+      - name: Verify binary exists
         if: steps.download-binary.outcome == 'success'
         run: |
-          tar xzf "rbuilder-${{ env.VERSION }}-x86_64-unknown-linux-gnu${{ github.event.inputs.features && format('-{0}', github.event.inputs.features) || '' }}.tar.gz"
-          if [ -f "./rbuilder" ]; then
-            echo "✅ Binary extracted successfully"
+          BIN="rbuilder-${{ env.VERSION }}-x86_64-unknown-linux-gnu${{ github.event.inputs.features && format('-{0}', github.event.inputs.features) || '' }}"
+          if [ -f "./${BIN}" ]; then
+            mv "./${BIN}" ./rbuilder
+            echo "✅ Binary downloaded successfully"
             ls -lh ./rbuilder
           else
-            echo "❌ Binary file not found after extraction"
+            echo "❌ Binary file not found after download"
+            ls -la
             exit 1
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -304,7 +304,7 @@ jobs:
       - name: Extract and verify binary
         if: steps.download-binary.outcome == 'success'
         run: |
-          tar xzf rbuilder-*.tar.gz
+          tar xzf "rbuilder-${{ env.VERSION }}-x86_64-unknown-linux-gnu${{ github.event.inputs.features && format('-{0}', github.event.inputs.features) || '' }}.tar.gz"
           if [ -f "./rbuilder" ]; then
             echo "✅ Binary extracted successfully"
             ls -lh ./rbuilder


### PR DESCRIPTION
## 📝 Summary

Separate jobs/steps are writing the same rbuilder artifact. Previously the end result was a linux binary. And lately, it is a macOS binary.

This PR separates artifact writes by OS and arch, in `*.tar.gz` format.
