### PR TITLE
ci: bind release workflow_dispatch inputs via env before shell

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,10 @@ jobs:
     steps:
       - name: Extract version
         id: extract_version
+        env:
+          BUILD_LINUX: ${{ github.event.inputs.build-linux || 'true' }}
+          BUILD_MAC: ${{ github.event.inputs.build-mac || 'true' }}
+          FEATURES: ${{ github.event.inputs.features || 'none' }}
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
@@ -61,9 +65,9 @@ jobs:
           echo "| \`GITHUB_REF\`      | \`${GITHUB_REF}\`      |" >> $GITHUB_STEP_SUMMARY
           echo "| \`GITHUB_SHA\`      | \`${GITHUB_SHA}\`      |" >> $GITHUB_STEP_SUMMARY
           echo "| \`VERSION\`         | \`${VERSION}\`         |" >> $GITHUB_STEP_SUMMARY
-          echo "| \`BUILD_LINUX\`     | \`${{ github.event.inputs.build-linux || 'true' }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| \`BUILD_MAC\`       | \`${{ github.event.inputs.build-mac || 'true' }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| \`FEATURES\`        | \`${{ github.event.inputs.features || 'none' }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`BUILD_LINUX\`     | \`${BUILD_LINUX}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`BUILD_MAC\`       | \`${BUILD_MAC}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`FEATURES\`        | \`${FEATURES}\` |" >> $GITHUB_STEP_SUMMARY
 
   build-binary:
     name: Build binary (${{ matrix.target }})
@@ -294,9 +298,11 @@ jobs:
 
       - name: Check if binary was downloaded
         if: steps.download-binary.outcome != 'success'
+        env:
+          FEATURES_SUFFIX: ${{ github.event.inputs.features && format('-{0}', github.event.inputs.features) || '' }}
         run: |
           echo "⚠️ Binary artifact not found. Will build from source."
-          echo "Artifact name attempted: rbuilder-${{ env.VERSION }}-x86_64-unknown-linux-gnu${{ github.event.inputs.features && format('-{0}', github.event.inputs.features) || '' }}"
+          echo "Artifact name attempted: rbuilder-${VERSION}-x86_64-unknown-linux-gnu${FEATURES_SUFFIX}"
           echo "This is expected if build-binary job didn't run or Linux build was skipped."
 
       - name: Verify binary exists


### PR DESCRIPTION
## Summary
- Bind `github.event.inputs.build-linux` / `build-mac` / `features` through `env:` before step-summary shell echoes in the release workflow.
- Bind features suffix through `env:` before the artifact-name diagnostic echo.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] workflow_dispatch release summary still shows the selected build-linux/build-mac/features values
- [ ] Artifact-name diagnostic still reflects optional features suffix


Made with [Cursor](https://cursor.com)