### PR TITLE
Earlier exit for sim thread

### DIFF
--- a/crates/rbuilder/src/live_builder/simulation/mod.rs
+++ b/crates/rbuilder/src/live_builder/simulation/mod.rs
@@ -38,6 +38,7 @@ pub struct SimulationContext {
     /// Simulation requests come in through this channel.
     pub requests: flume::Receiver<CancellableSimulationRequest>,
     /// Simulation results go out through this channel.
+    /// This is also implicitly used as a cancellation token. If this is closed there is no need to simulate anymore.
     pub results: mpsc::Sender<SimulatedResult>,
 }
 

--- a/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
+++ b/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
@@ -93,7 +93,10 @@ pub fn run_sim_worker<P>(
                                 if let Err(tokio::sync::mpsc::error::TrySendError::Full(_)) =
                                     current_sim_context.results.try_send(result)
                                 {
-                                    error!(?order_id, "simulation results channel is full");
+                                    error!(
+                                        ?order_id,
+                                        "Simulation results channel is full, order dropped"
+                                    );
                                 }
 
                                 true

--- a/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
+++ b/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
@@ -60,7 +60,7 @@ pub fn run_sim_worker<P>(
         while let Ok(cancellable_task) = current_sim_context.requests.recv() {
             // Avoid starting sims when the output channel is closed.
             if current_sim_context.results.is_closed() {
-                return;
+                break;
             }
             if let Some(task) = cancellable_task.into_request() {
                 let sim_thread_wait_time = last_sim_finished.elapsed();

--- a/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
+++ b/crates/rbuilder/src/live_builder/simulation/sim_worker.rs
@@ -58,6 +58,10 @@ pub fn run_sim_worker<P>(
                 }
             };
         while let Ok(cancellable_task) = current_sim_context.requests.recv() {
+            // Avoid starting sims when the output channel is closed.
+            if current_sim_context.results.is_closed() {
+                return;
+            }
             if let Some(task) = cancellable_task.into_request() {
                 let sim_thread_wait_time = last_sim_finished.elapsed();
                 let sim_start = Instant::now();
@@ -86,10 +90,12 @@ pub fn run_sim_worker<P>(
                                         .collect(),
                                     simulation_time: start_time.elapsed(),
                                 };
-                                current_sim_context
-                                    .results
-                                    .try_send(result)
-                                    .unwrap_or_default();
+                                if let Err(tokio::sync::mpsc::error::TrySendError::Full(_)) =
+                                    current_sim_context.results.try_send(result)
+                                {
+                                    error!(?order_id, "simulation results channel is full");
+                                }
+
                                 true
                             }
                             OrderSimResult::Failed(_) => false,


### PR DESCRIPTION
## 📝 Summary

This changes makes the sim thread finish as soon as the block ends.

## 💡 Motivation and Context

Saw on a test version lots of sims happening after the block ended.

## ✅ I have completed the following steps:

* [X] Run `make lint`
* [X] Run `make test`
* [ ] Added tests (if applicable)
