### PR TITLE
Handle successful relay response with plaintext body

### DIFF
--- a/crates/rbuilder/src/mev_boost/mod.rs
+++ b/crates/rbuilder/src/mev_boost/mod.rs
@@ -1060,7 +1060,13 @@ async fn map_response(response: Response) -> Result<(), SubmitBlockErr> {
             // bloxroute returns empty response in this format which we handle here because its not valid
             // jsonrpc response
             let data = String::from_utf8_lossy(&bytes).to_string();
-            if data.trim() == "{}" {
+            let trimmed = data.trim();
+            if trimmed == "{}" {
+                return Ok(());
+            }
+
+            // bloxroute may return a plain-text success response instead of JSON
+            if status == StatusCode::OK && trimmed == "block received" {
                 return Ok(());
             }
 


### PR DESCRIPTION
## 📝 Summary

bloxroute relay may return a plain-text success response instead of JSON

Example of the log line:
```
... {"message":"Error submitting block to the relay","err":"Relay error: Unknown relay response, status: 200 OK, body: \"block received\"\n"} ...
```

## 💡 Motivation and Context

<!--- (Optional) Why is this change required? What problem does it solve? Remove this section if not applicable. -->

---

## ✅ I have completed the following steps:

* [ ] Run `make lint`
* [ ] Run `make test`
* [ ] Added tests (if applicable)
