### PR TITLE
Build release binaries with cargo auditable to embed dependency data

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,6 +146,10 @@ jobs:
         if: steps.platform-check.outputs.skip != 'true' && matrix.platform == 'mac'
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo-auditable (Mac)
+        if: steps.platform-check.outputs.skip != 'true' && matrix.platform == 'mac'
+        run: cargo install cargo-auditable@0.7.5 --locked
+
       - name: Build binaries (Mac)
         if: steps.platform-check.outputs.skip != 'true' && matrix.platform == 'mac'
         env:
@@ -157,7 +161,7 @@ jobs:
           if [[ -n "$FEATURES" ]]; then
             FEATURE_FLAG="--features $FEATURES"
           fi
-          cargo build --profile ${{ matrix.profile }} $FEATURE_FLAG \
+          cargo auditable build --profile ${{ matrix.profile }} $FEATURE_FLAG \
             --bin rbuilder \
             --bin rbuilder-operator \
             --bin tbv-bidding-service \

--- a/Makefile
+++ b/Makefile
@@ -71,21 +71,26 @@ else
     BUILD_ENV =
 endif
 
+# The cargo-auditable embedded data is sorted and timestamp-free
+.PHONY: install-cargo-auditable
+install-cargo-auditable:
+	@command -v cargo-auditable >/dev/null 2>&1 || cargo install cargo-auditable@0.7.5 --locked
+
 .PHONY: build
-build: ## Build (release version)
-	$(BUILD_ENV) cargo build --features "$(FEATURES) jemalloc-unprefixed" --locked $(if $(BUILD_TARGET),--target $(BUILD_TARGET)) --profile $(BUILD_PROFILE) --workspace
+build: install-cargo-auditable ## Build (release version)
+	$(BUILD_ENV) cargo auditable build --features "$(FEATURES) jemalloc-unprefixed" --locked $(if $(BUILD_TARGET),--target $(BUILD_TARGET)) --profile $(BUILD_PROFILE) --workspace
 
 .PHONY: build-bid-scraper
-build-bid-scraper: ## Build the bid-scraper binary (release version)
-	$(BUILD_ENV) cargo build --features "$(FEATURES)" --locked $(if $(BUILD_TARGET),--target $(BUILD_TARGET)) --bin bid-scraper --profile $(BUILD_PROFILE)
+build-bid-scraper: install-cargo-auditable ## Build the bid-scraper binary (release version)
+	$(BUILD_ENV) cargo auditable build --features "$(FEATURES)" --locked $(if $(BUILD_TARGET),--target $(BUILD_TARGET)) --bin bid-scraper --profile $(BUILD_PROFILE)
 
 .PHONY: build-rbuilder-operator
-build-rbuilder-operator: ## Build the rbuilder-operator binary (release version)
-	$(BUILD_ENV) cargo build --features "$(FEATURES) jemalloc-unprefixed" --locked $(if $(BUILD_TARGET),--target $(BUILD_TARGET)) --bin rbuilder-operator --profile $(BUILD_PROFILE)
+build-rbuilder-operator: install-cargo-auditable ## Build the rbuilder-operator binary (release version)
+	$(BUILD_ENV) cargo auditable build --features "$(FEATURES) jemalloc-unprefixed" --locked $(if $(BUILD_TARGET),--target $(BUILD_TARGET)) --bin rbuilder-operator --profile $(BUILD_PROFILE)
 
 .PHONY: build-rbuilder-rebalancer
-build-rbuilder-rebalancer: ## Build the rbuilder-rebalancer binary (release version)
-	$(BUILD_ENV) cargo build --features "$(FEATURES) jemalloc-unprefixed" --locked $(if $(BUILD_TARGET),--target $(BUILD_TARGET)) --bin rbuilder-rebalancer --profile $(BUILD_PROFILE)
+build-rbuilder-rebalancer: install-cargo-auditable ## Build the rbuilder-rebalancer binary (release version)
+	$(BUILD_ENV) cargo auditable build --features "$(FEATURES) jemalloc-unprefixed" --locked $(if $(BUILD_TARGET),--target $(BUILD_TARGET)) --bin rbuilder-rebalancer --profile $(BUILD_PROFILE)
 
 .PHONY: build-dev
 build-dev: ## Build (debug version)
@@ -106,9 +111,10 @@ docker-image-test-relay: ## Build a test relay Docker image
 ##@ Debian Packages
 
 # Define binary paths for smart dependencies
-BID_SCRAPER_BIN := target/$(if $(BUILD_TARGET),$(BUILD_TARGET)/)$(BUILD_PROFILE)/bid-scraper
-RBUILDER_OPERATOR_BIN := target/$(if $(BUILD_TARGET),$(BUILD_TARGET)/)$(BUILD_PROFILE)/rbuilder-operator
-RBUILDER_REBALANCER_BIN := target/$(if $(BUILD_TARGET),$(BUILD_TARGET)/)$(BUILD_PROFILE)/rbuilder-rebalancer
+BUILD_OUTPUT_DIR := target/$(if $(BUILD_TARGET),$(BUILD_TARGET)/)$(BUILD_PROFILE)
+BID_SCRAPER_BIN := $(BUILD_OUTPUT_DIR)/bid-scraper
+RBUILDER_OPERATOR_BIN := $(BUILD_OUTPUT_DIR)/rbuilder-operator
+RBUILDER_REBALANCER_BIN := $(BUILD_OUTPUT_DIR)/rbuilder-rebalancer
 
 .PHONY: install-cargo-deb
 install-cargo-deb:
@@ -149,6 +155,21 @@ build-deb-rbuilder-rebalancer: install-cargo-deb $(RBUILDER_REBALANCER_BIN) ## B
 build-deb: build-deb-bid-scraper build-deb-rbuilder-operator build-deb-rbuilder-rebalancer ## Build all Debian packages
 
 ##@ Dev
+
+.PHONY: install-cargo-audit
+install-cargo-audit:
+	@command -v cargo-audit >/dev/null 2>&1 || cargo install cargo-audit@0.22.2 --locked
+
+.PHONY: audit-bin
+audit-bin: install-cargo-audit ## Scan built binaries for vulnerable dependencies (uses the audit data embedded by "make build")
+	@fail=0; \
+	for bin in $(BUILD_OUTPUT_DIR)/*; do \
+		if [ -f "$$bin" ] && [ -x "$$bin" ]; then \
+			echo "==> $$bin"; \
+			cargo audit bin "$$bin" || fail=1; \
+		fi; \
+	done; \
+	exit $$fail
 
 .PHONY: lint
 lint: ## Run the linters

--- a/README.md
+++ b/README.md
@@ -175,6 +175,19 @@ $ sha256sum target/release/rbuilder
 d92ac33b94e16ed4a035b9dd52108fe78bd9bb160a91fced8e439f59b84c3207  target/release/rbuilder
 ```
 
+### Auditable builds
+
+Release builds (`make build`, the Docker images, and the released binaries) go through
+[`cargo auditable`](https://github.com/rust-secure-code/cargo-auditable), which embeds the full
+dependency list into each binary. To scan the built binaries against the RustSec advisory database:
+
+```bash
+make audit-bin
+```
+
+The embedded data can also be picked up by scanners such as `trivy`, `grype`, `syft`. Meaning that container
+images built from these binaries can be scanned for Rust dependencies as well.
+
 ---
 
 ## Release Stability and Development Process

--- a/docker/Dockerfile.rbuilder
+++ b/docker/Dockerfile.rbuilder
@@ -36,6 +36,7 @@ RUN set -eux; \
     rm -rf /tmp/sccache.tar.gz /tmp/sccache-v0.8.2-${ARCH_TAG}
 
 RUN cargo install cargo-chef --version ^0.1
+RUN cargo install cargo-auditable@0.7.5 --locked
 
 
 ENV CARGO_HOME=/usr/local/cargo
@@ -72,14 +73,14 @@ ARG FEATURES
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo build --release --features="$FEATURES" --package=${RBUILDER_BIN}
+    cargo auditable build --release --features="$FEATURES" --package=${RBUILDER_BIN}
 
 FROM builder AS test-relay
 ARG FEATURES
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked \
-    cargo build --release --features="$FEATURES" --package=test-relay
+    cargo auditable build --release --features="$FEATURES" --package=test-relay
 
 
 # Runtime container for test-relay

--- a/docker/Dockerfile.reproducible
+++ b/docker/Dockerfile.reproducible
@@ -10,6 +10,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update && \
         libclang-dev \
         protobuf-compiler \
         cmake
+RUN cargo install cargo-auditable@0.7.5 --locked
 WORKDIR /build
 COPY . .
 RUN SOURCE_DATE=1730000000 make build && make build-deb


### PR DESCRIPTION
## 📝 Summary

Release builds now go through [`cargo auditable`](https://github.com/rust-secure-code/cargo-auditable),
which embeds the resolved dependency list into a `.dep-v0` section of each binary.

- `make build*` targets, `docker/Dockerfile.rbuilder`, `docker/Dockerfile.reproducible`, and the
  Mac path of the release workflow build with `cargo auditable build`
- New `make audit-bin` target scans built binaries against the RustSec advisory database
- `cargo-auditable` is pinned to `0.7.5` in all build paths so every artifact embeds identically
  formatted data
- Dev builds (`build-dev`, CI test builds) are unchanged

## 💡 Motivation and Context

Makes binaries — and container images built from them — scannable for Rust dependencies and known
vulnerabilities with `cargo audit bin`, trivy, grype, syft, etc.

---

## ✅ I have completed the following steps:

* [x] Run `make lint`
* [x] Run `make test`
* [n/a] Added tests (if applicable)
